### PR TITLE
feat: firewall modes, public API, and CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
         run: pip install -r .github/requirements-ci.txt
 
       - name: Check for dead code
-        run: vulture src/terok_shield/ vulture_whitelist.py --min-confidence 80
+        run: vulture src/terok_shield/ --min-confidence 80
 
   tach:
     if: github.repository == 'terok-ops/terok-shield'

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ complexity:
 
 # Find dead code (cross-file, min 80% confidence)
 deadcode:
-	poetry run vulture src/terok_shield/ vulture_whitelist.py --min-confidence 80
+	poetry run vulture src/terok_shield/ --min-confidence 80
 
 # Check REUSE (SPDX license/copyright) compliance
 reuse:

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -14,7 +14,6 @@ path = [
   ".gitignore",
   "MANIFEST.in",
   "Makefile",
-  "vulture_whitelist.py",
 ]
 SPDX-FileCopyrightText = "2026 Jiri Vyskocil"
 SPDX-License-Identifier = "Apache-2.0"

--- a/docs/gen_quality_report.py
+++ b/docs/gen_quality_report.py
@@ -232,7 +232,6 @@ def _section_dead_code() -> str:
         "-m",
         "vulture",
         str(SRC),
-        str(ROOT / "vulture_whitelist.py"),
         "--min-confidence",
         "80",
     )

--- a/src/terok_shield/__init__.py
+++ b/src/terok_shield/__init__.py
@@ -1,10 +1,295 @@
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
-"""terok-shield: nftables-based egress firewalling for Podman containers."""
+"""terok-shield: nftables-based egress firewalling for Podman containers.
+
+Public API for standalone use and integration with terok.
+"""
 
 __version__ = "0.1.0"
 
+from .audit import list_log_files, log_event, tail_log
 from .config import ShieldConfig, ShieldMode, load_shield_config
+from .dns import resolve_and_cache
+from .profiles import compose_profiles, list_profiles
+from .run import ExecError, dig
+from .util import is_ipv4 as _is_ip
 
-__all__ = ["ShieldConfig", "ShieldMode", "load_shield_config"]
+
+def _load_config(config: ShieldConfig | None) -> ShieldConfig:
+    """Return the given config or load the default."""
+    return config if config is not None else load_shield_config()
+
+
+def _mode_module(mode: ShieldMode):  # noqa: ANN202 – returns module
+    """Return the backend module for the given mode."""
+    if mode == ShieldMode.HARDENED:
+        from . import hardened
+
+        return hardened
+
+    from . import standard
+
+    return standard
+
+
+def shield_setup(*, config: ShieldConfig | None = None) -> None:
+    """Run shield setup (install hook or verify bridge).
+
+    Dispatches to standard or hardened setup based on ``config.mode``.
+
+    Args:
+        config: Shield configuration (loads default if None).
+    """
+    cfg = _load_config(config)
+    if cfg.mode == ShieldMode.HARDENED:
+        from . import hardened as hw
+
+        hw.setup(cfg)
+    else:
+        from . import standard as sw
+
+        sw.setup(cfg)
+
+
+def shield_status(*, config: ShieldConfig | None = None) -> dict:
+    """Return current shield status information.
+
+    Args:
+        config: Shield configuration (loads default if None).
+
+    Returns:
+        Dict with mode, profiles, audit_enabled, and log_files.
+    """
+    cfg = _load_config(config)
+    return {
+        "mode": cfg.mode.value,
+        "profiles": list_profiles(),
+        "audit_enabled": cfg.audit_enabled,
+        "log_files": list_log_files(),
+    }
+
+
+def shield_pre_start(
+    container: str,
+    profiles: list[str] | None = None,
+    *,
+    config: ShieldConfig | None = None,
+) -> list[str]:
+    """Prepare shield for container start.
+
+    Returns extra podman args (including network args).
+
+    Args:
+        container: Container name.
+        profiles: Profile names (defaults to config.default_profiles).
+        config: Shield configuration (loads default if None).
+
+    Returns:
+        Extra arguments for ``podman run``.
+    """
+    cfg = _load_config(config)
+    if profiles is None:
+        profiles = list(cfg.default_profiles)
+
+    if cfg.mode == ShieldMode.HARDENED:
+        from . import hardened
+
+        result = hardened.pre_start(cfg, container, profiles)
+    else:
+        from . import standard
+
+        result = standard.pre_start(cfg, container, profiles)
+
+    if cfg.audit_enabled:
+        log_event(container, "setup", detail=f"profiles={','.join(profiles)}")
+    return result
+
+
+def shield_post_start(
+    container: str,
+    profiles: list[str] | None = None,
+    *,
+    config: ShieldConfig | None = None,
+) -> None:
+    """Post-start hook.  Only needed for hardened mode.
+
+    Args:
+        container: Container name.
+        profiles: Profile names (defaults to config.default_profiles).
+        config: Shield configuration (loads default if None).
+    """
+    cfg = _load_config(config)
+    if cfg.mode != ShieldMode.HARDENED:
+        return
+
+    if profiles is None:
+        profiles = list(cfg.default_profiles)
+
+    from . import hardened
+
+    hardened.post_start(cfg, container, profiles)
+    if cfg.audit_enabled:
+        log_event(container, "setup", detail="hardened post_start complete")
+
+
+def shield_pre_stop(
+    container: str,
+    *,
+    config: ShieldConfig | None = None,
+) -> None:
+    """Pre-stop hook.  Only needed for hardened mode.
+
+    Args:
+        container: Container name.
+        config: Shield configuration (loads default if None).
+    """
+    cfg = _load_config(config)
+    if cfg.mode != ShieldMode.HARDENED:
+        return
+
+    from . import hardened
+
+    hardened.pre_stop(container)
+    if cfg.audit_enabled:
+        log_event(container, "teardown")
+
+
+def shield_allow(
+    container: str,
+    target: str,
+    *,
+    config: ShieldConfig | None = None,
+) -> list[str]:
+    """Live-allow a domain or IP for a running container.
+
+    If *target* is a domain, resolves it first.
+
+    Args:
+        container: Container name or ID.
+        target: Domain name or IPv4 address/CIDR.
+        config: Shield configuration (loads default if None).
+
+    Returns:
+        List of IPs that were allowed.
+    """
+    cfg = _load_config(config)
+    ips = [target] if _is_ip(target) else dig(target)
+    mod = _mode_module(cfg.mode)
+    allowed: list[str] = []
+
+    for ip in ips:
+        try:
+            mod.allow_ip(container, ip)
+            allowed.append(ip)
+            if cfg.audit_enabled:
+                log_event(container, "allowed", dest=ip, detail=f"target={target}")
+        except Exception:
+            pass
+
+    return allowed
+
+
+def shield_deny(
+    container: str,
+    target: str,
+    *,
+    config: ShieldConfig | None = None,
+) -> list[str]:
+    """Live-deny a domain or IP for a running container.
+
+    If *target* is a domain, resolves it first.  Failures to remove
+    individual IPs are silently ignored (best-effort).
+
+    Args:
+        container: Container name or ID.
+        target: Domain name or IPv4 address/CIDR.
+        config: Shield configuration (loads default if None).
+
+    Returns:
+        List of IPs that were denied.
+    """
+    cfg = _load_config(config)
+    ips = [target] if _is_ip(target) else dig(target)
+    mod = _mode_module(cfg.mode)
+    denied: list[str] = []
+
+    for ip in ips:
+        try:
+            mod.deny_ip(container, ip)
+            denied.append(ip)
+            if cfg.audit_enabled:
+                log_event(container, "denied", dest=ip, detail=f"target={target}")
+        except Exception:
+            pass
+
+    return denied
+
+
+def shield_rules(
+    container: str,
+    *,
+    config: ShieldConfig | None = None,
+) -> str:
+    """Return current nft rules for a container.
+
+    Args:
+        container: Container name or ID.
+        config: Shield configuration (loads default if None).
+
+    Returns:
+        The nft ruleset/set output.
+    """
+    cfg = _load_config(config)
+    return _mode_module(cfg.mode).list_rules(container)
+
+
+def shield_resolve(
+    container: str,
+    profiles: list[str] | None = None,
+    *,
+    config: ShieldConfig | None = None,
+    force: bool = False,
+) -> list[str]:
+    """Resolve DNS profiles and cache the results.
+
+    Args:
+        container: Container name (cache key).
+        profiles: Profile names (defaults to config.default_profiles).
+        config: Shield configuration (loads default if None).
+        force: If True, bypass cache freshness and re-resolve.
+
+    Returns:
+        List of resolved IPs + raw IPs/CIDRs.
+    """
+    cfg = _load_config(config)
+    if profiles is None:
+        profiles = list(cfg.default_profiles)
+
+    entries = compose_profiles(profiles)
+    if not entries:
+        return []
+
+    max_age = 0 if force else 3600
+    return resolve_and_cache(entries, container, max_age=max_age)
+
+
+__all__ = [
+    "ExecError",
+    "ShieldConfig",
+    "ShieldMode",
+    "list_log_files",
+    "list_profiles",
+    "load_shield_config",
+    "log_event",
+    "shield_allow",
+    "shield_deny",
+    "shield_post_start",
+    "shield_pre_start",
+    "shield_pre_stop",
+    "shield_resolve",
+    "shield_rules",
+    "shield_setup",
+    "shield_status",
+    "tail_log",
+]

--- a/src/terok_shield/cli.py
+++ b/src/terok_shield/cli.py
@@ -4,11 +4,26 @@
 """CLI entry point for terok-shield."""
 
 import argparse
+import json
 import sys
 
+from . import (
+    ExecError,
+    ShieldConfig,
+    ShieldMode,
+    list_log_files,
+    shield_allow,
+    shield_deny,
+    shield_resolve,
+    shield_rules,
+    shield_setup,
+    shield_status,
+    tail_log,
+)
 
-def main(argv: list[str] | None = None) -> None:
-    """Run the terok-shield CLI."""
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Build the argument parser with all subcommands."""
     parser = argparse.ArgumentParser(
         prog="terok-shield",
         description="nftables-based egress firewalling for Podman containers",
@@ -19,19 +34,145 @@ def main(argv: list[str] | None = None) -> None:
         version=f"%(prog)s {_get_version()}",
     )
     sub = parser.add_subparsers(dest="command")
-    sub.add_parser("setup", help="Install firewall hook or verify bridge")
+
+    p_setup = sub.add_parser("setup", help="Install firewall hook or verify bridge")
+    p_setup.add_argument(
+        "--hardened",
+        action="store_true",
+        default=False,
+        help="Use hardened mode (bridge network + rootless-netns)",
+    )
+
     sub.add_parser("status", help="Show shield status")
 
+    p_resolve = sub.add_parser("resolve", help="Resolve DNS profiles and cache IPs")
+    p_resolve.add_argument("container", help="Container name (cache key)")
+    p_resolve.add_argument(
+        "--force",
+        action="store_true",
+        default=False,
+        help="Bypass cache freshness and re-resolve",
+    )
+
+    p_allow = sub.add_parser("allow", help="Live-allow a domain or IP for a container")
+    p_allow.add_argument("container", help="Container name or ID")
+    p_allow.add_argument("target", help="Domain name or IP address to allow")
+
+    p_deny = sub.add_parser("deny", help="Live-deny a domain or IP for a container")
+    p_deny.add_argument("container", help="Container name or ID")
+    p_deny.add_argument("target", help="Domain name or IP address to deny")
+
+    p_rules = sub.add_parser("rules", help="Show current nft rules for a container")
+    p_rules.add_argument("container", help="Container name or ID")
+
+    p_logs = sub.add_parser("logs", help="Show audit log entries")
+    p_logs.add_argument("--container", default=None, help="Filter by container name")
+    p_logs.add_argument("-n", type=int, default=50, help="Number of recent entries")
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Run the terok-shield CLI."""
+    parser = _build_parser()
     args = parser.parse_args(argv)
 
     if args.command is None:
         parser.print_help()
         sys.exit(0)
 
-    if args.command == "setup":
-        print("terok-shield setup: not yet implemented")
-    elif args.command == "status":
-        print("terok-shield status: not yet implemented")
+    try:
+        _dispatch(args)
+    except (RuntimeError, ValueError, ExecError, OSError) as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def _dispatch(args: argparse.Namespace) -> None:
+    """Dispatch to the appropriate subcommand handler."""
+    cmd = args.command
+    if cmd == "setup":
+        _cmd_setup(hardened=args.hardened)
+    elif cmd == "status":
+        _cmd_status()
+    elif cmd == "resolve":
+        _cmd_resolve(args.container, force=args.force)
+    elif cmd == "allow":
+        _cmd_allow(args.container, args.target)
+    elif cmd == "deny":
+        _cmd_deny(args.container, args.target)
+    elif cmd == "rules":
+        _cmd_rules(args.container)
+    elif cmd == "logs":
+        _cmd_logs(container=args.container, n=args.n)
+
+
+def _cmd_setup(hardened: bool) -> None:
+    """Run shield setup."""
+    mode = ShieldMode.HARDENED if hardened else ShieldMode.STANDARD
+    shield_setup(config=ShieldConfig(mode=mode))
+    print(f"Shield setup complete ({mode.value} mode).")
+
+
+def _cmd_status() -> None:
+    """Show shield status."""
+    status = shield_status()
+    print(f"Mode:     {status['mode']}")
+    print(f"Audit:    {'enabled' if status['audit_enabled'] else 'disabled'}")
+    print(f"Profiles: {', '.join(status['profiles']) or '(none)'}")
+    if status["log_files"]:
+        print(f"Logs:     {len(status['log_files'])} container(s)")
+
+
+def _cmd_resolve(container: str, force: bool) -> None:
+    """Resolve DNS profiles and cache results."""
+    ips = shield_resolve(container, force=force)
+    label = " (forced)" if force else ""
+    print(f"Resolved {len(ips)} IPs for {container}{label}")
+    for ip in ips:
+        print(f"  {ip}")
+
+
+def _cmd_allow(container: str, target: str) -> None:
+    """Live-allow a domain or IP."""
+    ips = shield_allow(container, target)
+    if ips:
+        print(f"Allowed {target} -> {', '.join(ips)} for {container}")
+    else:
+        print(f"No IPs allowed for {container}")
+
+
+def _cmd_deny(container: str, target: str) -> None:
+    """Live-deny a domain or IP."""
+    ips = shield_deny(container, target)
+    if ips:
+        print(f"Denied {target} ({', '.join(ips)}) for {container}")
+    else:
+        print(f"No IPs denied for {container}")
+
+
+def _cmd_rules(container: str) -> None:
+    """Show nft rules for a container."""
+    rules = shield_rules(container)
+    if rules.strip():
+        print(rules)
+    else:
+        print(f"No rules found for {container}")
+
+
+def _cmd_logs(container: str | None, n: int) -> None:
+    """Show audit log entries."""
+    if container:
+        for entry in tail_log(container, n):
+            print(json.dumps(entry))
+    else:
+        files = list_log_files()
+        if not files:
+            print("No audit logs found.")
+            return
+        for ctr in files:
+            for entry in tail_log(ctr, n):
+                print(json.dumps(entry))
 
 
 def _get_version() -> str:

--- a/src/terok_shield/config.py
+++ b/src/terok_shield/config.py
@@ -24,7 +24,6 @@ ANNOTATION_KEY = "terok.shield.profiles"
 class ShieldMode(enum.Enum):
     """Operating mode for the shield firewall."""
 
-    DISABLED = "disabled"
     STANDARD = "standard"
     HARDENED = "hardened"
 
@@ -33,7 +32,7 @@ class ShieldMode(enum.Enum):
 class ShieldConfig:
     """Resolved shield configuration."""
 
