### PR TITLE
fix: dynamic versioning substitution for src-layout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,3 +104,6 @@ enable = true
 vcs = "git"
 pattern = "^v(?P<base>\\d+\\.\\d+\\.\\d+)$"
 style = "pep440"
+
+[tool.poetry-dynamic-versioning.substitution]
+folders = [{path = "src"}]

--- a/src/terok_shield/__init__.py
+++ b/src/terok_shield/__init__.py
@@ -15,7 +15,14 @@ The primary entry point is the ``Shield`` facade class:
 from collections.abc import Iterator
 from pathlib import Path
 
-__version__ = "0.1.3"
+__version__: str = "0.0.0"  # placeholder; replaced at build time
+
+from importlib.metadata import PackageNotFoundError, version as _meta_version
+
+try:
+    __version__ = _meta_version("terok-shield")
+except PackageNotFoundError:
+    pass  # editable install or running from source without metadata
 
 from . import state
 from .audit import AuditLogger


### PR DESCRIPTION
## Summary

- **Configure `poetry-dynamic-versioning` substitution folders** to `src/` so `__version__` in `__init__.py` is correctly replaced at build time (was defaulting to `.` which missed the src-layout package)
- **Read `__version__` from `importlib.metadata` at runtime** as the primary source of truth, making the placeholder a fallback rather than the canonical version

## Root cause

The `[tool.poetry-dynamic-versioning]` config had no `substitution` section. The plugin defaults to scanning `.` for `__version__` patterns, but the package lives under `src/terok_shield/`. The metadata (dist-info) was correctly versioned, but the `__version__` string in source was never touched.

## Test plan

- [x] `make lint` passes
- [x] `make test` — all 538 unit tests pass
- [x] `poetry run python -c "import terok_shield; print(terok_shield.__version__)"` → `0.2.1`

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured dynamic version substitution for the package. The version is now resolved at runtime from installed package metadata instead of using a hardcoded value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->