### PR TITLE
feat: merge 'state' into 'status' with optional container arg

### DIFF
--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -69,7 +69,17 @@ terok-shield prepare my-container --json
 
 ## status
 
-Show current shield status: active mode, available profiles, audit state.
+Show current shield status, or query a specific container's firewall state.
+
+```bash
+terok-shield status [container]
+```
+
+| Argument | Description |
+|----------|-------------|
+| `container` | Optional — when given, prints the container's firewall state |
+
+Without a container name, shows the global shield configuration:
 
 ```bash
 terok-shield status
@@ -79,6 +89,14 @@ terok-shield status
 Mode:     hook
 Audit:    enabled
 Profiles: base, dev-node, dev-python, dev-standard, nvidia-hpc
+```
+
+With a container name, prints the live firewall state (`up`, `down`, `down_all`,
+`inactive`, or `error`). Useful for scripting and integration:
+
+```bash
+terok-shield status my-container
+# up
 ```
 
 ## resolve
@@ -205,22 +223,6 @@ terok-shield rules <container>
 
 Shows the container's shield state and the full nftables ruleset in its
 network namespace.
-
-## state
-
-Query a container's shield state directly.
-
-```bash
-terok-shield state <container>
-```
-
-Prints the current state as a single value: `up`, `down`, `down_all`,
-`inactive`, or `error`. Useful for scripting and integration.
-
-```bash
-terok-shield state my-container
-# up
-```
 
 ## profiles
 

--- a/src/terok_shield/cli.py
+++ b/src/terok_shield/cli.py
@@ -229,6 +229,21 @@ def _build_parser() -> argparse.ArgumentParser:
         for arg in cmd.args:
             _add_argdef(p, arg)
 
+    # Inject "status CONTAINER" as a visible second line in help output
+    _orig_format_help = parser.format_help
+
+    def _format_help() -> str:
+        """Return help text with 'status CONTAINER' hint injected."""
+        text = _orig_format_help()
+        marker = "\n    status "
+        idx = text.find(marker)
+        if idx == -1:
+            return text
+        eol = text.index("\n", idx + 1)
+        hint = "\n    status CONTAINER    Query container firewall state (up/down/down_all/inactive/error)"
+        return text[:eol] + hint + text[eol:]
+
+    parser.format_help = _format_help  # type: ignore[assignment]
     return parser
 
 

--- a/src/terok_shield/registry.py
+++ b/src/terok_shield/registry.py
@@ -60,12 +60,16 @@ class CommandDef:
 # ── Handler functions ─────────────────────────────────────
 
 
-def _handle_status(shield: Shield) -> None:
-    """Show shield status."""
-    status = shield.status()
-    print(f"Mode:     {status['mode']}")
-    print(f"Audit:    {'enabled' if status['audit_enabled'] else 'disabled'}")
-    print(f"Profiles: {', '.join(status['profiles']) or '(none)'}")
+def _handle_status(shield: Shield, *, container: str | None = None) -> None:
+    """Show shield status, or query a container's firewall state."""
+    if container:
+        st = shield.state(container)
+        print(st.value)
+    else:
+        status = shield.status()
+        print(f"Mode:     {status['mode']}")
+        print(f"Audit:    {'enabled' if status['audit_enabled'] else 'disabled'}")
+        print(f"Profiles: {', '.join(status['profiles']) or '(none)'}")
 
 
 def _handle_allow(shield: Shield, container: str, *, target: str) -> None:
@@ -134,19 +138,20 @@ def _handle_preview(shield: Shield, *, down: bool = False, allow_all: bool = Fal
     print(ruleset)
 
 
-def _handle_state(shield: Shield, container: str) -> None:
-    """Query a container's shield state."""
-    st = shield.state(container)
-    print(st.value)
-
-
 # ── Command definitions ───────────────────────────────────
 
 COMMANDS: tuple[CommandDef, ...] = (
     CommandDef(
         name="status",
-        help="Show shield status",
+        help="Show shield configuration overview",
         handler=_handle_status,
+        args=(
+            ArgDef(
+                name="container",
+                nargs="?",
+                help="Container name — prints firewall state (up/down/down_all/inactive/error)",
+            ),
+        ),
     ),
     CommandDef(
         name="prepare",
@@ -240,11 +245,5 @@ COMMANDS: tuple[CommandDef, ...] = (
                 help="Omit private-range reject rules (requires --down)",
             ),
         ),
-    ),
-    CommandDef(
-        name="state",
-        help="Query a container's shield state",
-        handler=_handle_state,
-        needs_container=True,
     ),
 )

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -132,7 +132,6 @@ def force_hook_mode(monkeypatch: pytest.MonkeyPatch) -> None:
         pytest.param(["up", _CONTAINER], "up", id="up"),
         pytest.param(["preview"], "preview", id="preview"),
         pytest.param(["profiles"], "profiles", id="profiles"),
