### PR TITLE
ci: skip workflow jobs on forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   reuse:
+    if: github.repository == 'terok-ops/terok-shield'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -15,6 +16,7 @@ jobs:
         uses: fsfe/reuse-action@v6
 
   lint:
+    if: github.repository == 'terok-ops/terok-shield'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -30,6 +32,7 @@ jobs:
           args: format --check
 
   docstring-coverage:
+    if: github.repository == 'terok-ops/terok-shield'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -46,6 +49,7 @@ jobs:
         run: docstr-coverage src/terok_shield/ --fail-under=95
 
   dead-code:
+    if: github.repository == 'terok-ops/terok-shield'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -62,6 +66,7 @@ jobs:
         run: vulture src/terok_shield/ vulture_whitelist.py --min-confidence 80
 
   security:
+    if: github.repository == 'terok-ops/terok-shield'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -78,6 +83,7 @@ jobs:
         run: bandit -r src/terok_shield/ -ll
 
   test:
+    if: github.repository == 'terok-ops/terok-shield'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

- Add `if: github.repository == 'terok-ops/terok-shield'` to all CI jobs so fork syncs don't run redundant CI

## Test plan

- [ ] Verify CI runs on the upstream PR (terok-ops/terok-shield)
- [ ] Verify CI is skipped on the fork (sliwowitz/terok-shield)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow configuration to add repository-scoped guards to workflow jobs, ensuring they execute only in the designated repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->