-    mode: ShieldMode = ShieldMode.DISABLED
+    mode: ShieldMode = ShieldMode.STANDARD
     default_profiles: tuple[str, ...] = ("dev-standard",)
     gate_port: int = DEFAULT_GATE_PORT
     audit_enabled: bool = True
@@ -141,14 +140,14 @@ def load_shield_config() -> ShieldConfig:
     if not isinstance(section, dict):
         return ShieldConfig()
 
-    mode_str = section.get("mode", "disabled")
-    try:
-        mode = ShieldMode(mode_str)
-    except ValueError:
-        if mode_str == "auto":
-            mode = _auto_detect_mode()
-        else:
-            mode = ShieldMode.DISABLED
+    mode_str = section.get("mode", "auto")
+    if mode_str == "auto":
+        mode = _auto_detect_mode()
+    else:
+        try:
+            mode = ShieldMode(mode_str)
+        except ValueError:
+            raise ValueError(f"Unknown shield mode: {mode_str!r}") from None
 
     raw_profiles = section.get("default_profiles", ["dev-standard"])
     if not isinstance(raw_profiles, list):
@@ -188,7 +187,10 @@ def _auto_detect_mode() -> ShieldMode:
     """Auto-detect the best available shield mode.
 
     Checks for hardened mode prerequisites (podman bridge network + dnsmasq),
-    falls back to standard mode (nft binary), or returns disabled.
+    falls back to standard mode (nft binary).
+
+    Raises:
+        RuntimeError: If no supported shield mode is available.
     """
     import shutil
     import subprocess
@@ -209,4 +211,7 @@ def _auto_detect_mode() -> ShieldMode:
     if shutil.which("nft"):
         return ShieldMode.STANDARD
 
-    return ShieldMode.DISABLED
+    raise RuntimeError(
+        "No supported shield mode available. "
+        "Install nft (standard mode) or set up a podman bridge network with dnsmasq (hardened mode)."
+    )

--- a/src/terok_shield/dns.py
+++ b/src/terok_shield/dns.py
@@ -3,27 +3,23 @@
 
 """DNS domain resolution with timestamp-based caching."""
 
-import ipaddress
+import logging
 import re
 import time
 from pathlib import Path
 
 from .config import shield_resolved_dir
 from .run import dig
+from .util import is_ipv4
+
+logger = logging.getLogger(__name__)
 
 _SAFE_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 
 
 def _is_ip(entry: str) -> bool:
     """Return True if `entry` is an IPv4 address or CIDR, False if it's a domain."""
-    try:
-        if "/" in entry:
-            ipaddress.IPv4Network(entry, strict=False)
-        else:
-            ipaddress.IPv4Address(entry)
-        return True
-    except ValueError:
-        return False
+    return is_ipv4(entry)
 
 
 def _split_entries(entries: list[str]) -> tuple[list[str], list[str]]:
@@ -43,7 +39,10 @@ def resolve_domains(domains: list[str]) -> list[str]:
     seen: set[str] = set()
     result: list[str] = []
     for domain in domains:
-        for ip in dig(domain):
+        ips = dig(domain)
+        if not ips:
+            logger.warning("Domain %r resolved to no IPs (typo or DNS failure?)", domain)
+        for ip in ips:
             if ip not in seen:
                 seen.add(ip)
                 result.append(ip)

--- a/src/terok_shield/hardened.py
+++ b/src/terok_shield/hardened.py
@@ -1,0 +1,330 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Hardened mode: named bridge + rootless-netns.
+
+Uses a dedicated bridge network (``ctr-egress``) and applies nftables
+rules in podman's rootless-netns.  All container traffic traverses the
+bridge and is filtered at the forward chain.  Requires both the bridge
+network and ``dnsmasq`` to be present on the host.
+"""
+
+import logging
+import re
+
+from .config import (
+    BRIDGE_GATEWAY,
+    BRIDGE_NETWORK,
+    BRIDGE_SUBNET,
+    ShieldConfig,
+    ensure_shield_dirs,
+    shield_resolved_dir,
+)
+from .dns import resolve_and_cache
+from .nft import (
+    add_elements,
+    create_set,
+    forward_rule,
+    hardened_ruleset,
+    safe_ip,
+    safe_name,
+)
+from .nft_constants import NFT_TABLE_NAME
+from .profiles import compose_profiles
+from .run import ExecError, nft_via_rootless_netns, podman_inspect, run as run_cmd
+from .util import is_ipv4
+
+logger = logging.getLogger(__name__)
+
+_SAFE_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+_SAFE_DOMAIN = re.compile(
+    r"^[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?)*\.?$"
+)
+
+
+def setup(_config: ShieldConfig) -> None:
+    """Verify bridge network exists and create directories.
+
+    Args:
+        _config: Shield configuration (unused, kept for API consistency).
+
+    Raises:
+        RuntimeError: If the bridge network does not exist.
+    """
+    ensure_shield_dirs()
+    try:
+        run_cmd(["podman", "network", "exists", BRIDGE_NETWORK])
+    except ExecError:
+        raise RuntimeError(
+            f"Bridge network '{BRIDGE_NETWORK}' not found. "
+            f"Create it with: podman network create "
+            f"--subnet {BRIDGE_SUBNET} --gateway {BRIDGE_GATEWAY} {BRIDGE_NETWORK}"
+        ) from None
+
+
+def _ensure_netns(gate_port: int) -> None:
+    """Ensure rootless-netns has the shield nft table with current gate_port.
+
+    If the table exists but uses a different gate port, it is replaced.
+
+    Args:
+        gate_port: Gate server port for the ruleset.
+
+    Raises:
+        RuntimeError: If the table cannot be loaded.
+    """
+    expected = hardened_ruleset(BRIDGE_GATEWAY, BRIDGE_SUBNET, gate_port)
+
+    out = nft_via_rootless_netns(
+        "list",
+        "ruleset",
+        "inet",
+        check=False,
+    )
+    if "terok_shield" in out:
+        if f"th dport {gate_port}" in out:
+            return
+        # Gate port changed — delete stale table before reloading.
+        nft_via_rootless_netns(
+            "delete",
+            "table",
+            "inet",
+            "terok_shield",
+            check=False,
+        )
+
+    nft_via_rootless_netns(stdin=expected)
+
+    out = nft_via_rootless_netns(
+        "list",
+        "table",
+        "inet",
+        "terok_shield",
+        check=False,
+    )
+    if "terok_shield" not in out:
+        raise RuntimeError("Failed to load nft table in rootless-netns")
+
+
+def pre_start(
+    config: ShieldConfig,
+    container: str,
+    profiles: list[str],
+) -> list[str]:
+    """Prepare for container start in hardened mode.
+
+    Ensures the rootless-netns table is loaded, resolves DNS profiles,
+    and returns podman CLI arguments.
+
+    Args:
+        config: Shield configuration.
+        container: Container name (used as DNS cache key).
+        profiles: Profile names to compose and resolve.
+
+    Returns:
+        Extra arguments for ``podman run``.
+    """
+    _ensure_netns(config.gate_port)
+
+    entries = compose_profiles(profiles)
+    resolve_and_cache(entries, container)
+
+    return [
+        "--network",
+        BRIDGE_NETWORK,
+        "--dns",
+        BRIDGE_GATEWAY,
+        "--cap-drop",
+        "NET_ADMIN",
+        "--cap-drop",
+        "NET_RAW",
+        "--security-opt",
+        "no-new-privileges",
+    ]
+
+
+def _read_resolved_cache(container: str) -> list[str]:
+    """Read pre-resolved IPs from the cache file for a container.
+
+    Returns an empty list if the file does not exist or the name is invalid.
+    """
+    if not _SAFE_NAME.fullmatch(container):
+        return []
+    path = shield_resolved_dir() / f"{container}.resolved"
+    if not path.is_file():
+        return []
+    return [line.strip() for line in path.read_text().splitlines() if line.strip()]
+
+
+def post_start(
+    _config: ShieldConfig,
+    container: str,
+    profiles: list[str],
+) -> None:
+    """Post-start: create per-container nft set and load IPs.
+
+    Must be called after ``podman run`` succeeds.  Inspects the container
+    for its bridge IP, creates a per-container allow set, loads resolved
+    IPs, and adds a forward rule.
+
+    Args:
+        _config: Shield configuration (unused, kept for API consistency).
+        container: Container name.
+        profiles: Profile names (for dnsmasq nftset generation).
+    """
+    ip = podman_inspect(
+        container,
+        "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}",
+    )
+
+    nft_via_rootless_netns(stdin=create_set(container))
+
+    ips = _read_resolved_cache(container)
+    if ips:
+        safe = safe_name(container)
+        cmd = add_elements(f"{safe}_allow_v4", ips)
+        if cmd:
+            nft_via_rootless_netns(stdin=cmd, check=False)
+
+    nft_via_rootless_netns(stdin=forward_rule(container, ip))
+
+    entries = compose_profiles(profiles)
+    domains = [e for e in entries if not is_ipv4(e)]
+    _update_dnsmasq_nftsets(container, domains)
+
+
+def pre_stop(container: str) -> None:
+    """Remove per-container forward rules and allow set.
+
+    Call before ``podman stop`` to clean up hardened-mode nft state.
+
+    Args:
+        container: Container name.
+    """
+    safe = safe_name(container)
+
+    out = nft_via_rootless_netns(
+        "-a",
+        "list",
+        "chain",
+        "inet",
+        "terok_shield",
+        "forward",
+        check=False,
+    )
+    for line in out.splitlines():
+        if f"terok_shield:{safe}" in line and "handle" in line:
+            parts = line.strip().split()
+            try:
+                h = parts[parts.index("handle") + 1]
+                nft_via_rootless_netns(
+                    "delete",
+                    "rule",
+                    "inet",
+                    "terok_shield",
+                    "forward",
+                    "handle",
+                    h,
+                    check=False,
+                )
+            except (ValueError, IndexError):
+                pass
+
+    nft_via_rootless_netns(
+        "delete",
+        "set",
+        "inet",
+        "terok_shield",
+        f"{safe}_allow_v4",
+        check=False,
+    )
+
+    (shield_resolved_dir() / f"{safe}.dnsmasq-nftset").unlink(missing_ok=True)
+
+
+def allow_ip(container: str, ip: str) -> None:
+    """Live-allow an IP for a running container in rootless-netns.
+
+    Args:
+        container: Container name or ID.
+        ip: IPv4 address or CIDR to allow.
+    """
+    safe_ip(ip)
+    safe = safe_name(container)
+    nft_via_rootless_netns(
+        "add",
+        "element",
+        "inet",
+        "terok_shield",
+        f"{safe}_allow_v4",
+        f"{{ {ip} }}",
+    )
+
+
+def deny_ip(container: str, ip: str) -> None:
+    """Live-deny an IP for a running container in rootless-netns.
+
+    Args:
+        container: Container name or ID.
+        ip: IPv4 address or CIDR to deny.
+    """
+    safe_ip(ip)
+    safe = safe_name(container)
+    nft_via_rootless_netns(
+        "delete",
+        "element",
+        "inet",
+        "terok_shield",
+        f"{safe}_allow_v4",
+        f"{{ {ip} }}",
+    )
+
+
+def list_rules(container: str) -> str:
+    """List per-container allow set in rootless-netns.
+
+    Args:
+        container: Container name or ID.
+
+    Returns:
+        The nft set output, or empty string on failure.
+    """
+    safe = safe_name(container)
+    return nft_via_rootless_netns(
+        "list",
+        "set",
+        "inet",
+        "terok_shield",
+        f"{safe}_allow_v4",
+        check=False,
+    )
+
+
+def _safe_domain(domain: str) -> bool:
+    """Return True if domain is safe for use in dnsmasq nftset directives."""
+    return bool(_SAFE_DOMAIN.fullmatch(domain)) and len(domain) <= 253
+
+
+def _update_dnsmasq_nftsets(container: str, domains: list[str]) -> None:
+    """Write dnsmasq nftset config for a container (best-effort).
+
+    Domains that fail validation are skipped with a warning.
+
+    Args:
+        container: Container name.
+        domains: Domain names to include in nftset rules.
+    """
+    if not domains:
+        return
+    safe = safe_name(container)
+    valid = []
+    for d in domains:
+        if _safe_domain(d):
+            valid.append(d)
+        else:
+            logger.warning("Skipping invalid domain %r for container %s", d, container)
+    if not valid:
+        return
+    lines = [f"nftset=/{d}/4#inet#{NFT_TABLE_NAME}#{safe}_allow_v4" for d in valid]
+    nftset_file = shield_resolved_dir() / f"{safe}.dnsmasq-nftset"
+    nftset_file.write_text("\n".join(lines) + "\n")

--- a/src/terok_shield/resources/shield_probe.py
+++ b/src/terok_shield/resources/shield_probe.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Probe network reachability and report the exact ICMP error code.
+
+Standalone diagnostic script designed to run INSIDE containers.  Uses
+``IP_RECVERR`` + ``MSG_ERRQUEUE`` on a regular UDP socket to retrieve
+the kernel's ``sock_extended_err`` struct, which preserves the original
+ICMP type and code — unlike ``connect()`` errno, which maps several
+distinct ICMP codes to the same ``EHOSTUNREACH``.
+
+No special capabilities (``CAP_NET_RAW``, ``CAP_NET_ADMIN``) are needed.
+
+Usage::
+
+    shield_probe.py HOST [PORT]
+
+Exit codes:
+
+- 0: probe completed (check JSON output for result)
+- 1: usage error or unexpected failure
+
+Output is a single JSON object on stdout.
+"""
+
+from __future__ import annotations
+
+import json
+import select
+import socket
+import struct
+import sys
+
+# Stable Linux kernel ABI constants.
+_SOL_IP = 0
+_IP_RECVERR = getattr(socket, "IP_RECVERR", 11)  # Added to Python in 3.14
+_SO_EE_ORIGIN_ICMP = 2
+
+# ICMP Destination Unreachable (type 3) code names.
+_ICMP_UNREACH_CODES: dict[int, str] = {
+    0: "net-unreachable",
+    1: "host-unreachable",
+    2: "protocol-unreachable",
+    3: "port-unreachable",
+    4: "fragmentation-needed",
+    5: "source-route-failed",
+    6: "net-unknown",
+    7: "host-unknown",
+    9: "net-admin-prohibited",
+    10: "host-admin-prohibited",
+    13: "admin-prohibited",
+}
+
+# Layout of struct sock_extended_err (linux/errqueue.h):
+#   uint32_t ee_errno
+#   uint8_t  ee_origin
+#   uint8_t  ee_type
+#   uint8_t  ee_code
+#   uint8_t  ee_pad
+#   uint32_t ee_info
+#   uint32_t ee_data
+_SOCK_EE_FMT = "@IBBBxII"
+_SOCK_EE_SIZE = struct.calcsize(_SOCK_EE_FMT)
+
+
+def _parse_icmp_error(ancdata: list) -> dict | None:
+    """Extract ICMP error fields from recvmsg ancillary data, or return None."""
+    for cmsg_level, cmsg_type, cmsg_data in ancdata:
+        if cmsg_level != _SOL_IP or cmsg_type != _IP_RECVERR:
+            continue
+        if len(cmsg_data) < _SOCK_EE_SIZE:
+            continue
+        ee_errno, ee_origin, ee_type, ee_code, _, _ = struct.unpack(
+            _SOCK_EE_FMT, cmsg_data[:_SOCK_EE_SIZE]
+        )
+        if ee_origin != _SO_EE_ORIGIN_ICMP:
+            continue
+        return {
+            "result": "icmp-error",
+            "icmp_type": ee_type,
+            "icmp_code": ee_code,
+            "icmp_code_name": _ICMP_UNREACH_CODES.get(ee_code, f"code-{ee_code}"),
+            "errno": ee_errno,
+        }
+    return None
+
+
+def probe(host: str, port: int = 443, timeout: float = 3.0) -> dict:
+    """Probe *host*:*port* and return a result dict.
+
+    The dict always contains ``"host"``, ``"port"``, and ``"result"``
+    (one of ``"open"``, ``"icmp-error"``, ``"timeout"``).  On ICMP
+    errors it also contains ``"icmp_type"``, ``"icmp_code"``,
+    ``"icmp_code_name"``, and ``"errno"``.
+    """
+    base: dict = {"host": host, "port": port}
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        sock.setblocking(False)
+        sock.setsockopt(_SOL_IP, _IP_RECVERR, 1)
+        sock.connect((host, port))
+        # Send a minimal datagram to trigger the ICMP response.
+        try:
+            sock.send(b"\x00")
+        except OSError:
+            pass
+
+        # Wait for the ICMP error to arrive on the error queue.
+        # poll() + POLLERR reliably detects error queue events on Linux;
+        # select() exceptfds does NOT signal them on many kernels.
+        poller = select.poll()
+        poller.register(sock, select.POLLERR)
+        if not poller.poll(timeout * 1000):
+            # No error within timeout — confirm reachability with a second send.
+            # With IP_RECVERR enabled, the kernel queues ICMP errors on the
+            # socket's error queue and makes subsequent send() fail with the
+            # cached errno.  A successful send() therefore means no ICMP
+            # unreachable was received — the host is genuinely reachable.
+            try:
+                sock.send(b"\x00")
+                return {**base, "result": "open"}
+            except OSError:
+                pass
+            # Re-check the error queue one more time.
+            if not poller.poll(100):
+                return {**base, "result": "timeout"}
+
+        # Read the ICMP error from the error queue.
+        try:
+            _data, ancdata, _flags, _addr = sock.recvmsg(1024, 1024, socket.MSG_ERRQUEUE)
+        except OSError:
+            return {**base, "result": "timeout"}
+
+        icmp = _parse_icmp_error(ancdata)
+        return {**base, **icmp} if icmp else {**base, "result": "timeout"}
+    finally:
+        sock.close()
+
+
+def main() -> int:
+    """CLI entry point."""
+    if len(sys.argv) < 2:
+        print(f"Usage: {sys.argv[0]} HOST [PORT]", file=sys.stderr)
+        return 1
+
+    host = sys.argv[1]
+    try:
+        port = int(sys.argv[2]) if len(sys.argv) > 2 else 443
+    except ValueError:
+        print(json.dumps({"error": f"invalid port: {sys.argv[2]!r}"}))
+        return 1
+
+    try:
+        result = probe(host, port)
+    except Exception as e:
+        print(json.dumps({"error": str(e)}))
+        return 1
+
+    print(json.dumps(result))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/terok_shield/standard.py
+++ b/src/terok_shield/standard.py
@@ -1,0 +1,214 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Standard mode: OCI hooks + per-container netns.
+
+Uses OCI hooks to apply per-container nftables rules inside each
+container's network namespace.  No root required — only podman and nft.
+The OCI hook (``hook.py``) applies the ruleset at container creation;
+this module handles setup, DNS pre-resolution, and live allow/deny.
+"""
+
+import json
+import os
+import shlex
+import stat
+import sys
+
+from .config import (
+    ANNOTATION_KEY,
+    ShieldConfig,
+    ensure_shield_dirs,
+    shield_hook_entrypoint,
+    shield_hooks_dir,
+)
+from .dns import resolve_and_cache
+from .nft import safe_ip
+from .profiles import compose_profiles
+from .run import nft_via_nsenter, run as run_cmd
+
+
+def _detect_rootless_network_mode() -> str:
+    """Detect the rootless network mode (pasta or slirp4netns).
+
+    Runs ``podman info -f json`` and reads ``host.rootlessNetworkCmd``.
+    Returns ``"pasta"`` if detection fails (modern podman default).
+    """
+    output = run_cmd(["podman", "info", "-f", "json"], check=False)
+    if not output:
+        return "pasta"
+    try:
+        info = json.loads(output)
+    except json.JSONDecodeError:
+        return "pasta"
+    cmd = info.get("host", {}).get("rootlessNetworkCmd", "")
+    return cmd if cmd in ("pasta", "slirp4netns") else "pasta"
+
+
+def _generate_entrypoint() -> str:
+    """Generate the OCI hook entrypoint shell script.
+
+    Uses the current Python interpreter so the hook runs in the
+    same environment where terok-shield is installed.
+    """
+    return f"#!/bin/sh\nexec {shlex.quote(sys.executable)} -m terok_shield.hook\n"
+
+
+def _generate_hook_json(entrypoint: str) -> str:
+    """Generate the OCI hook JSON descriptor.
+
+    The hook fires at ``createRuntime`` for containers with the
+    ``terok.shield.profiles`` annotation.
+
+    Args:
+        entrypoint: Absolute path to the hook entrypoint script.
+    """
+    hook = {
+        "version": "1.0.0",
+        "hook": {"path": entrypoint, "args": ["terok-shield-hook"]},
+        "when": {"annotations": {ANNOTATION_KEY: ".*"}},
+        "stages": ["createRuntime"],
+    }
+    return json.dumps(hook, indent=2) + "\n"
+
+
+def setup(_config: ShieldConfig) -> None:
+    """Install OCI hook JSON and entrypoint script.
+
+    Args:
+        _config: Shield configuration (unused, kept for API consistency).
+    """
+    ensure_shield_dirs()
+
+    ep = shield_hook_entrypoint()
+    ep.write_text(_generate_entrypoint())
+    ep.chmod(ep.stat().st_mode | stat.S_IEXEC)
+
+    hook_json = _generate_hook_json(str(ep))
+    (shield_hooks_dir() / "terok-shield-hook.json").write_text(hook_json)
+
+
+def pre_start(
+    config: ShieldConfig,
+    container: str,
+    profiles: list[str],
+) -> list[str]:
+    """Prepare for container start in standard mode.
+
+    Composes profiles, resolves DNS domains, caches results, and
+    returns the podman CLI arguments needed for shield protection.
+
+    Args:
+        config: Shield configuration.
+        container: Container name (used as DNS cache key).
+        profiles: Profile names to compose and resolve.
+
+    Returns:
+        Extra arguments for ``podman run``.
+
+    Raises:
+        RuntimeError: If the OCI hook is not installed.
+        FileNotFoundError: If a named profile does not exist.
+    """
+    hook_json = shield_hooks_dir() / "terok-shield-hook.json"
+    if not hook_json.is_file():
+        raise RuntimeError("Shield hook not installed. Run 'terok-shield setup' first.")
+
+    ep = shield_hook_entrypoint()
+    if not ep.is_file() or not os.access(ep, os.X_OK):
+        raise RuntimeError(
+            "Shield hook entrypoint missing or not executable. Run 'terok-shield setup' first."
+        )
+
+    entries = compose_profiles(profiles)
+    resolve_and_cache(entries, container)
+
+    args: list[str] = []
+
+    if os.geteuid() != 0:
+        mode = _detect_rootless_network_mode()
+        if mode == "slirp4netns":
+            args += [
+                "--network",
+                "slirp4netns:allow_host_loopback=true",
+                "--add-host",
+                "host.containers.internal:10.0.2.2",
+            ]
+        else:
+            args += [
+                "--network",
+                f"pasta:-T,{config.gate_port}",
+                "--add-host",
+                "host.containers.internal:127.0.0.1",
+            ]
+
+    args += [
+        "--annotation",
+        f"{ANNOTATION_KEY}={','.join(profiles)}",
+        "--hooks-dir",
+        str(shield_hooks_dir()),
+        "--cap-drop",
+        "NET_ADMIN",
+        "--cap-drop",
+        "NET_RAW",
+        "--security-opt",
+        "no-new-privileges",
+    ]
+    return args
+
+
+def allow_ip(container: str, ip: str) -> None:
+    """Live-allow an IP for a running container via nsenter.
+
+    Args:
+        container: Container name or ID.
+        ip: IPv4 address or CIDR to allow.
+    """
+    safe_ip(ip)
+    nft_via_nsenter(
+        container,
+        "add",
+        "element",
+        "inet",
+        "terok_shield",
+        "allow_v4",
+        f"{{ {ip} }}",
+    )
+
+
+def deny_ip(container: str, ip: str) -> None:
+    """Live-deny an IP for a running container via nsenter.
+
+    Args:
+        container: Container name or ID.
+        ip: IPv4 address or CIDR to deny.
+    """
+    safe_ip(ip)
+    nft_via_nsenter(
+        container,
+        "delete",
+        "element",
+        "inet",
+        "terok_shield",
+        "allow_v4",
+        f"{{ {ip} }}",
+    )
+
+
+def list_rules(container: str) -> str:
+    """List current nft rules for a running container.
+
+    Args:
+        container: Container name or ID.
+
+    Returns:
+        The nft ruleset output, or empty string on failure.
+    """
+    return nft_via_nsenter(
+        container,
+        "list",
+        "table",
+        "inet",
+        "terok_shield",
+        check=False,
+    )

--- a/src/terok_shield/util.py
+++ b/src/terok_shield/util.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared utility functions."""
+
+import ipaddress
+
+
+def is_ipv4(value: str) -> bool:
+    """Return True if *value* is an IPv4 address or CIDR notation.
+
+    Uses ``ipaddress.IPv4Address`` for plain addresses and
+    ``ipaddress.IPv4Network(..., strict=False)`` for CIDRs.
+    """
+    try:
+        if "/" in value:
+            ipaddress.IPv4Network(value, strict=False)
+        else:
+            ipaddress.IPv4Address(value)
+        return True
+    except ValueError:
+        return False

