### PR TITLE
feat: embed Codecov coverage treemap in quality report docs

### DIFF
--- a/docs/gen_quality_report.py
+++ b/docs/gen_quality_report.py
@@ -261,20 +261,51 @@ _CODECOV_TOKEN = "D74Q7lvnIF"
 _CODECOV_REPO = "terok-ai/terok-shield"
 
 
+def _fetch_codecov_treemap() -> str | None:
+    """Fetch the Codecov treemap SVG and patch it for dark-mode compatibility."""
+    from urllib.error import URLError
+    from urllib.request import Request, urlopen
+
+    url = f"https://codecov.io/gh/{_CODECOV_REPO}/graphs/tree.svg?token={_CODECOV_TOKEN}"
+    try:
+        req = Request(url, headers={"User-Agent": "mkdocs-gen-files"})
+        with urlopen(req, timeout=30) as resp:  # noqa: S310  # nosec B310
+            svg = resp.read().decode("utf-8")
+    except (URLError, OSError, UnicodeDecodeError):
+        return None
+
+    # Remove white cell borders so the page background shows through in dark mode.
+    svg = svg.replace('stroke="white"', 'stroke="none"')
+    # Make the SVG responsive instead of fixed 300×300.
+    svg = svg.replace(
+        'width="300" height="300"',
+        'style="max-width:300px;width:100%;height:auto"',
+    )
+    return svg
+
+
 def _section_test_coverage() -> str:
     """Generate test coverage section with embedded Codecov treemap."""
     base = f"https://codecov.io/gh/{_CODECOV_REPO}"
     badge = f"{base}/graph/badge.svg?token={_CODECOV_TOKEN}"
-    treemap = f"{base}/graphs/tree.svg?token={_CODECOV_TOKEN}"
+
+    svg = _fetch_codecov_treemap()
+    if svg:
+        treemap_block = f"{svg}\n\n"
+    else:
+        # Fallback: remote image (no hover tooltips, white borders).
+        remote = f"{base}/graphs/tree.svg?token={_CODECOV_TOKEN}"
+        treemap_block = f'<img src="{remote}" style="max-width:100%">\n\n'
+
     return (
         f"[![codecov]({badge})]({base})\n\n"
         f"Coverage is collected from unit tests in CI and uploaded to "
         f"[Codecov]({base}).\n\n"
         f"### Coverage Treemap\n\n"
-        f"![Codecov Coverage Treemap]({treemap})\n\n"
-        f"Each rectangle represents a source file. Size is proportional to the "
-        f"number of lines; colour shows the coverage percentage (green = high, "
-        f"red = low).\n"
+        + treemap_block
+        + "Each rectangle represents a source file. Size is proportional to the "
+        "number of lines; colour shows the coverage percentage (green = high, "
+        "red = low). Hover over a cell to see the file name.\n"
     )
 
 


### PR DESCRIPTION
## Summary
- Adds a **Test Coverage** section to the auto-generated Code Quality Report page (`quality_report.md`)
- Embeds the live Codecov badge and coverage treemap SVG, following the same pattern used in [terok-ai/terok](https://github.com/terok-ai/terok)
- The treemap visualises per-file coverage directly in the docs, so contributors don't need to check CI logs

Closes #11

## Changes
- `docs/gen_quality_report.py`: new `_section_test_coverage()` function that renders the Codecov badge + treemap SVG (token already public in README badge); section inserted between Architecture and Cognitive Complexity

## Test plan
- [ ] `mkdocs build --strict` passes (no new warnings)
- [ ] Quality report page renders the Codecov badge and treemap correctly
- [ ] Existing quality report sections unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integrated Codecov into generated quality reports with automatic test coverage visualization.
  * Added a "Test Coverage" section showing coverage badges, links, and an embedded treemap with a fallback image.

* **Documentation**
  * Updated report layout and footer to reference embedded Codecov coverage information.
  * Improved treemap styling for dark mode and graceful fallback when remote content is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->