### PR TITLE
ci: provide CODECOV_TOKEN to Codecov action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,3 +145,4 @@ jobs:
         with:
           files: ./coverage.xml
           fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary
- pass `CODECOV_TOKEN` to the Codecov GitHub Action
- allow uploads from the protected upstream `master` branch

## Context
Codecov was accepting tokenless fork PR uploads, but upstream protected-branch uploads were failing with: `Token required because branch is protected`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD infrastructure configuration for improved security practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->