### PR TITLE
fix: address Sonar Bandit findings

### DIFF
--- a/src/terok_shield/__init__.py
+++ b/src/terok_shield/__init__.py
@@ -117,10 +117,10 @@ class Shield:
         for ip in ips:
             try:
                 self._mode.allow_ip(container, ip)
-                allowed.append(ip)
-                self.audit.log_event(container, "allowed", dest=ip, detail=f"target={target}")
-            except Exception:
-                pass
+            except (ExecError, OSError):
+                continue
+            allowed.append(ip)
+            self.audit.log_event(container, "allowed", dest=ip, detail=f"target={target}")
         return allowed
 
     def deny(self, container: str, target: str) -> list[str]:
@@ -130,10 +130,10 @@ class Shield:
         for ip in ips:
             try:
                 self._mode.deny_ip(container, ip)
-                denied.append(ip)
-                self.audit.log_event(container, "denied", dest=ip, detail=f"target={target}")
-            except Exception:
-                pass
+            except (ExecError, OSError):
+                continue
+            denied.append(ip)
+            self.audit.log_event(container, "denied", dest=ip, detail=f"target={target}")
         return denied
 
     def rules(self, container: str) -> str:

--- a/src/terok_shield/cli.py
+++ b/src/terok_shield/cli.py
@@ -7,6 +7,7 @@ import argparse
 import json
 import os
 import shlex
+import shutil
 import sys
 from pathlib import Path
 
@@ -361,6 +362,16 @@ _SHIELD_MANAGED_FLAGS = frozenset(
 )
 
 
+def _find_podman() -> str:
+    """Locate the podman binary for the ``run`` subcommand."""
+    found = shutil.which("podman")
+    if found:
+        resolved = Path(found).resolve()
+        if resolved.is_file() and os.access(resolved, os.X_OK):
+            return str(resolved)
+    raise OSError("podman binary not found. Install Podman to use 'terok-shield run'.")
+
+
 def _reject_shield_managed_flags(podman_args: list[str]) -> None:
     """Reject podman flags that conflict with shield-managed configuration."""
     conflicts: set[str] = set()
@@ -390,9 +401,12 @@ def _cmd_run(
 
     _reject_shield_managed_flags(podman_args)
 
+    podman = _find_podman()
     shield_args = shield.pre_start(container, profiles)
-    argv = ["podman", "run", "--name", container, *shield_args, *podman_args]
-    os.execvp("podman", argv)
+    argv = [podman, "run", "--name", container, *shield_args, *podman_args]
+    # Exec replaces the current process; argv is constructed locally and uses
+    # an absolute podman path, so shell injection and PATH spoofing do not apply.
+    os.execv(podman, argv)  # nosec B606
 
 
 def _cmd_resolve(shield: Shield, container: str, force: bool) -> None:

--- a/src/terok_shield/run.py
+++ b/src/terok_shield/run.py
@@ -129,12 +129,15 @@ class SubprocessRunner:
     ) -> str:
         """Run a command, return stdout.  Raise ExecError on failure when check=True."""
         try:
+            # All external commands flow through this boundary as explicit argv
+            # lists with ``shell=False`` so call sites stay auditable and testable.
             r = subprocess.run(
                 cmd,
                 input=stdin,
                 capture_output=True,
                 text=True,
                 timeout=timeout,
+                shell=False,  # nosec B603
             )
         except FileNotFoundError as e:
             if check:

--- a/tests/testfs.py
+++ b/tests/testfs.py
@@ -48,6 +48,7 @@ STATE_DIR_WITH_SPACES = "/path/with spaces/dir"
 
 NFT_BINARY = "/usr/bin/nft"
 NFT_SBIN = "/usr/sbin/nft"