--- a/tach.toml
+++ b/tach.toml
@@ -30,6 +30,11 @@ depends_on = [
     "terok_shield.nft_constants",
 ]
 
+# Shared utilities — standalone, no internal deps
+[[modules]]
+path = "terok_shield.util"
+depends_on = []
+
 # Subprocess helpers — standalone, no internal deps
 [[modules]]
 path = "terok_shield.run"
@@ -47,12 +52,13 @@ depends_on = [
     "terok_shield.config",
 ]
 
-# DNS resolution and caching — depends on config + run
+# DNS resolution and caching — depends on config + run + util
 [[modules]]
 path = "terok_shield.dns"
 depends_on = [
     "terok_shield.config",
     "terok_shield.run",
+    "terok_shield.util",
 ]
 
 # Profile loading — depends on config
@@ -72,16 +78,47 @@ depends_on = [
     "terok_shield.run",
 ]
 
-# CLI — depends on config and package root
+# Standard mode — OCI hooks, per-container netns
+[[modules]]
+path = "terok_shield.standard"
+depends_on = [
+    "terok_shield.config",
+    "terok_shield.dns",
+    "terok_shield.nft",
+    "terok_shield.profiles",
+    "terok_shield.run",
+]
+
+# Hardened mode — bridge network, rootless-netns
+[[modules]]
+path = "terok_shield.hardened"
+depends_on = [
+    "terok_shield.config",
+    "terok_shield.dns",
+    "terok_shield.nft",
+    "terok_shield.nft_constants",
+    "terok_shield.profiles",
+    "terok_shield.run",
+    "terok_shield.util",
+]
+
+# CLI — depends on package root (public API)
 [[modules]]
 path = "terok_shield.cli"
 depends_on = [
     "terok_shield",
 ]
 
-# Package root — depends on config for public API re-exports
+# Package root — public API, dispatches to mode modules
 [[modules]]
 path = "terok_shield"
 depends_on = [
+    "terok_shield.audit",
     "terok_shield.config",
+    "terok_shield.dns",
+    "terok_shield.hardened",
+    "terok_shield.profiles",
+    "terok_shield.run",
+    "terok_shield.standard",
+    "terok_shield.util",
 ]

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -12,6 +12,7 @@ import os
 import shutil
 import subprocess
 from collections.abc import Iterator
+from pathlib import Path
 
 import pytest
 
@@ -112,6 +113,40 @@ def container_pid(container: str) -> str:
     from terok_shield.run import podman_inspect
 
     return podman_inspect(container, "{{.State.Pid}}")
+
+
+@pytest.fixture
+def probe_container(_pull_image: None) -> Iterator[str]:
+    """Start an Alpine container with Python and shield_probe installed."""
+    name = f"{CTR_PREFIX}-probe-{os.getpid()}"
+    subprocess.run(["podman", "rm", "-f", name], capture_output=True)
+    try:
+        subprocess.run(
+            ["podman", "run", "-d", "--name", name, IMAGE, "sleep", "120"],
+            check=True,
+            capture_output=True,
+        )
+        # Install Python inside the container.
+        subprocess.run(
+            ["podman", "exec", name, "apk", "add", "--no-cache", "python3"],
+            check=True,
+            capture_output=True,
+            timeout=120,
+        )
+        # Copy the probe script into the container.
+        probe_src = Path(__file__).resolve().parent.parent.parent / (
+            "src/terok_shield/resources/shield_probe.py"
+        )
+        if not probe_src.exists():
+            pytest.skip(f"shield_probe.py not found at {probe_src}")
+        subprocess.run(
+            ["podman", "cp", str(probe_src), f"{name}:/usr/local/bin/shield_probe.py"],
+            check=True,
+            capture_output=True,
+        )
+        yield name
+    finally:
+        subprocess.run(["podman", "rm", "-f", name], capture_output=True)
 
 
 def nsenter_nft(pid: str, *args: str, stdin: str | None = None) -> subprocess.CompletedProcess:

--- a/tests/integration/test_firewall.py
+++ b/tests/integration/test_firewall.py
@@ -26,6 +26,7 @@ from ..testnet import (
     ALLOWED_TARGET_HTTPS,
     ALLOWED_TARGET_IPS,
     BLOCKED_TARGET_HTTP,
+    BLOCKED_TARGET_IP,
     GOOGLE_DNS_IP,
     IPV6_CLOUDFLARE,
     IPV6_GOOGLE,
@@ -47,21 +48,11 @@ def _exec(container: str, *cmd: str, timeout: int = 10) -> subprocess.CompletedP
     )
 
 
-def _wget(
-    container: str, url: str, timeout: int = 5, *, ipv4_only: bool = True
-) -> subprocess.CompletedProcess:
+def _wget(container: str, url: str, timeout: int = 5) -> subprocess.CompletedProcess:
     """Attempt an outbound HTTP/HTTPS request from inside a container."""
-    flags = ["-q", "--spider", f"--timeout={timeout}"]
-    if ipv4_only:
-        flags.insert(0, "-4")
-    return _exec(container, "wget", *flags, url, timeout=timeout + 5)
-
-
-def _check_internet(container: str) -> None:
-    """Skip test if container has no internet connectivity."""
-    pre = _wget(container, ALLOWED_TARGET_HTTP)
-    if pre.returncode != 0:
-        pytest.skip("No internet connectivity from container")
+    return _exec(
+        container, "wget", "-q", "--spider", f"--timeout={timeout}", url, timeout=timeout + 5
+    )
 
 
 # ── Firewall enforcement: blocking ──────────────────────
@@ -76,7 +67,7 @@ class TestFirewallBlocking:
 
     def test_http_blocked_after_ruleset(self, container: str, container_pid: str) -> None:
         """Outbound HTTP to an external IP is rejected after applying the ruleset."""
-        _check_internet(container)
+
         r = nsenter_nft(container_pid, stdin=standard_ruleset())
         assert r.returncode == 0, f"Ruleset apply failed: {r.stderr}"
 
@@ -85,7 +76,7 @@ class TestFirewallBlocking:
 
     def test_https_blocked_after_ruleset(self, container: str, container_pid: str) -> None:
         """Outbound HTTPS is rejected after applying the ruleset."""
-        _check_internet(container)
+
         r = nsenter_nft(container_pid, stdin=standard_ruleset())
         assert r.returncode == 0, f"Ruleset apply failed: {r.stderr}"
 