-        pytest.param(["state", _CONTAINER], "state", id="state"),
     ],
 )
 def test_parser_recognizes_subcommands(
@@ -486,7 +485,6 @@ def test_allow_and_deny_dispatch_to_shield(
             id="preview-down-all",
         ),
         pytest.param(["profiles"], "profiles_list", mock.call(), id="profiles"),
-        pytest.param(["state", _CONTAINER], "state", mock.call(_CONTAINER), id="state"),
     ],
 )
 def test_misc_dispatch_paths(
@@ -498,8 +496,6 @@ def test_misc_dispatch_paths(
     """Simple CLI subcommands dispatch to the expected Shield methods."""
     if method_name == "preview":
         cli_dispatch.shield.preview.return_value = "table inet terok_shield {}"
-    elif method_name == "state":
-        cli_dispatch.shield.state.return_value = ShieldState.UP
     elif method_name == "profiles_list":
         cli_dispatch.shield.profiles_list.return_value = ["dev-standard", "dev-python"]
 
@@ -662,13 +658,20 @@ def test_profiles_output_lists_one_profile_per_line(
     assert capsys.readouterr().out.strip().splitlines() == ["dev-standard", "dev-python"]
 
 
-def test_state_output_prints_state_value(
+def test_status_with_container_dispatches(cli_dispatch: CliDispatchHarness) -> None:
+    """status <container> dispatches to shield.state()."""
+    cli_dispatch.shield.state.return_value = ShieldState.UP
+    main(["status", _CONTAINER])
+    cli_dispatch.shield.state.assert_called_once_with(_CONTAINER)
+
+
+def test_status_container_output(
     cli_dispatch: CliDispatchHarness,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """state prints the enum value, not the enum repr."""
+    """status <container> prints the state value, not the enum repr."""
     cli_dispatch.shield.state.return_value = ShieldState.DOWN
-    main(["state", _CONTAINER])
+    main(["status", _CONTAINER])
     assert capsys.readouterr().out.strip() == "down"
 
 

--- a/tests/unit/test_registry.py
+++ b/tests/unit/test_registry.py
@@ -17,7 +17,7 @@ from terok_shield.registry import (
     _handle_logs,
     _handle_preview,
     _handle_profiles,
-    _handle_state,
+    _handle_status,
 )
 
 
@@ -96,13 +96,26 @@ class TestHandlers:
         lines = capsys.readouterr().out.strip().splitlines()
         assert lines == ["dev-standard", "dev-python"]
 
-    def test_handle_state_prints_value(self, capsys: pytest.CaptureFixture[str]) -> None:
-        """_handle_state prints the ShieldState value."""
+    def test_handle_status_global(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """_handle_status without container prints config overview."""
+        shield = mock.MagicMock()
+        shield.status.return_value = {
+            "mode": "hook",
+            "audit_enabled": True,
+            "profiles": ["dev-standard"],
+        }
+        _handle_status(shield)
+        output = capsys.readouterr().out
+        assert "Mode:" in output
+        assert "hook" in output
+
+    def test_handle_status_with_container(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """_handle_status with container prints the ShieldState value."""
         from terok_shield import ShieldState
 
         shield = mock.MagicMock()
         shield.state.return_value = ShieldState.UP
-        _handle_state(shield, "ctr")
+        _handle_status(shield, container="ctr")
         assert capsys.readouterr().out.strip() == "up"
 
     def test_handle_preview_all_without_down_raises(self) -> None:


### PR DESCRIPTION
## Summary

- Removes the `state` command and merges its functionality into `status` with an optional `container` positional argument
- `terok-shield status` → global config overview (unchanged behavior)
- `terok-shield status CONTAINER` → per-container firewall state (replaces `state CONTAINER`)
- Top-level help shows both variants as separate aligned lines for discoverability

## Test plan

- [x] `make check` passes (lint, 487 tests, tach, docstrings, REUSE)
- [x] `terok-shield --help` shows both `status` and `status CONTAINER` lines
- [x] `terok-shield status --help` documents the optional container arg
- [ ] Integration tests (`test_state.py`) unaffected — they test `Shield.state()` API directly

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Status command now accepts an optional container argument to show either global shield configuration or a container's live firewall state.

* **Documentation**
  * CLI guide updated with usage, parameters, examples, and possible firewall states (up, down, down_all, inactive, error).

* **Removed**
  * The separate state command has been removed and its functionality merged into status.

* **Tests / CLI Help**
  * Tests and CLI help updated; help text now includes a visible hint for container usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->