### PR TITLE
chore: pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,5 @@
+# Pin third-party actions to full commit SHAs for supply-chain security.
+# GitHub-owned actions (actions/*) may use version tags.
 name: CI
 
 on:
@@ -13,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: REUSE compliance check
-        uses: fsfe/reuse-action@v6
+        uses: fsfe/reuse-action@676e2d560c9a403aa252096d99fcab3e1132b0f5 # v6
 
   lint:
     if: github.repository == 'terok-ai/terok-shield'
@@ -22,12 +24,12 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Ruff lint
-        uses: astral-sh/ruff-action@v3
+        uses: astral-sh/ruff-action@4919ec5cf1f49eff0871dbcea0da843445b837e6 # v3
         with:
           args: check
 
       - name: Ruff format check
-        uses: astral-sh/ruff-action@v3
+        uses: astral-sh/ruff-action@4919ec5cf1f49eff0871dbcea0da843445b837e6 # v3
         with:
           args: format --check
 
@@ -113,7 +115,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install Poetry
-        uses: snok/install-poetry@v1
+        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1
         with:
           virtualenvs-create: true
           virtualenvs-in-project: true
@@ -139,7 +141,7 @@ jobs:
         run: poetry run pytest tests/integration/host/ -v
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
         with:
           files: ./coverage.xml
           fail_ci_if_error: false

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,3 +1,5 @@
+# Pin third-party actions to full commit SHAs for supply-chain security.
+# GitHub-owned actions (actions/*) may use version tags.
 name: Documentation
 
 on:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,3 +1,5 @@
+# Pin third-party actions to full commit SHAs for supply-chain security.
+# GitHub-owned actions (actions/*) may use version tags.
 name: Integration Tests
 
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,5 @@
+# Pin third-party actions to full commit SHAs for supply-chain security.
+# GitHub-owned actions (actions/*) may use version tags.
 name: Release
 
 on:
@@ -22,7 +24,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install Poetry
-        uses: snok/install-poetry@v1
+        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1
         with:
           virtualenvs-create: true
           virtualenvs-in-project: true
@@ -45,6 +47,6 @@ jobs:
         run: poetry build
 
       - name: Upload release assets
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2
         with:
           files: dist/*


### PR DESCRIPTION
## Summary

- Pin all third-party GitHub Actions to full commit SHAs for supply-chain security
- GitHub-owned actions (`actions/*`) keep version tags
- Add a comment header to each workflow file documenting this convention

### Actions pinned

| Action | SHA | Version |
|--------|-----|---------|
| `fsfe/reuse-action` | `676e2d56…` | v6 |
| `astral-sh/ruff-action` | `4919ec5c…` | v3 |
| `snok/install-poetry` | `76e04a91…` | v1 |
| `codecov/codecov-action` | `671740ac…` | v5 |
| `softprops/action-gh-release` | `a06a81a0…` | v2 |

## Test plan

- [ ] CI workflows pass (no action resolution changes — same versions, just pinned)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to strengthen build pipeline reliability and consistency across continuous integration, documentation, integration testing, and release processes. No functional changes to application features or user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->