@@ -124,22 +115,32 @@ class TestFirewallBlocking:
         assert ping_g.returncode != 0, "IPv6 ping to Google should be blocked"
 
         # Functional: HTTP over IPv6 literal (must not force IPv4)
-        http6 = _wget(container, IPV6_HTTP_URL, timeout=5, ipv4_only=False)
+        http6 = _wget(container, IPV6_HTTP_URL, timeout=5)
         assert http6.returncode != 0, "HTTP over IPv6 should be blocked"
 
-    def test_reject_returns_icmp_error(self, container: str, container_pid: str) -> None:
-        """Blocked traffic receives ICMP admin-prohibited (reject, not drop/timeout)."""
-        _check_internet(container)
+    def test_reject_is_fast_not_timeout(self, container: str, container_pid: str) -> None:
+        """Blocked traffic fails fast (reject), not via silent timeout (drop).
+
+        A ``reject`` rule sends an ICMP error back immediately, so the
+        connection fails in well under the timeout.  A ``drop`` rule
+        would silently discard packets, causing the client to hang until
+        the full timeout expires.  We verify reject behavior by measuring
+        elapsed time rather than parsing tool-specific error messages.
+        """
+        import time
+
         r = nsenter_nft(container_pid, stdin=standard_ruleset())
         assert r.returncode == 0, f"Ruleset apply failed: {r.stderr}"
 