+PODMAN_BINARY = "/usr/bin/podman"
 
 # ── Well-known terok-shield path segments used in tests ──
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -21,6 +21,7 @@ from terok_shield.cli import (
     _auto_detect_mode,
     _build_config,
     _build_parser,
+    _find_podman,
     _load_config_file,
     _parse_loopback_ports,
     _resolve_config_root,
@@ -31,6 +32,7 @@ from terok_shield.config import ShieldMode
 
 from ..testfs import (
     AUDIT_FILENAME,
+    BIN_DIR_NAME,
     CONTAINERS_DIR_NAME,
     FAKE_CONFIG_DIR,
     FAKE_STATE_DIR,
@@ -40,6 +42,7 @@ from ..testfs import (
     FORBIDDEN_TRAVERSAL,
     NFT_BINARY,
     NONEXISTENT_DIR,
+    PODMAN_BINARY,
     STATE_DIR_WITH_SPACES,
     VOLUME_MOUNT_DATA,
     VOLUME_MOUNT_HOST,
@@ -68,7 +71,7 @@ class CliDispatchHarness:
 class CliRunHarness(CliDispatchHarness):
     """Patched CLI collaborators for the ``run`` subcommand."""
 
-    execvp: mock.MagicMock
+    execv: mock.MagicMock
 
 
 @pytest.fixture
@@ -89,13 +92,14 @@ def cli_dispatch() -> Iterator[CliDispatchHarness]:
 
 @pytest.fixture
 def cli_run() -> Iterator[CliRunHarness]:
-    """Patch CLI collaborators plus ``os.execvp`` for ``run`` tests."""
+    """Patch CLI collaborators plus ``os.execv`` for ``run`` tests."""
     with (
         mock.patch("terok_shield.cli._build_config") as build_config,
         mock.patch("terok_shield.cli.Shield") as shield_cls,
-        mock.patch("os.execvp") as execvp,
+        mock.patch("terok_shield.cli._find_podman", return_value=PODMAN_BINARY),
+        mock.patch("os.execv") as execv,
     ):
-        yield CliRunHarness(build_config=build_config, shield_cls=shield_cls, execvp=execvp)
+        yield CliRunHarness(build_config=build_config, shield_cls=shield_cls, execv=execv)
 
 
 def _write_audit_entries(state_root: Path, container: str, entries: list[dict[str, str]]) -> Path:
@@ -343,12 +347,54 @@ def test_run_execs_podman_with_shield_flags(
     cli_run.shield.pre_start.return_value = ["--annotation", "a=b"]
     main(argv)
     cli_run.shield.pre_start.assert_called_once_with(_CONTAINER, profiles)
-    cli_run.execvp.assert_called_once()
-    podman_argv = cli_run.execvp.call_args.args[1]
-    assert podman_argv[:3] == ["podman", "run", "--name"]
+    cli_run.execv.assert_called_once()
+    assert cli_run.execv.call_args.args[0] == PODMAN_BINARY
+    podman_argv = cli_run.execv.call_args.args[1]
+    assert podman_argv[:3] == [PODMAN_BINARY, "run", "--name"]
     assert _CONTAINER in podman_argv
     for item in expected_tail:
         assert item in podman_argv
+
+
+def test_find_podman_resolves_relative_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """_find_podman() resolves relative PATH hits to an absolute executable path."""
+    podman_path = tmp_path / BIN_DIR_NAME / "podman"
+    podman_path.parent.mkdir()
+    podman_path.write_text("#!/bin/sh\n")
+    podman_path.chmod(0o755)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "terok_shield.cli.shutil.which", lambda _name: str(Path(BIN_DIR_NAME) / "podman")
+    )
+    assert _find_podman() == str(podman_path.resolve())
+
+
+def test_find_podman_rejects_non_executable_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """_find_podman() rejects resolved paths that are not executable."""
+    podman_path = tmp_path / BIN_DIR_NAME / "podman"
+    podman_path.parent.mkdir()
+    podman_path.write_text("not executable\n")
+    podman_path.chmod(0o644)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "terok_shield.cli.shutil.which", lambda _name: str(Path(BIN_DIR_NAME) / "podman")
+    )
+    with pytest.raises(OSError, match="podman binary not found"):
+        _find_podman()
+
+
+def test_run_reports_missing_podman(cli_dispatch: CliDispatchHarness) -> None:
+    """run() exits with a clear error when podman cannot be found."""
+    cli_dispatch.shield.pre_start.return_value = ["--annotation", "a=b"]
+    with mock.patch("terok_shield.cli.shutil.which", return_value=None):
+        with pytest.raises(SystemExit) as ctx:
+            main(["run", _CONTAINER, "--", _IMAGE])
+    assert ctx.value.code == 1
+    cli_dispatch.shield.pre_start.assert_not_called()
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_shield_facade.py
+++ b/tests/unit/test_shield_facade.py
@@ -10,7 +10,7 @@ from unittest import mock
 
 import pytest
 
-from terok_shield import Shield, ShieldConfig, ShieldState
+from terok_shield import ExecError, Shield, ShieldConfig, ShieldState
 
 from ..testfs import NFT_BINARY
 from ..testnet import TEST_DOMAIN, TEST_IP1, TEST_IP2
@@ -215,7 +215,7 @@ def test_allow_and_deny_swallow_backend_exceptions(
 ) -> None:
     """allow()/deny() are best-effort when backend IP operations fail."""
     harness = make_shield()
-    getattr(harness.mode, backend_method).side_effect = RuntimeError("nft failed")
+    getattr(harness.mode, backend_method).side_effect = ExecError(["nft"], 1, "nft failed")
     assert getattr(harness.shield, method)("test-ctr", target) == []
 
 


### PR DESCRIPTION
## Summary
- stop swallowing all exceptions in `Shield.allow()` / `Shield.deny()` and only ignore the expected operational failures
- resolve `podman` to an absolute path before `terok-shield run` execs into it, and fail early with a clear error if Podman is missing
- document the centralized subprocess boundary in `run.py` and mark the reviewed `subprocess.run(..., shell=False)` call accordingly
- update CLI tests for the absolute-path exec path and add a regression test for missing Podman

## Validation
- `PYTHONPATH=src /home/dev/terok-shield-tools-venv/bin/python -m pytest tests/unit/test_shield_facade.py tests/unit/test_cli.py tests/unit/test_run.py`
- `/home/dev/terok-shield-tools-venv/bin/ruff check src/terok_shield/__init__.py src/terok_shield/cli.py src/terok_shield/run.py tests/testfs.py tests/unit/test_cli.py tests/unit/test_run.py`
- `PYTHONPATH=src /home/dev/terok-shield-tools-venv/bin/bandit -q -r src/terok_shield/__init__.py src/terok_shield/cli.py src/terok_shield/run.py`
- `python3 -m py_compile src/terok_shield/__init__.py src/terok_shield/cli.py src/terok_shield/run.py`
- `git diff --check`

## Notes
The targeted Bandit run now only reports the long-standing `B404` informational warning on importing `subprocess` in `run.py`; the Sonar-reported new-code findings are addressed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Strengthened protection against PATH spoofing by resolving executables to absolute paths and avoiding shell-based execution.
* **Bug Fixes**
  * Narrowed exception handling in allow/deny flows to specific error types to avoid silently recording failed operations.
* **Tests**
  * Added tests for binary detection, handling of missing/non-executable binaries, and adjusted exception behavior coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->