### PR TITLE
feat: add NftNotFoundError for missing nft binary

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.poetry]
 name = "terok-shield"
-version = "0.2.3"
+version = "0.2.4"
 description = "nftables-based egress firewalling for Podman containers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/terok_shield/__init__.py
+++ b/src/terok_shield/__init__.py
@@ -30,7 +30,7 @@ from .config import ShieldConfig, ShieldMode, ShieldState
 from .dns import DnsResolver
 from .nft import RulesetBuilder
 from .profiles import ProfileLoader
-from .run import CommandRunner, ExecError, SubprocessRunner
+from .run import CommandRunner, ExecError, NftNotFoundError, SubprocessRunner
 from .util import is_ip as _is_ip
 
 # ── Shield Facade ────────────────────────────────────────
@@ -201,6 +201,7 @@ __all__ = [
     "CommandRunner",
     "DnsResolver",
     "ExecError",
+    "NftNotFoundError",
     "ProfileLoader",
     "RulesetBuilder",
     "Shield",

--- a/src/terok_shield/cli.py
+++ b/src/terok_shield/cli.py
@@ -64,14 +64,14 @@ def _auto_detect_mode() -> ShieldMode:
     Currently only hook mode is supported.
 
     Raises:
-        RuntimeError: If no supported shield mode is available.
+        NftNotFoundError: If nft is not installed.
     """
-    from .run import find_nft
+    from .run import NftNotFoundError, find_nft
 
     if find_nft():
         return ShieldMode.HOOK
 
-    raise RuntimeError("No supported shield mode available. Install nft for hook mode.")
+    raise NftNotFoundError("No supported shield mode available. Install nft for hook mode.")
 
 
 def _load_config_file() -> dict:

--- a/src/terok_shield/run.py
+++ b/src/terok_shield/run.py
@@ -33,6 +33,10 @@ def find_nft() -> str:
     return ""
 
 
+class NftNotFoundError(RuntimeError):
+    """Raised when the ``nft`` binary is not found on the host."""
+
+
 class ExecError(Exception):
     """Raised when a subprocess fails."""
 
@@ -101,14 +105,14 @@ class SubprocessRunner:
     """Default ``CommandRunner`` implementation using ``subprocess.run``.
 
     Resolves the nft binary path at construction time and raises
-    ``RuntimeError`` immediately if nft is not installed.
+    ``NftNotFoundError`` immediately if nft is not installed.
     """
 
     def __init__(self) -> None:
-        """Resolve the nft binary path, raising RuntimeError if missing."""
+        """Resolve the nft binary path, raising NftNotFoundError if missing."""
         self._nft = find_nft()
         if not self._nft:
-            raise RuntimeError(
+            raise NftNotFoundError(
                 "nft binary not found. Install nftables:\n"
                 "  Debian/Ubuntu: sudo apt install nftables\n"
                 "  Fedora/RHEL:   sudo dnf install nftables\n"

--- a/tests/unit/test_api_surface.py
+++ b/tests/unit/test_api_surface.py
@@ -13,7 +13,7 @@ from pathlib import Path
 import pytest
 
 import terok_shield
-from terok_shield import ExecError, ShieldConfig, ShieldMode, ShieldState
+from terok_shield import ExecError, NftNotFoundError, ShieldConfig, ShieldMode, ShieldState
 
 EXPECTED_ALL = [
     "ArgDef",
@@ -23,6 +23,7 @@ EXPECTED_ALL = [
     "CommandRunner",
     "DnsResolver",
     "ExecError",
+    "NftNotFoundError",
     "ProfileLoader",
     "RulesetBuilder",
     "Shield",
@@ -86,6 +87,13 @@ class TestAPISurface:
         cfg = make_config()
         with pytest.raises(dataclasses.FrozenInstanceError):
             cfg.mode = ShieldMode.HOOK  # type: ignore[misc]
+
+    # ── NftNotFoundError ──────────────────────────────────
+
+    def test_nft_not_found_error_is_runtime_error(self):
+        """NftNotFoundError is a RuntimeError subclass for backwards compat."""
+        err = NftNotFoundError("nft missing")
+        assert isinstance(err, RuntimeError)
 
     # ── ExecError ────────────────────────────────────────
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -16,7 +16,7 @@ from unittest import mock
 
 import pytest
 
-from terok_shield import ExecError, ShieldState
+from terok_shield import ExecError, NftNotFoundError, ShieldState
 from terok_shield.cli import (
     _auto_detect_mode,
     _build_config,
@@ -791,7 +791,7 @@ def test_parse_loopback_ports(raw: object, expected: tuple[int, ...]) -> None:
 def test_auto_detect_mode_raises_without_nft(monkeypatch: pytest.MonkeyPatch) -> None:
     """_auto_detect_mode() fails when nft is unavailable."""
     monkeypatch.setattr("terok_shield.run.find_nft", lambda: "")
-    with pytest.raises(RuntimeError):
+    with pytest.raises(NftNotFoundError):
         _auto_detect_mode()
 
 

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -11,7 +11,7 @@ from unittest import mock
 
 import pytest
 
-from terok_shield.run import CommandRunner, ExecError, SubprocessRunner, find_nft
+from terok_shield.run import CommandRunner, ExecError, NftNotFoundError, SubprocessRunner, find_nft
 
 from ..testfs import NFT_BINARY, NFT_SBIN
 from ..testnet import (
@@ -356,9 +356,9 @@ def test_find_nft_returns_empty_when_missing(monkeypatch: pytest.MonkeyPatch) ->
 
 
 def test_subprocess_runner_raises_when_nft_missing() -> None:
-    """SubprocessRunner raises RuntimeError with install instructions when nft is missing."""
+    """SubprocessRunner raises NftNotFoundError with install instructions when nft is missing."""
     with mock.patch("terok_shield.run.find_nft", return_value=""):
-        with pytest.raises(RuntimeError, match="nft binary not found"):
+        with pytest.raises(NftNotFoundError, match="nft binary not found"):
             SubprocessRunner()
 
 


### PR DESCRIPTION
## Summary

- Adds `NftNotFoundError(RuntimeError)` exception to `terok_shield.run`
- `SubprocessRunner.__init__()` and `_auto_detect_mode()` now raise `NftNotFoundError` instead of bare `RuntimeError`
- Exported via `__init__.py` so integrators (e.g. terok) can catch it cleanly
- Backwards-compatible: subclasses `RuntimeError`, so existing `except RuntimeError` still works

Closes #79 (defense-in-depth: typed exception for programmatic catching)

## Test plan

- [x] `test_subprocess_runner_raises_when_nft_missing` updated to assert `NftNotFoundError`
- [x] `test_auto_detect_mode_raises_without_nft` updated to assert `NftNotFoundError`
- [x] `test_nft_not_found_error_is_runtime_error` — confirms backwards compat
- [x] API surface snapshot test updated
- [x] `make check` passes (lint + 544 tests + tach + security + docstrings + reuse)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced NftNotFoundError, a new specific exception type that is raised when the NFT binary is not found during initialization. Applications can now catch this dedicated exception to handle NFT-related errors more precisely and implement targeted error handling, enabling better error reporting and troubleshooting capabilities.

* **Chores**
  * Version bumped to 0.2.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->