### PR TITLE
SonarCloud experiment [DO NOT MERGE]

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,10 +1,13 @@
 # CI and `make sonar-inputs` write scanner inputs under reports/ so the repo root
 # stays clean for humans. Unit tests write coverage/junit there, and the Ruff/Bandit
 # report targets emit the JSON files imported below.
+#
+# We intentionally leave `tests/` out of the Sonar analysis scope for now. SonarCloud's
+# Architecture view currently derives its structure from all analyzed Python files, so
+# including tests makes the map unusable. Coverage still comes from the unit-test report.
 sonar.organization=terok-ai
 sonar.projectKey=terok-ai_terok-shield
 sonar.sources=src
-sonar.tests=tests
 sonar.python.coverage.reportPaths=reports/coverage.xml
 sonar.python.bandit.reportPaths=reports/bandit-report.json
 sonar.python.ruff.reportPaths=reports/ruff-report.json


### PR DESCRIPTION
This is a small SonarCloud experiment, related to https://github.com/terok-ai/terok-shield/issues/96#issuecomment-4058428923

## What changed
- remove `sonar.tests=tests` from `sonar-project.properties`
- leave `sonar.sources=src`
- keep importing coverage + Ruff + Bandit reports from `reports/`

## Why
SonarCloud currently shows `tests/` as a top-level block in the Architecture view even when tests are classified via `sonar.tests=tests`, which makes the feature unusable on this repo.

This PR checks whether leaving tests out of the Sonar analysis scope fixes that while still preserving source coverage from the imported unit-test report.

## What to verify after merge / analysis
- Architecture shows only `src`
- coverage on `src` still looks correct
- Ruff/Bandit imports still work
- no unexpected regressions in Sonar UI metrics


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code analysis configuration to exclude tests from analysis while maintaining coverage reporting from unit-test results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->