-        # wget to a blocked target with short timeout — stderr should show reject
-        post = _wget(container, BLOCKED_TARGET_HTTP, timeout=5)
-        assert post.returncode != 0
-        stderr_lower = post.stderr.lower()
-        reject_phrases = ("network unreachable", "prohibited", "refused", "network error")
-        assert any(phrase in stderr_lower for phrase in reject_phrases), (
-            f"Expected ICMP reject indication in stderr, got: {post.stderr!r}"
+        wget_timeout = 10
+        t0 = time.monotonic()
+        post = _wget(container, BLOCKED_TARGET_HTTP, timeout=wget_timeout)
+        elapsed = time.monotonic() - t0
+
+        assert post.returncode != 0, "Blocked target should be rejected"
+        assert elapsed < wget_timeout / 2, (
+            f"Connection took {elapsed:.1f}s (timeout={wget_timeout}s) — "
+            f"looks like drop (silent timeout), not reject (ICMP error)"
         )
 
     def test_rfc1918_still_blocked_when_not_whitelisted(
@@ -170,6 +171,48 @@ class TestFirewallBlocking:
         assert allow_pos < rfc_pos, "Allow set must precede RFC1918 reject rules"
 
 
+# ── ICMP error detection via shield_probe ─────────────
+
+
+@pytest.mark.integration
+@podman_missing
+@nft_missing
+@pytest.mark.usefixtures("nft_in_netns")
+class TestShieldProbe:
+    """Verify shield_probe detects the exact ICMP admin-prohibited code."""
+
+    def _run_probe(self, container: str, host: str, port: int = 443, timeout: int = 15) -> dict:
+        """Run shield_probe.py inside the container and return parsed JSON."""
+        r = _exec(
+            container, "python3", "/usr/local/bin/shield_probe.py", host, str(port), timeout=timeout
+        )
+        assert r.returncode == 0, f"shield_probe failed: {r.stderr}"
+        return json.loads(r.stdout)
+
+    def test_admin_prohibited_detected(self, probe_container: str) -> None:
+        """Blocked traffic reports ICMP type 3, code 13 (admin-prohibited)."""
+        # Apply the standard-mode firewall.
+        pid = subprocess.run(
+            ["podman", "inspect", "--format", "{{.State.Pid}}", probe_container],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        ).stdout.strip()
+        r = nsenter_nft(pid, stdin=standard_ruleset())
+        assert r.returncode == 0, f"Ruleset apply failed: {r.stderr}"
+
+        result = self._run_probe(probe_container, BLOCKED_TARGET_IP)
+        assert result["result"] == "icmp-error", f"Expected icmp-error, got: {result}"
+        assert result["icmp_type"] == 3, f"Expected ICMP type 3, got: {result}"
+        assert result["icmp_code"] == 13, f"Expected ICMP code 13, got: {result}"
+        assert result["icmp_code_name"] == "admin-prohibited"
+
+    def test_allowed_ip_is_open(self, probe_container: str) -> None:
+        """Without a firewall, probe reports open/timeout (not icmp-error)."""
+        result = self._run_probe(probe_container, ALLOWED_TARGET_IPS[0], port=53)
+        assert result["result"] != "icmp-error", f"Unexpected ICMP error: {result}"
+
+
 # ── Firewall enforcement: allowing ──────────────────────
 
 
@@ -182,7 +225,7 @@ class TestFirewallAllowing:
 
     def test_allowed_ip_reachable_http(self, container: str, container_pid: str) -> None:
         """HTTP traffic to an allowed IP is permitted."""
-        _check_internet(container)
+
         r = nsenter_nft(container_pid, stdin=standard_ruleset())
         assert r.returncode == 0, f"Ruleset apply failed: {r.stderr}"
         r = nsenter_nft(container_pid, stdin=add_elements("allow_v4", ALLOWED_TARGET_IPS))
@@ -193,7 +236,7 @@ class TestFirewallAllowing:
 
     def test_allowed_ip_reachable_https(self, container: str, container_pid: str) -> None:
         """HTTPS traffic to an allowed IP is permitted."""
-        _check_internet(container)
+
         r = nsenter_nft(container_pid, stdin=standard_ruleset())
         assert r.returncode == 0, f"Ruleset apply failed: {r.stderr}"
         r = nsenter_nft(container_pid, stdin=add_elements("allow_v4", ALLOWED_TARGET_IPS))
@@ -204,7 +247,7 @@ class TestFirewallAllowing:
 
     def test_non_allowed_ip_still_blocked(self, container: str, container_pid: str) -> None:
         """IPs not in the allow set remain blocked after adding others."""
-        _check_internet(container)
+
         r = nsenter_nft(container_pid, stdin=standard_ruleset())
         assert r.returncode == 0, f"Ruleset apply failed: {r.stderr}"
         r = nsenter_nft(container_pid, stdin=add_elements("allow_v4", ALLOWED_TARGET_IPS))
@@ -215,7 +258,7 @@ class TestFirewallAllowing:
 
     def test_allow_then_block_different_targets(self, container: str, container_pid: str) -> None:
         """One IP allowed, another blocked — in the same container."""
-        _check_internet(container)
+
         r = nsenter_nft(container_pid, stdin=standard_ruleset())
         assert r.returncode == 0, f"Ruleset apply failed: {r.stderr}"
         r = nsenter_nft(container_pid, stdin=add_elements("allow_v4", ALLOWED_TARGET_IPS))
@@ -309,7 +352,6 @@ class TestApplyHookE2E:
         self, container: str, container_pid: str, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """After apply_hook, outbound traffic is blocked."""
-        _check_internet(container)
 
         with tempfile.TemporaryDirectory() as tmp:
             monkeypatch.setenv("TEROK_SHIELD_STATE_DIR", tmp)
@@ -322,7 +364,6 @@ class TestApplyHookE2E:
         self, container: str, container_pid: str, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """After apply_hook with pre-resolved IPs, those IPs are reachable."""
-        _check_internet(container)
 
         with tempfile.TemporaryDirectory() as tmp:
             monkeypatch.setenv("TEROK_SHIELD_STATE_DIR", tmp)
@@ -485,7 +526,6 @@ class TestHookMainE2E:
         self, container: str, container_pid: str, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Full lifecycle: OCI state → hook_main → traffic filtered."""
-        _check_internet(container)
 
         with tempfile.TemporaryDirectory() as tmp:
             monkeypatch.setenv("TEROK_SHIELD_STATE_DIR", tmp)

--- a/tests/integration/test_shield_probe.py
+++ b/tests/integration/test_shield_probe.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Integration tests for shield_probe — exercises the real kernel IP_RECVERR path.
+
+These tests depend on Linux kernel ``IP_RECVERR`` support on the loopback
+interface.  They do NOT require containers, nftables, or root — just a
+standard Linux kernel.  If ``IP_RECVERR`` is not available (e.g. non-Linux
+host), the tests will fail naturally, which is the desired signal.
+"""
+
+import socket
+import unittest
+
+import pytest
+
+from terok_shield.resources.shield_probe import probe
+
+
+@pytest.mark.integration
+class TestProbeRealSocket(unittest.TestCase):
+    """Test probe() against real kernel ICMP via localhost sockets."""
+
+    def test_port_unreachable_on_localhost(self) -> None:
+        """Probing an unused localhost port gets ICMP port-unreachable."""
+        # Allocate an ephemeral port, then close so it's guaranteed unused.
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        sock.bind(("127.0.0.1", 0))
+        _, port = sock.getsockname()
+        sock.close()
+
+        result = probe("127.0.0.1", port, timeout=2.0)
+        self.assertEqual(result["result"], "icmp-error")
+        self.assertEqual(result["icmp_type"], 3)
+        self.assertEqual(result["icmp_code"], 3)
+        self.assertEqual(result["icmp_code_name"], "port-unreachable")
+
+    def test_open_port_on_localhost(self) -> None:
+        """Probing a port with a listening UDP socket does not report ICMP error."""
+        server = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        try:
+            server.bind(("127.0.0.1", 0))
+            _, port = server.getsockname()
+            result = probe("127.0.0.1", port, timeout=1.0)
+            self.assertNotEqual(result["result"], "icmp-error")
+        finally:
+            server.close()

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -1,0 +1,190 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the public API (terok_shield.__init__)."""
+
+import unittest
+from unittest import mock
+
+from terok_shield import (
+    ShieldConfig,
+    ShieldMode,
+    shield_allow,
+    shield_deny,
+    shield_pre_start,
+    shield_pre_stop,
+    shield_resolve,
+    shield_rules,
+    shield_setup,
+    shield_status,
+)
+
+from ..testnet import TEST_IP1
+
+
+class TestShieldSetup(unittest.TestCase):
+    """Test shield_setup dispatch."""
+
+    @mock.patch("terok_shield.standard.setup")
+    def test_standard_mode(self, mock_setup):
+        """shield_setup dispatches to standard.setup."""
+        config = ShieldConfig(mode=ShieldMode.STANDARD)
+        shield_setup(config=config)
+        mock_setup.assert_called_once_with(config)
+
+    @mock.patch("terok_shield.hardened.setup")
+    def test_hardened_mode(self, mock_setup):
+        """shield_setup dispatches to hardened.setup."""
+        config = ShieldConfig(mode=ShieldMode.HARDENED)
+        shield_setup(config=config)
+        mock_setup.assert_called_once_with(config)
+
+
+class TestShieldStatus(unittest.TestCase):
+    """Test shield_status."""
+
+    @mock.patch("terok_shield.list_log_files", return_value=[])
+    @mock.patch("terok_shield.list_profiles", return_value=["dev-standard"])
+    def test_returns_status_dict(self, _profiles, _logs):
+        """shield_status returns dict with expected keys."""
+        config = ShieldConfig(mode=ShieldMode.STANDARD)
+        status = shield_status(config=config)
+        self.assertEqual(status["mode"], "standard")
+        self.assertIn("profiles", status)
+        self.assertIn("audit_enabled", status)
+        self.assertIn("log_files", status)
+
+
+class TestShieldPreStart(unittest.TestCase):
+    """Test shield_pre_start dispatch."""
+
+    @mock.patch("terok_shield.log_event")
+    @mock.patch("terok_shield.standard.pre_start", return_value=["--network", "pasta:"])
+    def test_standard_dispatch(self, mock_pre, _log):
+        """shield_pre_start dispatches to standard.pre_start."""
+        config = ShieldConfig(mode=ShieldMode.STANDARD)
+        args = shield_pre_start("test", ["dev-standard"], config=config)
+        mock_pre.assert_called_once_with(config, "test", ["dev-standard"])
+        self.assertIn("--network", args)
+
+    @mock.patch("terok_shield.log_event")
+    @mock.patch("terok_shield.hardened.pre_start", return_value=["--network", "ctr-egress"])
+    def test_hardened_dispatch(self, mock_pre, _log):
+        """shield_pre_start dispatches to hardened.pre_start."""
+        config = ShieldConfig(mode=ShieldMode.HARDENED)
+        shield_pre_start("test", ["dev-hardened"], config=config)
+        mock_pre.assert_called_once_with(config, "test", ["dev-hardened"])
+
+    @mock.patch("terok_shield.log_event")
+    @mock.patch("terok_shield.standard.pre_start", return_value=[])
+    def test_uses_default_profiles(self, mock_pre, _log):
+        """shield_pre_start uses config.default_profiles if none given."""
+        config = ShieldConfig(mode=ShieldMode.STANDARD, default_profiles=("base",))
+        shield_pre_start("test", config=config)
+        mock_pre.assert_called_once_with(config, "test", ["base"])
+
+
+class TestShieldPreStop(unittest.TestCase):
+    """Test shield_pre_stop dispatch."""
+
+    @mock.patch("terok_shield.log_event")
+    def test_standard_noop(self, mock_log):
+        """shield_pre_stop is a no-op in standard mode."""
+        config = ShieldConfig(mode=ShieldMode.STANDARD)
+        shield_pre_stop("test", config=config)
+        mock_log.assert_not_called()
+
+    @mock.patch("terok_shield.log_event")
+    @mock.patch("terok_shield.hardened.pre_stop")
+    def test_hardened_dispatch(self, mock_pre_stop, _log):
+        """shield_pre_stop calls hardened.pre_stop."""
+        config = ShieldConfig(mode=ShieldMode.HARDENED)
+        shield_pre_stop("test", config=config)
+        mock_pre_stop.assert_called_once_with("test")
+
+
+class TestShieldAllow(unittest.TestCase):
+    """Test shield_allow."""
+
+    @mock.patch("terok_shield.log_event")
+    @mock.patch("terok_shield.standard.allow_ip")
+    def test_allows_ip_directly(self, mock_allow, _log):
+        """shield_allow passes an IP directly to allow_ip."""
+        config = ShieldConfig(mode=ShieldMode.STANDARD)
+        ips = shield_allow("test", TEST_IP1, config=config)
+        mock_allow.assert_called_once_with("test", TEST_IP1)
+        self.assertEqual(ips, [TEST_IP1])
+
+    @mock.patch("terok_shield.log_event")
+    @mock.patch("terok_shield.standard.allow_ip")
+    @mock.patch("terok_shield.dig", return_value=[TEST_IP1])
+    def test_resolves_domain(self, mock_dig, mock_allow, _log):
+        """shield_allow resolves domains via dig."""
+        config = ShieldConfig(mode=ShieldMode.STANDARD)
+        ips = shield_allow("test", "example.com", config=config)
+        mock_dig.assert_called_once_with("example.com")
+        mock_allow.assert_called_once_with("test", TEST_IP1)
+        self.assertEqual(ips, [TEST_IP1])
+
+
+class TestShieldDeny(unittest.TestCase):
+    """Test shield_deny."""
+
+    @mock.patch("terok_shield.log_event")
+    @mock.patch("terok_shield.standard.deny_ip")
+    def test_denies_ip_directly(self, mock_deny, _log):
+        """shield_deny passes an IP directly to deny_ip."""
+        config = ShieldConfig(mode=ShieldMode.STANDARD)
+        ips = shield_deny("test", TEST_IP1, config=config)
+        mock_deny.assert_called_once_with("test", TEST_IP1)
+        self.assertEqual(ips, [TEST_IP1])
+
+    @mock.patch("terok_shield.log_event")
+    @mock.patch("terok_shield.standard.deny_ip", side_effect=RuntimeError("nft error"))
+    def test_swallows_errors(self, mock_deny, _log):
+        """shield_deny ignores errors from deny_ip (best-effort)."""
+        config = ShieldConfig(mode=ShieldMode.STANDARD)
+        ips = shield_deny("test", TEST_IP1, config=config)
+        self.assertEqual(ips, [])
+
+
+class TestShieldRules(unittest.TestCase):
+    """Test shield_rules."""
+
+    @mock.patch(
+        "terok_shield.standard.list_rules",
+        return_value="table inet terok_shield {}",
+    )
+    def test_standard_dispatch(self, mock_rules):
+        """shield_rules dispatches to standard.list_rules."""
+        config = ShieldConfig(mode=ShieldMode.STANDARD)
+        result = shield_rules("test", config=config)
+        self.assertIn("terok_shield", result)
+
+
+class TestShieldResolve(unittest.TestCase):
+    """Test shield_resolve."""
+
+    @mock.patch("terok_shield.resolve_and_cache", return_value=[TEST_IP1])
+    @mock.patch("terok_shield.compose_profiles", return_value=["github.com"])
+    def test_resolves_profiles(self, _compose, mock_resolve):
+        """shield_resolve composes profiles and resolves."""
+        config = ShieldConfig(mode=ShieldMode.STANDARD)
+        ips = shield_resolve("test", ["dev-standard"], config=config)
+        self.assertEqual(ips, [TEST_IP1])
+
+    @mock.patch("terok_shield.compose_profiles", return_value=[])
+    def test_empty_profiles_returns_empty(self, _compose):
+        """shield_resolve returns empty list for empty profiles."""
+        config = ShieldConfig(mode=ShieldMode.STANDARD)
+        ips = shield_resolve("test", ["empty"], config=config)
+        self.assertEqual(ips, [])
+
+    @mock.patch("terok_shield.resolve_and_cache", return_value=[TEST_IP1])
+    @mock.patch("terok_shield.compose_profiles", return_value=["github.com"])
+    def test_force_sets_max_age_zero(self, _compose, mock_resolve):
+        """shield_resolve passes max_age=0 when force=True."""
+        config = ShieldConfig(mode=ShieldMode.STANDARD)
+        shield_resolve("test", ["dev-standard"], config=config, force=True)
+        call_kwargs = mock_resolve.call_args[1]
+        self.assertEqual(call_kwargs["max_age"], 0)

--- a/tests/unit/test_basic.py
+++ b/tests/unit/test_basic.py
@@ -44,18 +44,34 @@ def test_cli_no_command(capsys) -> None:
 
 
 def test_cli_setup(capsys) -> None:
-    """CLI setup subcommand prints placeholder."""
+    """CLI setup subcommand completes without error."""
+    from unittest import mock
+
     from terok_shield.cli import main
 
-    main(["setup"])
+    with mock.patch("terok_shield.cli.shield_setup") as mock_setup:
+        main(["setup"])
+    mock_setup.assert_called_once()
     captured = capsys.readouterr()
-    assert "terok-shield setup:" in captured.out
+    assert "setup complete" in captured.out.lower()
 
 
 def test_cli_status(capsys) -> None:
-    """CLI status subcommand prints placeholder."""
+    """CLI status subcommand prints mode info."""
+    from unittest import mock
+
     from terok_shield.cli import main
 
-    main(["status"])
+    with mock.patch(
+        "terok_shield.cli.shield_status",
+        return_value={
+            "mode": "standard",
+            "audit_enabled": True,
+            "profiles": [],
+            "log_files": [],
+        },
+    ) as mock_status:
+        main(["status"])
+    mock_status.assert_called_once()
     captured = capsys.readouterr()
-    assert "terok-shield status:" in captured.out
+    assert "standard" in captured.out.lower()

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,0 +1,191 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the CLI entry point."""
+
+import unittest
+from unittest import mock
+
+from terok_shield import ExecError
+from terok_shield.cli import _build_parser, main
+
+
+class TestBuildParser(unittest.TestCase):
+    """Test argument parser construction."""
+
+    def test_has_subcommands(self):
+        """Parser has all expected subcommands."""
+        parser = _build_parser()
+        # Parse known subcommands without error
+        for cmd in ["setup", "status", "rules", "logs"]:
+            ns = parser.parse_args([cmd] if cmd in ("setup", "status", "logs") else [cmd, "ctr"])
+            self.assertEqual(ns.command, cmd)
+
+    def test_setup_hardened_flag(self):
+        """Setup subcommand accepts --hardened."""
+        parser = _build_parser()
+        ns = parser.parse_args(["setup", "--hardened"])
+        self.assertTrue(ns.hardened)
+
+    def test_resolve_requires_container(self):
+        """Resolve subcommand requires container arg."""
+        parser = _build_parser()
+        with self.assertRaises(SystemExit):
+            parser.parse_args(["resolve"])
+
+    def test_allow_requires_args(self):
+        """Allow subcommand requires container and target."""
+        parser = _build_parser()
+        with self.assertRaises(SystemExit):
+            parser.parse_args(["allow"])
+
+    def test_deny_requires_args(self):
+        """Deny subcommand requires container and target."""
+        parser = _build_parser()
+        with self.assertRaises(SystemExit):
+            parser.parse_args(["deny"])
+
+    def test_logs_optional_container(self):
+        """Logs subcommand has optional --container."""
+        parser = _build_parser()
+        ns = parser.parse_args(["logs"])
+        self.assertIsNone(ns.container)
+        ns = parser.parse_args(["logs", "--container", "test"])
+        self.assertEqual(ns.container, "test")
+
+    def test_logs_optional_count(self):
+        """Logs subcommand has -n with default 50."""
+        parser = _build_parser()
+        ns = parser.parse_args(["logs"])
+        self.assertEqual(ns.n, 50)
+        ns = parser.parse_args(["logs", "-n", "10"])
+        self.assertEqual(ns.n, 10)
+
+
+class TestMainNoCommand(unittest.TestCase):
+    """Test CLI with no subcommand."""
+
+    def test_no_args_exits_zero(self):
+        """CLI with no args exits 0."""
+        with self.assertRaises(SystemExit) as ctx:
+            main([])
+        self.assertEqual(ctx.exception.code, 0)
+
+
+class TestMainHelp(unittest.TestCase):
+    """Test CLI help output."""
+
+    def test_help_exits_zero(self):
+        """CLI --help exits 0."""
+        with self.assertRaises(SystemExit) as ctx:
+            main(["--help"])
+        self.assertEqual(ctx.exception.code, 0)
+
+
+class TestMainDispatch(unittest.TestCase):
+    """Test CLI subcommand dispatch."""
+
+    @mock.patch("terok_shield.cli.shield_setup")
+    def test_setup_standard(self, mock_setup):
+        """CLI setup calls shield_setup with standard config."""
+        main(["setup"])
+        mock_setup.assert_called_once()
+        call_kwargs = mock_setup.call_args[1]
+        self.assertEqual(call_kwargs["config"].mode.value, "standard")
+
+    @mock.patch("terok_shield.cli.shield_setup")
+    def test_setup_hardened(self, mock_setup):
+        """CLI setup --hardened calls shield_setup with hardened config."""
+        main(["setup", "--hardened"])
+        mock_setup.assert_called_once()
+        call_kwargs = mock_setup.call_args[1]
+        self.assertEqual(call_kwargs["config"].mode.value, "hardened")
+
+    @mock.patch("terok_shield.cli.shield_status")
+    def test_status(self, mock_status):
+        """CLI status calls shield_status."""
+        mock_status.return_value = {
+            "mode": "standard",
+            "audit_enabled": True,
+            "profiles": ["dev-standard"],
+            "log_files": [],
+        }
+        main(["status"])
+        mock_status.assert_called_once()
+
+    @mock.patch("terok_shield.cli.shield_resolve")
+    def test_resolve(self, mock_resolve):
+        """CLI resolve calls shield_resolve."""
+        mock_resolve.return_value = ["192.0.2.1"]
+        main(["resolve", "test"])
+        mock_resolve.assert_called_once_with("test", force=False)
+
+    @mock.patch("terok_shield.cli.shield_resolve")
+    def test_resolve_force(self, mock_resolve):
+        """CLI resolve --force passes force=True."""
+        mock_resolve.return_value = []
+        main(["resolve", "test", "--force"])
+        mock_resolve.assert_called_once_with("test", force=True)
+
+    @mock.patch("terok_shield.cli.shield_allow")
+    def test_allow(self, mock_allow):
+        """CLI allow calls shield_allow."""
+        mock_allow.return_value = ["192.0.2.1"]
+        main(["allow", "test", "192.0.2.1"])
+        mock_allow.assert_called_once_with("test", "192.0.2.1")
+
+    @mock.patch("terok_shield.cli.shield_deny")
+    def test_deny(self, mock_deny):
+        """CLI deny calls shield_deny."""
+        mock_deny.return_value = ["192.0.2.1"]
+        main(["deny", "test", "192.0.2.1"])
+        mock_deny.assert_called_once_with("test", "192.0.2.1")
+
+    @mock.patch("terok_shield.cli.shield_rules")
+    def test_rules(self, mock_rules):
+        """CLI rules calls shield_rules."""
+        mock_rules.return_value = "table inet terok_shield {}"
+        main(["rules", "test"])
+        mock_rules.assert_called_once_with("test")
+
+
+class TestMainErrorHandling(unittest.TestCase):
+    """Test CLI error handling."""
+
+    @mock.patch("terok_shield.cli.shield_setup", side_effect=RuntimeError("nope"))
+    def test_runtime_error_exits_1(self, _setup):
+        """RuntimeError in dispatch exits with code 1."""
+        with self.assertRaises(SystemExit) as ctx:
+            main(["setup"])
+        self.assertEqual(ctx.exception.code, 1)
+
+    @mock.patch("terok_shield.cli.shield_rules", side_effect=FileNotFoundError("missing"))
+    def test_file_not_found_exits_1(self, _rules):
+        """FileNotFoundError in dispatch exits with code 1."""
+        with self.assertRaises(SystemExit) as ctx:
+            main(["rules", "test"])
+        self.assertEqual(ctx.exception.code, 1)
+
+    @mock.patch("terok_shield.cli.shield_allow", side_effect=ValueError("bad ip"))
+    def test_value_error_exits_1(self, _allow):
+        """ValueError in dispatch exits with code 1."""
+        with self.assertRaises(SystemExit) as ctx:
+            main(["allow", "test", "bad"])
+        self.assertEqual(ctx.exception.code, 1)
+
+    @mock.patch(
+        "terok_shield.cli.shield_setup",
+        side_effect=ExecError(["nft", "list"], 1, "command failed"),
+    )
+    def test_exec_error_exits_1(self, _setup):
+        """ExecError in dispatch exits with code 1."""
+        with self.assertRaises(SystemExit) as ctx:
+            main(["setup"])
+        self.assertEqual(ctx.exception.code, 1)
+
+    @mock.patch("terok_shield.cli.shield_rules", side_effect=OSError("permission denied"))
+    def test_os_error_exits_1(self, _rules):
+        """OSError in dispatch exits with code 1."""
+        with self.assertRaises(SystemExit) as ctx:
+            main(["rules", "test"])
+        self.assertEqual(ctx.exception.code, 1)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -27,9 +27,9 @@ class TestShieldConfig(unittest.TestCase):
     """Tests for ShieldConfig dataclass."""
 
     def test_defaults(self) -> None:
-        """Default config is disabled with standard profiles."""
+        """Default config is standard with standard profiles."""
         cfg = ShieldConfig()
-        self.assertEqual(cfg.mode, ShieldMode.DISABLED)
+        self.assertEqual(cfg.mode, ShieldMode.STANDARD)
         self.assertEqual(cfg.default_profiles, ("dev-standard",))
         self.assertEqual(cfg.gate_port, 9418)
         self.assertTrue(cfg.audit_enabled)
@@ -44,7 +44,7 @@ class TestShieldConfig(unittest.TestCase):
         """Config is immutable."""
         cfg = ShieldConfig()
         with self.assertRaises(AttributeError):
-            cfg.mode = ShieldMode.STANDARD  # type: ignore[misc]
+            cfg.mode = ShieldMode.HARDENED  # type: ignore[misc]
 
 
 class TestPathHelpers(unittest.TestCase):
@@ -161,7 +161,7 @@ class TestLoadShieldConfig(unittest.TestCase):
             "os.environ", {"TEROK_SHIELD_CONFIG_DIR": "/nonexistent-path"}
         ):
             cfg = load_shield_config()
-            self.assertEqual(cfg.mode, ShieldMode.DISABLED)
+            self.assertEqual(cfg.mode, ShieldMode.STANDARD)
 
     def test_loads_yaml(self, tmp_path=None) -> None:
         """Load configuration from YAML file."""
@@ -212,19 +212,21 @@ class TestLoadShieldConfig(unittest.TestCase):
             config_file.write_text(": : : invalid yaml [[[")
             with unittest.mock.patch.dict("os.environ", {"TEROK_SHIELD_CONFIG_DIR": tmp}):
                 cfg = load_shield_config()
-                self.assertEqual(cfg.mode, ShieldMode.DISABLED)
+                self.assertEqual(cfg.mode, ShieldMode.STANDARD)
 
-    def test_invalid_mode_returns_disabled(self) -> None:
-        """Return disabled for unknown mode string."""
+    def test_invalid_mode_raises(self) -> None:
+        """Raise ValueError for unknown mode string."""
         import tempfile
         from pathlib import Path
 
         with tempfile.TemporaryDirectory() as tmp:
             config_file = Path(tmp) / "config.yml"
             config_file.write_text("mode: bogus\n")
-            with unittest.mock.patch.dict("os.environ", {"TEROK_SHIELD_CONFIG_DIR": tmp}):
-                cfg = load_shield_config()
-                self.assertEqual(cfg.mode, ShieldMode.DISABLED)
+            with (
+                unittest.mock.patch.dict("os.environ", {"TEROK_SHIELD_CONFIG_DIR": tmp}),
+                self.assertRaises(ValueError),
+            ):
+                load_shield_config()
 
     def test_non_dict_yaml_returns_defaults(self) -> None:
         """Return defaults when YAML parses to non-dict (e.g. a list)."""
@@ -236,7 +238,7 @@ class TestLoadShieldConfig(unittest.TestCase):
             config_file.write_text("- item1\n- item2\n")
             with unittest.mock.patch.dict("os.environ", {"TEROK_SHIELD_CONFIG_DIR": tmp}):
                 cfg = load_shield_config()
-                self.assertEqual(cfg.mode, ShieldMode.DISABLED)
+                self.assertEqual(cfg.mode, ShieldMode.STANDARD)
 
     def test_non_list_profiles_falls_back(self) -> None:
         """Non-list default_profiles value falls back to default."""
@@ -245,7 +247,7 @@ class TestLoadShieldConfig(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmp:
             config_file = Path(tmp) / "config.yml"
-            config_file.write_text("default_profiles: not-a-list\n")
+            config_file.write_text("mode: standard\ndefault_profiles: not-a-list\n")
             with unittest.mock.patch.dict("os.environ", {"TEROK_SHIELD_CONFIG_DIR": tmp}):
                 cfg = load_shield_config()
                 self.assertEqual(cfg.default_profiles, ("dev-standard",))
@@ -257,7 +259,7 @@ class TestLoadShieldConfig(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmp:
             config_file = Path(tmp) / "config.yml"
-            config_file.write_text("audit: not-a-dict\n")
+            config_file.write_text("mode: standard\naudit: not-a-dict\n")
             with unittest.mock.patch.dict("os.environ", {"TEROK_SHIELD_CONFIG_DIR": tmp}):
                 cfg = load_shield_config()
                 self.assertTrue(cfg.audit_enabled)
@@ -269,7 +271,7 @@ class TestLoadShieldConfig(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmp:
             config_file = Path(tmp) / "config.yml"
-            config_file.write_text('audit:\n  enabled: "yes"\n  log_allowed: 42\n')
+            config_file.write_text('mode: standard\naudit:\n  enabled: "yes"\n  log_allowed: 42\n')
             with unittest.mock.patch.dict("os.environ", {"TEROK_SHIELD_CONFIG_DIR": tmp}):
                 cfg = load_shield_config()
                 self.assertIs(cfg.audit_enabled, True)
@@ -293,13 +295,12 @@ class TestAutoDetectMode(unittest.TestCase):
 
     @unittest.mock.patch("shutil.which", return_value=None)
     @unittest.mock.patch("subprocess.run", side_effect=FileNotFoundError)
-    def test_no_tools_returns_disabled(
-        self, _run: unittest.mock.Mock, _which: unittest.mock.Mock
-    ) -> None:
-        """Return DISABLED when neither nft nor podman is available."""
+    def test_no_tools_raises(self, _run: unittest.mock.Mock, _which: unittest.mock.Mock) -> None:
+        """Raise RuntimeError when neither nft nor podman is available."""
         from terok_shield.config import _auto_detect_mode
 
-        self.assertEqual(_auto_detect_mode(), ShieldMode.DISABLED)
+        with self.assertRaises(RuntimeError):
+            _auto_detect_mode()
 
     @unittest.mock.patch(
         "shutil.which", side_effect=lambda n: "/usr/sbin/nft" if n == "nft" else None
@@ -341,7 +342,7 @@ class TestGatePortValidation(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmp:
             config_file = Path(tmp) / "config.yml"
-            config_file.write_text("gate_port: true\n")
+            config_file.write_text("mode: standard\ngate_port: true\n")
             with unittest.mock.patch.dict("os.environ", {"TEROK_SHIELD_CONFIG_DIR": tmp}):
                 cfg = load_shield_config()
                 self.assertEqual(cfg.gate_port, 9418)
@@ -353,7 +354,7 @@ class TestGatePortValidation(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmp:
             config_file = Path(tmp) / "config.yml"
-            config_file.write_text("gate_port: 99999\n")
+            config_file.write_text("mode: standard\ngate_port: 99999\n")
             with unittest.mock.patch.dict("os.environ", {"TEROK_SHIELD_CONFIG_DIR": tmp}):
                 cfg = load_shield_config()
                 self.assertEqual(cfg.gate_port, 9418)
@@ -365,7 +366,7 @@ class TestGatePortValidation(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmp:
             config_file = Path(tmp) / "config.yml"
-            config_file.write_text("gate_port: 0\n")
+            config_file.write_text("mode: standard\ngate_port: 0\n")
             with unittest.mock.patch.dict("os.environ", {"TEROK_SHIELD_CONFIG_DIR": tmp}):
                 cfg = load_shield_config()
                 self.assertEqual(cfg.gate_port, 9418)

--- a/tests/unit/test_dns.py
+++ b/tests/unit/test_dns.py
@@ -79,6 +79,22 @@ class TestResolveDomains(unittest.TestCase):
         self.assertEqual(result, [TEST_IP1])
 
     @unittest.mock.patch("terok_shield.dns.dig")
+    def test_logs_warning_for_unresolvable(self, mock_dig: unittest.mock.Mock) -> None:
+        """Log warning when a domain resolves to no IPs."""
+        mock_dig.side_effect = [[TEST_IP1], []]
+        with self.assertLogs("terok_shield.dns", level="WARNING") as cm:
+            resolve_domains(["good.com", "bad.com"])
+        self.assertEqual(len(cm.output), 1)
+        self.assertIn("bad.com", cm.output[0])
+
+    @unittest.mock.patch("terok_shield.dns.dig")
+    def test_no_warning_when_all_resolve(self, mock_dig: unittest.mock.Mock) -> None:
+        """No warning when all domains resolve successfully."""
+        mock_dig.side_effect = [[TEST_IP1], [TEST_IP2]]
+        with self.assertNoLogs("terok_shield.dns", level="WARNING"):
+            resolve_domains(["good.com", "also-good.com"])
+
+    @unittest.mock.patch("terok_shield.dns.dig")
     def test_empty_input(self, mock_dig: unittest.mock.Mock) -> None:
         """Empty domain list returns empty result."""
         result = resolve_domains([])

--- a/tests/unit/test_hardened.py
+++ b/tests/unit/test_hardened.py
@@ -1,0 +1,343 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for hardened mode lifecycle."""
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from terok_shield.config import (
+    BRIDGE_GATEWAY,
+    BRIDGE_NETWORK,
+    ShieldConfig,
+    ShieldMode,
+)
+from terok_shield.hardened import (
+    _read_resolved_cache,
+    _safe_domain,
+    _update_dnsmasq_nftsets,
+    allow_ip,
+    deny_ip,
+    list_rules,
+    post_start,
+    pre_start,
+    pre_stop,
+    setup,
+)
+from terok_shield.run import ExecError
+
+from ..testnet import TEST_IP1, TEST_IP2
+
+
+class TestSetup(unittest.TestCase):
+    """Test hardened mode setup."""
+
+    @mock.patch("terok_shield.hardened.ensure_shield_dirs")
+    @mock.patch("terok_shield.hardened.run_cmd")
+    def test_succeeds_when_network_exists(self, mock_run, mock_dirs):
+        """Setup succeeds if the bridge network exists."""
+        config = ShieldConfig(mode=ShieldMode.HARDENED)
+        setup(config)
+        mock_dirs.assert_called_once()
+        mock_run.assert_called_once_with(["podman", "network", "exists", BRIDGE_NETWORK])
+
+    @mock.patch("terok_shield.hardened.ensure_shield_dirs")
+    @mock.patch(
+        "terok_shield.hardened.run_cmd",
+        side_effect=ExecError(["podman", "network", "exists"], 1, "not found"),
+    )
+    def test_raises_if_network_missing(self, mock_run, mock_dirs):
+        """Setup raises RuntimeError if bridge network is absent."""
+        config = ShieldConfig(mode=ShieldMode.HARDENED)
+        with self.assertRaises(RuntimeError) as ctx:
+            setup(config)
+        self.assertIn(BRIDGE_NETWORK, str(ctx.exception))
+
+
+class TestPreStart(unittest.TestCase):
+    """Test hardened mode pre_start."""
+
+    def _config(self, gate_port=9418):
+        return ShieldConfig(mode=ShieldMode.HARDENED, gate_port=gate_port)
+
+    @mock.patch("terok_shield.hardened.resolve_and_cache")
+    @mock.patch("terok_shield.hardened.compose_profiles", return_value=["github.com"])
+    @mock.patch("terok_shield.hardened.nft_via_rootless_netns")
+    def test_returns_bridge_args(self, mock_nft, _compose, _resolve):
+        """Pre-start returns bridge network args."""
+        mock_nft.return_value = "table inet terok_shield { th dport 9418 }"
+        args = pre_start(self._config(), "test", ["dev-hardened"])
+
+        self.assertIn("--network", args)
+        net_idx = args.index("--network") + 1
+        self.assertEqual(args[net_idx], BRIDGE_NETWORK)
+
+    @mock.patch("terok_shield.hardened.resolve_and_cache")
+    @mock.patch("terok_shield.hardened.compose_profiles", return_value=["github.com"])
+    @mock.patch("terok_shield.hardened.nft_via_rootless_netns")
+    def test_includes_dns_and_security(self, mock_nft, _compose, _resolve):
+        """Pre-start includes DNS, cap-drop, and no-new-privileges args."""
+        mock_nft.return_value = "table inet terok_shield { th dport 9418 }"
+        args = pre_start(self._config(), "test", ["dev-hardened"])
+
+        self.assertIn("--dns", args)
+        dns_idx = args.index("--dns") + 1
+        self.assertEqual(args[dns_idx], BRIDGE_GATEWAY)
+        self.assertIn("--cap-drop", args)
+        self.assertIn("NET_ADMIN", args)
+        self.assertIn("--security-opt", args)
+        self.assertIn("no-new-privileges", args)
+
+    @mock.patch("terok_shield.hardened.resolve_and_cache")
+    @mock.patch("terok_shield.hardened.compose_profiles", return_value=[])
+    @mock.patch("terok_shield.hardened.nft_via_rootless_netns")
+    def test_resolve_called_with_empty_entries(self, mock_nft, _compose, mock_resolve):
+        """Pre-start calls resolve_and_cache even with empty entries (clears stale cache)."""
+        mock_nft.return_value = "table inet terok_shield { th dport 9418 }"
+        pre_start(self._config(), "test", [])
+        mock_resolve.assert_called_once_with([], "test")
+
+    @mock.patch("terok_shield.hardened.resolve_and_cache")
+    @mock.patch("terok_shield.hardened.compose_profiles", return_value=["github.com"])
+    @mock.patch("terok_shield.hardened.nft_via_rootless_netns")
+    def test_ensure_netns_loads_table(self, mock_nft, _compose, _resolve):
+        """Pre-start creates table if not already present."""
+        # First: list ruleset -> empty. Second: load. Third: verify.
+        mock_nft.side_effect = [
+            "",
+            "",
+            "table inet terok_shield {}",
+        ]
+        pre_start(self._config(), "test", ["dev-hardened"])
+        self.assertEqual(mock_nft.call_count, 3)
+
+    @mock.patch("terok_shield.hardened.resolve_and_cache")
+    @mock.patch("terok_shield.hardened.compose_profiles", return_value=["github.com"])
+    @mock.patch("terok_shield.hardened.nft_via_rootless_netns")
+    def test_ensure_netns_reloads_on_port_change(self, mock_nft, _compose, _resolve):
+        """Pre-start reloads table when gate port has changed."""
+        # First: list ruleset -> table exists with old port.
+        # Second: delete old table. Third: load new. Fourth: verify.
+        mock_nft.side_effect = [
+            "table inet terok_shield { th dport 9999 }",
+            "",
+            "",
+            "table inet terok_shield {}",
+        ]
+        pre_start(self._config(gate_port=1234), "test", ["dev-hardened"])
+        # 4 nft calls: list, delete, load, verify
+        self.assertEqual(mock_nft.call_count, 4)
+
+    @mock.patch("terok_shield.hardened.resolve_and_cache")
+    @mock.patch("terok_shield.hardened.compose_profiles", return_value=["github.com"])
+    @mock.patch("terok_shield.hardened.nft_via_rootless_netns")
+    def test_ensure_netns_raises_on_failure(self, mock_nft, _compose, _resolve):
+        """Pre-start raises RuntimeError if nft table cannot be loaded."""
+        mock_nft.return_value = ""  # Table never appears
+        with self.assertRaises(RuntimeError):
+            pre_start(self._config(), "test", ["dev-hardened"])
+
+
+class TestPostStart(unittest.TestCase):
+    """Test hardened mode post_start."""
+
+    def _config(self):
+        return ShieldConfig(mode=ShieldMode.HARDENED)
+
+    @mock.patch("terok_shield.hardened._update_dnsmasq_nftsets")
+    @mock.patch("terok_shield.hardened.nft_via_rootless_netns")
+    @mock.patch("terok_shield.hardened.podman_inspect", return_value="10.90.0.2")
+    @mock.patch("terok_shield.hardened.compose_profiles", return_value=["github.com"])
+    @mock.patch("terok_shield.hardened._read_resolved_cache", return_value=[])
+    def test_creates_set_and_forward(self, _cache, _compose, mock_inspect, mock_nft, _dnsmasq):
+        """Post-start creates per-container set and forward rule."""
+        post_start(self._config(), "test", ["dev-hardened"])
+        # At least: create_set + forward_rule (2 nft calls)
+        self.assertGreaterEqual(mock_nft.call_count, 2)
+
+    @mock.patch("terok_shield.hardened._update_dnsmasq_nftsets")
+    @mock.patch("terok_shield.hardened.nft_via_rootless_netns")
+    @mock.patch("terok_shield.hardened.podman_inspect", return_value="10.90.0.2")
+    @mock.patch("terok_shield.hardened.compose_profiles", return_value=["github.com"])
+    @mock.patch(
+        "terok_shield.hardened._read_resolved_cache",
+        return_value=[TEST_IP1, TEST_IP2],
+    )
+    def test_loads_resolved_ips(self, _cache, _compose, _inspect, mock_nft, _dnsmasq):
+        """Post-start loads resolved IPs into the allow set."""
+        post_start(self._config(), "test", ["dev-hardened"])
+        # create_set + add_elements + forward_rule (3 nft calls)
+        self.assertGreaterEqual(mock_nft.call_count, 3)
+
+
+class TestPreStop(unittest.TestCase):
+    """Test hardened mode pre_stop."""
+
+    @mock.patch("terok_shield.hardened.shield_resolved_dir")
+    @mock.patch("terok_shield.hardened.nft_via_rootless_netns")
+    def test_removes_rules_and_set(self, mock_nft, mock_dir):
+        """Pre-stop deletes forward rules, allow set, and dnsmasq file."""
+        with tempfile.TemporaryDirectory() as td:
+            mock_dir.return_value = Path(td)
+            dnsmasq_file = Path(td) / "test.dnsmasq-nftset"
+            dnsmasq_file.write_text("nftset=/example.com/4#inet#terok_shield#test_allow_v4\n")
+            mock_nft.return_value = '  meta nftrace set 1 comment "terok_shield:test" # handle 5\n'
+            pre_stop("test")
+            self.assertFalse(dnsmasq_file.exists())
+        # 1 list chain + 1 delete rule + 1 delete set = 3 nft calls
+        self.assertGreaterEqual(mock_nft.call_count, 3)
+
+    @mock.patch("terok_shield.hardened.shield_resolved_dir")
+    @mock.patch("terok_shield.hardened.nft_via_rootless_netns")
+    def test_no_rules_to_remove(self, mock_nft, mock_dir):
+        """Pre-stop handles missing rules and missing dnsmasq file gracefully."""
+        with tempfile.TemporaryDirectory() as td:
+            mock_dir.return_value = Path(td)
+            mock_nft.return_value = ""
+            pre_stop("test")
+        # 1 list chain + 1 delete set = 2 nft calls
+        self.assertEqual(mock_nft.call_count, 2)
+
+
+class TestAllowDenyIp(unittest.TestCase):
+    """Test live allow/deny via rootless-netns."""
+
+    @mock.patch("terok_shield.hardened.nft_via_rootless_netns")
+    def test_allow_ip(self, mock_nft):
+        """allow_ip adds element to per-container allow set."""
+        allow_ip("test", TEST_IP1)
+        mock_nft.assert_called_once()
+        args = mock_nft.call_args[0]
+        self.assertIn("add", args)
+        self.assertIn("test_allow_v4", args)
+
+    @mock.patch("terok_shield.hardened.nft_via_rootless_netns")
+    def test_deny_ip(self, mock_nft):
+        """deny_ip removes element from per-container allow set."""
+        deny_ip("test", TEST_IP1)
+        mock_nft.assert_called_once()
+        args = mock_nft.call_args[0]
+        self.assertIn("delete", args)
+
+    def test_allow_invalid_ip_raises(self):
+        """allow_ip raises ValueError for invalid IPs."""
+        with self.assertRaises(ValueError):
+            allow_ip("test", "not-an-ip")
+
+    def test_deny_invalid_ip_raises(self):
+        """deny_ip raises ValueError for invalid IPs."""
+        with self.assertRaises(ValueError):
+            deny_ip("test", "not-an-ip")
+
+
+class TestListRules(unittest.TestCase):
+    """Test list_rules."""
+
+    @mock.patch(
+        "terok_shield.hardened.nft_via_rootless_netns",
+        return_value="table inet terok_shield {}",
+    )
+    def test_returns_output(self, mock_nft):
+        """list_rules returns nft output."""
+        result = list_rules("test")
+        self.assertIn("terok_shield", result)
+
+
+class TestReadResolvedCache(unittest.TestCase):
+    """Test _read_resolved_cache."""
+
+    @mock.patch("terok_shield.hardened.shield_resolved_dir")
+    def test_reads_cached_ips(self, mock_dir):
+        """Reads IPs from cache file."""
+        with tempfile.TemporaryDirectory() as td:
+            mock_dir.return_value = Path(td)
+            cache = Path(td) / "test.resolved"
+            cache.write_text(f"{TEST_IP1}\n{TEST_IP2}\n")
+            result = _read_resolved_cache("test")
+        self.assertEqual(result, [TEST_IP1, TEST_IP2])
+
+    @mock.patch("terok_shield.hardened.shield_resolved_dir")
+    def test_returns_empty_on_missing_file(self, mock_dir):
+        """Returns empty list if cache file does not exist."""
+        with tempfile.TemporaryDirectory() as td:
+            mock_dir.return_value = Path(td)
+            result = _read_resolved_cache("test")
+        self.assertEqual(result, [])
+
+    def test_rejects_unsafe_name(self):
+        """Returns empty list for container names that fail validation."""
+        result = _read_resolved_cache("../escape")
+        self.assertEqual(result, [])
+
+
+class TestSafeDomain(unittest.TestCase):
+    """Test _safe_domain validation."""
+
+    def test_valid_domain(self):
+        """Accepts valid domain names."""
+        self.assertTrue(_safe_domain("github.com"))
+        self.assertTrue(_safe_domain("sub.example.co.uk"))
+        self.assertTrue(_safe_domain("example.com."))
+
+    def test_rejects_slash(self):
+        """Rejects domains containing slashes."""
+        self.assertFalse(_safe_domain("evil/domain"))
+
+    def test_rejects_hash(self):
+        """Rejects domains containing hash."""
+        self.assertFalse(_safe_domain("evil#domain"))
+
+    def test_rejects_whitespace(self):
+        """Rejects domains containing whitespace."""
+        self.assertFalse(_safe_domain("evil domain"))
+        self.assertFalse(_safe_domain("evil\tdomain"))
+
+    def test_rejects_newline(self):
+        """Rejects domains containing newlines."""
+        self.assertFalse(_safe_domain("evil\ndomain"))
+
+    def test_rejects_empty(self):
+        """Rejects empty strings."""
+        self.assertFalse(_safe_domain(""))
+
+    def test_rejects_consecutive_dots(self):
+        """Rejects domains with consecutive dots."""
+        self.assertFalse(_safe_domain("exam..ple.com"))
+        self.assertFalse(_safe_domain("a..b"))
+
+    def test_single_label(self):
+        """Accepts single-label domains."""
+        self.assertTrue(_safe_domain("localhost"))
+
+    def test_rejects_leading_hyphen_in_label(self):
+        """Rejects labels starting with a hyphen."""
+        self.assertFalse(_safe_domain("-example.com"))
+
+    def test_rejects_trailing_hyphen_in_label(self):
+        """Rejects labels ending with a hyphen."""
+        self.assertFalse(_safe_domain("example-.com"))
+
+
+class TestUpdateDnsmasqNftsetsWarning(unittest.TestCase):
+    """Test _update_dnsmasq_nftsets logs warnings for invalid domains."""
+
+    @mock.patch("terok_shield.hardened.shield_resolved_dir")
+    def test_logs_warning_for_invalid_domains(self, mock_dir):
+        """Invalid domains produce a warning log."""
+        with tempfile.TemporaryDirectory() as td:
+            mock_dir.return_value = Path(td)
+            with self.assertLogs("terok_shield.hardened", level="WARNING") as cm:
+                _update_dnsmasq_nftsets("test", ["github.com", "evil/domain", "exam ple.com"])
+            self.assertEqual(len(cm.output), 2)
+            self.assertIn("evil/domain", cm.output[0])
+            self.assertIn("exam ple.com", cm.output[1])
+
+    @mock.patch("terok_shield.hardened.shield_resolved_dir")
+    def test_no_warning_for_all_valid_domains(self, mock_dir):
+        """All-valid domains produce no warnings."""
+        with tempfile.TemporaryDirectory() as td:
+            mock_dir.return_value = Path(td)
+            with self.assertNoLogs("terok_shield.hardened", level="WARNING"):
+                _update_dnsmasq_nftsets("test", ["github.com", "example.com"])

--- a/tests/unit/test_shield_probe.py
+++ b/tests/unit/test_shield_probe.py
@@ -1,0 +1,255 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the shield_probe ICMP diagnostic tool."""
+
+import json
+import struct
+import unittest
+from unittest.mock import MagicMock, patch
+
+from terok_shield.resources.shield_probe import (
+    _ICMP_UNREACH_CODES,
+    _SO_EE_ORIGIN_ICMP,
+    _SOCK_EE_FMT,
+    _SOL_IP,
+    main,
+    probe,
+)
+
+from ..testnet import TEST_IP1
+
+
+def _make_sock_ee(
+    ee_errno: int,
+    ee_origin: int,
+    ee_type: int,
+    ee_code: int,
+    ee_info: int = 0,
+    ee_data: int = 0,
+) -> bytes:
+    """Build a binary sock_extended_err struct."""
+    return struct.pack(_SOCK_EE_FMT, ee_errno, ee_origin, ee_type, ee_code, ee_info, ee_data)
+
+
+def _make_ancdata(ee_errno: int, ee_origin: int, ee_type: int, ee_code: int) -> list:
+    """Build ancillary data list as returned by recvmsg."""
+    from terok_shield.resources.shield_probe import _IP_RECVERR
+
+    return [(_SOL_IP, _IP_RECVERR, _make_sock_ee(ee_errno, ee_origin, ee_type, ee_code))]
+
+
+def _mock_probe(poll_returns, recvmsg_result=None, send_side_effect=None) -> dict:
+    """Run probe() with mocked socket and poll.
+
+    Args:
+        poll_returns: List of return values for successive poll() calls.
+        recvmsg_result: Tuple (data, ancdata, flags, addr) for recvmsg.
+        send_side_effect: Side effect for sock.send (e.g. [None, OSError]).
+    """
+    mock_sock = MagicMock()
+    mock_poller = MagicMock()
+    mock_poller.poll = MagicMock(side_effect=poll_returns)
+
+    if recvmsg_result is not None:
+        mock_sock.recvmsg.return_value = recvmsg_result
+    if send_side_effect is not None:
+        mock_sock.send.side_effect = send_side_effect
+
+    with (
+        patch("terok_shield.resources.shield_probe.socket.socket", return_value=mock_sock),
+        patch("terok_shield.resources.shield_probe.select.poll", return_value=mock_poller),
+    ):
+        return probe(TEST_IP1, 443, timeout=1.0)
+
+
+# ── Mocked tests for core probe paths ─────────────────────────────────
+
+
+class TestProbeMockedPaths(unittest.TestCase):
+    """Mocked equivalents of the real-socket tests (work on any platform)."""
+
+    def test_port_unreachable(self) -> None:
+        """Poll detects error; recvmsg returns ICMP type=3 code=3 (port-unreachable)."""
+        ancdata = _make_ancdata(111, _SO_EE_ORIGIN_ICMP, 3, 3)
+        result = _mock_probe(
+            poll_returns=[[(0, 8)]],
+            recvmsg_result=(b"\x00", ancdata, 0, (TEST_IP1, 443)),
+        )
+        self.assertEqual(result["result"], "icmp-error")
+        self.assertEqual(result["icmp_code"], 3)
+        self.assertEqual(result["icmp_code_name"], "port-unreachable")
+
+    def test_open_no_error(self) -> None:
+        """No poll events; second send succeeds → port is open."""
+        result = _mock_probe(
+            poll_returns=[[]],
+            send_side_effect=[None, None],  # first send OK, second send OK
+        )
+        self.assertEqual(result["result"], "open")
+
+    def test_timeout_no_response(self) -> None:
+        """No poll events; second send raises OSError; second poll empty → timeout."""
+        result = _mock_probe(
+            poll_returns=[[], []],
+            send_side_effect=[None, OSError("connection refused")],
+        )
+        self.assertEqual(result["result"], "timeout")
+
+
+# ── Mocked tests for edge cases ────────────────────────────────────────
+
+
+class TestProbeEdgeCases(unittest.TestCase):
+    """Test probe() branches that cannot be triggered with real sockets."""
+
+    def test_icmp_admin_prohibited(self) -> None:
+        """Detect ICMP admin-prohibited (code 13)."""
+        ancdata = _make_ancdata(113, _SO_EE_ORIGIN_ICMP, 3, 13)
+        result = _mock_probe(
+            poll_returns=[[(0, 8)]],
+            recvmsg_result=(b"\x00", ancdata, 0, (TEST_IP1, 443)),
+        )
+        self.assertEqual(result["result"], "icmp-error")
+        self.assertEqual(result["icmp_code"], 13)
+        self.assertEqual(result["icmp_code_name"], "admin-prohibited")
+
+    def test_icmp_unknown_code(self) -> None:
+        """Unknown ICMP code falls back to 'code-N' naming."""
+        ancdata = _make_ancdata(113, _SO_EE_ORIGIN_ICMP, 3, 99)
+        result = _mock_probe(
+            poll_returns=[[(0, 8)]],
+            recvmsg_result=(b"\x00", ancdata, 0, (TEST_IP1, 443)),
+        )
+        self.assertEqual(result["icmp_code_name"], "code-99")
+
+    def test_timeout_recvmsg_fails(self) -> None:
+        """OSError on recvmsg returns timeout."""
+        mock_sock = MagicMock()
+        mock_sock.recvmsg.side_effect = OSError("queue empty")
+        mock_poller = MagicMock()
+        mock_poller.poll = MagicMock(return_value=[(0, 8)])
+
+        with (
+            patch("terok_shield.resources.shield_probe.socket.socket", return_value=mock_sock),
+            patch("terok_shield.resources.shield_probe.select.poll", return_value=mock_poller),
+        ):
+            result = probe(TEST_IP1, 443, timeout=1.0)
+        self.assertEqual(result["result"], "timeout")
+
+    def test_ancdata_too_short(self) -> None:
+        """Truncated ancdata is skipped, falls through to timeout."""
+        from terok_shield.resources.shield_probe import _IP_RECVERR
+
+        short_ancdata = [(_SOL_IP, _IP_RECVERR, b"\x00\x01")]
+        result = _mock_probe(
+            poll_returns=[[(0, 8)]],
+            recvmsg_result=(b"\x00", short_ancdata, 0, (TEST_IP1, 443)),
+        )
+        self.assertEqual(result["result"], "timeout")
+
+    def test_non_icmp_origin(self) -> None:
+        """Non-ICMP origin (e.g. LOCAL) is skipped."""
+        ancdata = _make_ancdata(113, 1, 3, 13)  # origin=1 (LOCAL), not ICMP
+        result = _mock_probe(
+            poll_returns=[[(0, 8)]],
+            recvmsg_result=(b"\x00", ancdata, 0, (TEST_IP1, 443)),
+        )
+        self.assertEqual(result["result"], "timeout")
+
+    def test_first_send_oserror_still_detects_icmp(self) -> None:
+        """OSError on first send does not prevent ICMP detection."""
+        ancdata = _make_ancdata(111, _SO_EE_ORIGIN_ICMP, 3, 3)
+        result = _mock_probe(
+            poll_returns=[[(0, 8)]],
+            recvmsg_result=(b"\x00", ancdata, 0, (TEST_IP1, 443)),
+            send_side_effect=OSError("send failed"),
+        )
+        self.assertEqual(result["result"], "icmp-error")
+        self.assertEqual(result["icmp_code"], 3)
+
+
+# ── CLI main() tests ──────────────────────────────────────────────────
+
+
+class TestMain(unittest.TestCase):
+    """Test the main() CLI entry point."""
+
+    def test_usage_error(self) -> None:
+        """No arguments prints usage and returns 1."""
+        with patch("sys.argv", ["shield_probe.py"]):
+            self.assertEqual(main(), 1)
+
+    def test_success_default_port(
+        self,
+    ) -> None:
+        """Valid host uses default port 443."""
+        with (
+            patch("sys.argv", ["shield_probe.py", TEST_IP1]),
+            patch(
+                "terok_shield.resources.shield_probe.probe",
+                return_value={"host": TEST_IP1, "port": 443, "result": "open"},
+            ) as mock_probe,
+        ):
+            self.assertEqual(main(), 0)
+            mock_probe.assert_called_once_with(TEST_IP1, 443)
+
+    def test_custom_port(self) -> None:
+        """Custom port is parsed from argv."""
+        with (
+            patch("sys.argv", ["shield_probe.py", TEST_IP1, "80"]),
+            patch(
+                "terok_shield.resources.shield_probe.probe",
+                return_value={"host": TEST_IP1, "port": 80, "result": "open"},
+            ) as mock_probe,
+        ):
+            self.assertEqual(main(), 0)
+            mock_probe.assert_called_once_with(TEST_IP1, 80)
+
+    def test_invalid_port(self) -> None:
+        """Non-integer port returns 1 with error JSON."""
+        with (
+            patch("sys.argv", ["shield_probe.py", TEST_IP1, "abc"]),
+            patch("builtins.print") as mock_print,
+        ):
+            self.assertEqual(main(), 1)
+            output = json.loads(mock_print.call_args[0][0])
+            self.assertIn("invalid port", output["error"])
+
+    def test_probe_exception(self) -> None:
+        """Exception in probe returns 1 with error JSON."""
+        with (
+            patch("sys.argv", ["shield_probe.py", TEST_IP1]),
+            patch(
+                "terok_shield.resources.shield_probe.probe",
+                side_effect=RuntimeError("boom"),
+            ),
+        ):
+            self.assertEqual(main(), 1)
+
+    def test_output_is_json(self) -> None:
+        """Successful probe outputs valid JSON to stdout."""
+        expected = {"host": TEST_IP1, "port": 443, "result": "timeout"}
+        with (
+            patch("sys.argv", ["shield_probe.py", TEST_IP1]),
+            patch("terok_shield.resources.shield_probe.probe", return_value=expected),
+            patch("builtins.print") as mock_print,
+        ):
+            main()
+            output = mock_print.call_args[0][0]
+            self.assertEqual(json.loads(output), expected)
+
+
+# ── Constants sanity checks ───────────────────────────────────────────
+
+
+class TestConstants(unittest.TestCase):
+    """Verify ICMP code table has expected entries."""
+
+    def test_admin_prohibited_in_table(self) -> None:
+        """Code 13 maps to admin-prohibited."""
+        self.assertEqual(_ICMP_UNREACH_CODES[13], "admin-prohibited")
+
+    def test_port_unreachable_in_table(self) -> None:
+        """Code 3 maps to port-unreachable."""
+        self.assertEqual(_ICMP_UNREACH_CODES[3], "port-unreachable")

--- a/tests/unit/test_standard.py
+++ b/tests/unit/test_standard.py
@@ -1,0 +1,303 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for standard mode lifecycle."""
+
+import json
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from terok_shield.config import ANNOTATION_KEY, ShieldConfig, ShieldMode
+from terok_shield.standard import (
+    _detect_rootless_network_mode,
+    _generate_entrypoint,
+    _generate_hook_json,
+    allow_ip,
+    deny_ip,
+    list_rules,
+    pre_start,
+    setup,
+)
+
+from ..testnet import TEST_IP1
+
+
+class TestDetectRootlessNetworkMode(unittest.TestCase):
+    """Test rootless network mode detection."""
+
+    @mock.patch("terok_shield.standard.run_cmd")
+    def test_pasta_from_podman_info(self, mock_run):
+        """Detect pasta mode from podman info output."""
+        mock_run.return_value = json.dumps({"host": {"rootlessNetworkCmd": "pasta"}})
+        self.assertEqual(_detect_rootless_network_mode(), "pasta")
+
+    @mock.patch("terok_shield.standard.run_cmd")
+    def test_slirp4netns_from_podman_info(self, mock_run):
+        """Detect slirp4netns mode from podman info output."""
+        mock_run.return_value = json.dumps({"host": {"rootlessNetworkCmd": "slirp4netns"}})
+        self.assertEqual(_detect_rootless_network_mode(), "slirp4netns")
+
+    @mock.patch("terok_shield.standard.run_cmd")
+    def test_fallback_on_empty_output(self, mock_run):
+        """Default to pasta when podman info returns nothing."""
+        mock_run.return_value = ""
+        self.assertEqual(_detect_rootless_network_mode(), "pasta")
+
+    @mock.patch("terok_shield.standard.run_cmd")
+    def test_fallback_on_invalid_json(self, mock_run):
+        """Default to pasta when podman info returns invalid JSON."""
+        mock_run.return_value = "not json"
+        self.assertEqual(_detect_rootless_network_mode(), "pasta")
+
+    @mock.patch("terok_shield.standard.run_cmd")
+    def test_fallback_on_missing_field(self, mock_run):
+        """Default to pasta when rootlessNetworkCmd is absent."""
+        mock_run.return_value = json.dumps({"host": {}})
+        self.assertEqual(_detect_rootless_network_mode(), "pasta")
+
+    @mock.patch("terok_shield.standard.run_cmd")
+    def test_fallback_on_unknown_mode(self, mock_run):
+        """Default to pasta for unrecognised network modes."""
+        mock_run.return_value = json.dumps({"host": {"rootlessNetworkCmd": "unknown"}})
+        self.assertEqual(_detect_rootless_network_mode(), "pasta")
+
+
+class TestGenerateEntrypoint(unittest.TestCase):
+    """Test OCI hook entrypoint generation."""
+
+    def test_contains_python_path(self):
+        """Entrypoint uses the current Python interpreter."""
+        ep = _generate_entrypoint()
+        self.assertIn(sys.executable, ep)
+
+    def test_contains_module_invocation(self):
+        """Entrypoint invokes the hook module."""
+        ep = _generate_entrypoint()
+        self.assertIn("-m terok_shield.hook", ep)
+
+    def test_starts_with_shebang(self):
+        """Entrypoint starts with a shebang line."""
+        ep = _generate_entrypoint()
+        self.assertTrue(ep.startswith("#!/bin/sh\n"))
+
+
+class TestGenerateHookJson(unittest.TestCase):
+    """Test OCI hook JSON generation."""
+
+    def test_valid_json(self):
+        """Output is valid JSON."""
+        result = json.loads(_generate_hook_json("/path/to/hook"))
+        self.assertEqual(result["version"], "1.0.0")
+        self.assertEqual(result["hook"]["path"], "/path/to/hook")
+
+    def test_annotation_filter(self):
+        """Hook triggers on the shield profiles annotation."""
+        result = json.loads(_generate_hook_json("/hook"))
+        self.assertIn(ANNOTATION_KEY, result["when"]["annotations"])
+
+    def test_create_runtime_stage(self):
+        """Hook fires at createRuntime stage."""
+        result = json.loads(_generate_hook_json("/hook"))
+        self.assertEqual(result["stages"], ["createRuntime"])
+
+
+class TestSetup(unittest.TestCase):
+    """Test standard mode setup."""
+
+    def test_creates_hook_files(self):
+        """Setup creates entrypoint and hook JSON files."""
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as td:
+            self._run_setup(Path(td))
+
+    def _run_setup(self, tmp_dir):
+        config = ShieldConfig(mode=ShieldMode.STANDARD)
+        with (
+            mock.patch(
+                "terok_shield.standard.shield_hook_entrypoint",
+                return_value=tmp_dir / "terok-shield-hook",
+            ),
+            mock.patch(
+                "terok_shield.standard.shield_hooks_dir",
+                return_value=tmp_dir / "hooks",
+            ),
+            mock.patch("terok_shield.standard.ensure_shield_dirs"),
+        ):
+            (tmp_dir / "hooks").mkdir(parents=True, exist_ok=True)
+            setup(config)
+
+        ep = tmp_dir / "terok-shield-hook"
+        self.assertTrue(ep.exists())
+        self.assertIn("-m terok_shield.hook", ep.read_text())
+
+        hook_json = tmp_dir / "hooks" / "terok-shield-hook.json"
+        self.assertTrue(hook_json.exists())
+        data = json.loads(hook_json.read_text())
+        self.assertEqual(data["hook"]["path"], str(ep))
+
+
+class TestPreStart(unittest.TestCase):
+    """Test standard mode pre_start."""
+
+    def setUp(self):
+        """Create a temporary hooks directory with entrypoint for each test."""
+        import tempfile
+
+        self._tmpdir_obj = tempfile.TemporaryDirectory()
+        self._tmpdir = Path(self._tmpdir_obj.name)
+        hooks_dir = self._tmpdir / "hooks"
+        hooks_dir.mkdir()
+        (hooks_dir / "terok-shield-hook.json").touch()
+        ep = self._tmpdir / "terok-shield-hook"
+        ep.write_text("#!/bin/sh\n")
+        ep.chmod(0o755)
+        self._hooks_patch = mock.patch(
+            "terok_shield.standard.shield_hooks_dir",
+            return_value=hooks_dir,
+        )
+        self._ep_patch = mock.patch(
+            "terok_shield.standard.shield_hook_entrypoint",
+            return_value=ep,
+        )
+        self._hooks_patch.start()
+        self._ep_patch.start()
+
+    def tearDown(self):
+        """Clean up patches and temp directory."""
+        self._ep_patch.stop()
+        self._hooks_patch.stop()
+        self._tmpdir_obj.cleanup()
+
+    def _config(self, gate_port=9418):
+        return ShieldConfig(mode=ShieldMode.STANDARD, gate_port=gate_port)
+
+    @mock.patch("terok_shield.standard.resolve_and_cache")
+    @mock.patch("terok_shield.standard.compose_profiles", return_value=["github.com"])
+    @mock.patch("terok_shield.standard._detect_rootless_network_mode", return_value="pasta")
+    @mock.patch("os.geteuid", return_value=1000)
+    def test_pasta_args(self, _euid, _mode, _compose, _resolve):
+        """Pre-start returns pasta network args for rootless mode."""
+        args = pre_start(self._config(), "test", ["dev-standard"])
+        self.assertIn("--network", args)
+        pasta_idx = args.index("--network") + 1
+        self.assertIn("pasta:", args[pasta_idx])
+
+    @mock.patch("terok_shield.standard.resolve_and_cache")
+    @mock.patch("terok_shield.standard.compose_profiles", return_value=["github.com"])
+    @mock.patch("terok_shield.standard._detect_rootless_network_mode", return_value="slirp4netns")
+    @mock.patch("os.geteuid", return_value=1000)
+    def test_slirp4netns_args(self, _euid, _mode, _compose, _resolve):
+        """Pre-start returns slirp4netns args when detected."""
+        args = pre_start(self._config(), "test", ["dev-standard"])
+        net_idx = args.index("--network") + 1
+        self.assertIn("slirp4netns", args[net_idx])
+
+    @mock.patch("terok_shield.standard.resolve_and_cache")
+    @mock.patch("terok_shield.standard.compose_profiles", return_value=[])
+    @mock.patch("os.geteuid", return_value=0)
+    def test_root_no_network_args(self, _euid, _compose, _resolve):
+        """Root user gets no special network args."""
+        args = pre_start(self._config(), "test", ["dev-standard"])
+        # No --network before the annotation args
+        before_annotation = args[: args.index("--annotation")]
+        self.assertNotIn("--network", before_annotation)
+
+    @mock.patch("terok_shield.standard.resolve_and_cache")
+    @mock.patch("terok_shield.standard.compose_profiles", return_value=["github.com"])
+    @mock.patch("os.geteuid", return_value=1000)
+    @mock.patch("terok_shield.standard._detect_rootless_network_mode", return_value="pasta")
+    def test_shield_args(self, _mode, _euid, _compose, _resolve):
+        """Pre-start includes cap-drop and no-new-privileges."""
+        args = pre_start(self._config(), "test", ["dev-standard"])
+        self.assertIn("--cap-drop", args)
+        self.assertIn("NET_ADMIN", args)
+        self.assertIn("NET_RAW", args)
+        self.assertIn("--security-opt", args)
+        self.assertIn("no-new-privileges", args)
+
+    @mock.patch("terok_shield.standard.compose_profiles", return_value=[])
+    def test_missing_hook_raises(self, _compose):
+        """Pre-start raises RuntimeError if hook not installed."""
+        self._hooks_patch.stop()
+        self._ep_patch.stop()
+        with (
+            mock.patch(
+                "terok_shield.standard.shield_hooks_dir",
+                return_value=Path("/nonexistent"),
+            ),
+            mock.patch(
+                "terok_shield.standard.shield_hook_entrypoint",
+                return_value=Path("/nonexistent/ep"),
+            ),
+            self.assertRaises(RuntimeError),
+        ):
+            pre_start(self._config(), "test", ["dev-standard"])
+        self._hooks_patch.start()
+        self._ep_patch.start()
+
+    @mock.patch("terok_shield.standard.resolve_and_cache")
+    @mock.patch("terok_shield.standard.compose_profiles", return_value=["github.com"])
+    @mock.patch("os.geteuid", return_value=1000)
+    @mock.patch("terok_shield.standard._detect_rootless_network_mode", return_value="pasta")
+    def test_custom_gate_port(self, _mode, _euid, _compose, _resolve):
+        """Gate port from config appears in pasta network args."""
+        args = pre_start(self._config(gate_port=1234), "test", ["dev-standard"])
+        net_idx = args.index("--network") + 1
+        self.assertIn("1234", args[net_idx])
+
+    @mock.patch("terok_shield.standard.resolve_and_cache")
+    @mock.patch("terok_shield.standard.compose_profiles", return_value=["github.com"])
+    @mock.patch("os.geteuid", return_value=1000)
+    @mock.patch("terok_shield.standard._detect_rootless_network_mode", return_value="pasta")
+    def test_annotation_includes_profiles(self, _mode, _euid, _compose, _resolve):
+        """Annotation arg lists the profile names."""
+        args = pre_start(self._config(), "test", ["dev-standard", "base"])
+        ann_idx = args.index("--annotation") + 1
+        self.assertIn(ANNOTATION_KEY, args[ann_idx])
+        self.assertIn("dev-standard,base", args[ann_idx])
+
+
+class TestAllowDenyIp(unittest.TestCase):
+    """Test live allow/deny via nsenter."""
+
+    @mock.patch("terok_shield.standard.nft_via_nsenter")
+    def test_allow_ip(self, mock_nsenter):
+        """allow_ip adds element to allow_v4 set."""
+        allow_ip("test", TEST_IP1)
+        mock_nsenter.assert_called_once()
+        call_args = mock_nsenter.call_args[0]
+        self.assertEqual(call_args[0], "test")
+        self.assertIn("add", call_args)
+        self.assertIn("allow_v4", call_args)
+
+    @mock.patch("terok_shield.standard.nft_via_nsenter")
+    def test_deny_ip(self, mock_nsenter):
+        """deny_ip removes element from allow_v4 set."""
+        deny_ip("test", TEST_IP1)
+        mock_nsenter.assert_called_once()
+        call_args = mock_nsenter.call_args[0]
+        self.assertIn("delete", call_args)
+
+    def test_allow_invalid_ip_raises(self):
+        """allow_ip raises ValueError for invalid IPs."""
+        with self.assertRaises(ValueError):
+            allow_ip("test", "not-an-ip")
+
+    def test_deny_invalid_ip_raises(self):
+        """deny_ip raises ValueError for invalid IPs."""
+        with self.assertRaises(ValueError):
+            deny_ip("test", "not-an-ip")
+
+
+class TestListRules(unittest.TestCase):
+    """Test list_rules."""
+
+    @mock.patch("terok_shield.standard.nft_via_nsenter", return_value="table inet terok_shield {}")
+    def test_returns_output(self, mock_nsenter):
+        """list_rules returns nft output."""
+        result = list_rules("test")
+        self.assertIn("terok_shield", result)
+        mock_nsenter.assert_called_once()

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for shared utility functions."""
+
+import unittest
+
+from terok_shield.util import is_ipv4
+
+from ..testnet import TEST_IP1, TEST_NET1
+
+
+class TestIsIpv4(unittest.TestCase):
+    """Tests for is_ipv4."""
+
+    def test_ipv4_address(self) -> None:
+        """Detect plain IPv4 address."""
+        self.assertTrue(is_ipv4(TEST_IP1))
+
+    def test_cidr(self) -> None:
+        """Detect CIDR notation."""
+        self.assertTrue(is_ipv4(TEST_NET1))
+
+    def test_domain(self) -> None:
+        """Reject domain names."""
+        self.assertFalse(is_ipv4("example.com"))
+
+    def test_empty(self) -> None:
+        """Reject empty string."""
+        self.assertFalse(is_ipv4(""))
+
+    def test_ipv6_rejected(self) -> None:
+        """Reject IPv6 addresses."""
+        self.assertFalse(is_ipv4("::1"))

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -1,1 +1,0 @@
-# Vulture whitelist — false positives that are actually required.


### PR DESCRIPTION
## Summary

Implements issue #5 — the two shield operating modes, full public API, and CLI subcommands.

- **Standard mode** (`standard.py`): OCI hooks apply per-container nftables rules inside each container's network namespace. `setup()` installs the hook; `pre_start()` resolves DNS, verifies hook installation (fail-closed), and returns podman args; live `allow_ip/deny_ip` via nsenter.
- **Hardened mode** (`hardened.py`): Dedicated bridge network with filtering in podman's rootless-netns. `setup()` verifies bridge exists; `pre_start()` loads the base table; `post_start()` creates per-container allow sets + forward rules; `pre_stop()` cleans up.
- **Public API** (`__init__.py`): `shield_setup`, `shield_pre_start`, `shield_post_start`, `shield_pre_stop`, `shield_allow`, `shield_deny`, `shield_rules`, `shield_resolve`, `shield_status` — all accept optional `config` kwarg for integration use.
- **CLI** (`cli.py`): 7 subcommands — `setup`, `status`, `resolve`, `allow`, `deny`, `rules`, `logs`.
- **tach.toml**: New module boundaries for `standard` and `hardened`.
- **73 new tests** across 4 test files (`test_standard.py`, `test_hardened.py`, `test_api.py`, `test_cli.py`).

All 273 tests pass, 93% coverage, `make check` clean.

## Test plan

- [x] `make check` passes (lint + test + tach + docstrings + deadcode + reuse)
- [x] All 273 unit tests pass
- [x] Standard mode: hook generation, rootless network detection, fail-closed on missing hook
- [x] Hardened mode: bridge verification, rootless-netns table loading, post_start/pre_stop lifecycle
- [x] Public API: mode dispatch, default profiles, domain resolution, error swallowing
- [x] CLI: argument parsing, dispatch, error handling (exits 1 on RuntimeError/ValueError/FileNotFoundError)

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mode-based shield (Standard & Hardened), full CLI (setup, status, resolve, allow, deny, rules, logs with JSON), live per-container allow/deny and rule inspection, DNS profile resolution with caching/force, IPv4 validation util, and standalone network probe tool.

* **Behavioral**
  * Default mode is STANDARD (DISABLED removed); auto-detect now errors on failure.

* **Tests**
  * Expanded unit/integration coverage for API, CLI, Hardened/Standard lifecycles, DNS warnings, util, and probe.

* **Chores**
  * Package manifest and CI dead-code scan adjusted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->