### PR TITLE
bugfix: return sudo to containers

### DIFF
--- a/src/terok_shield/cli.py
+++ b/src/terok_shield/cli.py
@@ -372,7 +372,6 @@ _SHIELD_MANAGED_FLAGS = frozenset(
         "--annotation",
         "--cap-add",
         "--cap-drop",
-        "--security-opt",
     }
 )
 

--- a/src/terok_shield/mode_hook.py
+++ b/src/terok_shield/mode_hook.py
@@ -289,8 +289,6 @@ class HookMode:
             "NET_ADMIN",
             "--cap-drop",
             "NET_RAW",
-            "--security-opt",
-            "no-new-privileges",
         ]
         return args
 

--- a/tests/integration/launch/test_pre_start.py
+++ b/tests/integration/launch/test_pre_start.py
@@ -30,7 +30,6 @@ class TestShieldPreStart:
         assert "--hooks-dir" in args
         assert "--annotation" in args
         assert "--cap-drop" in args
-        assert "--security-opt" in args
 
     @pytest.mark.needs_internet
     def test_pre_start_resolves_dns(self, shield_env: Path) -> None:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -427,14 +427,12 @@ def test_run_and_separator_validation(
         pytest.param("--annotation", id="annotation"),
         pytest.param("--cap-add", id="cap-add"),
         pytest.param("--cap-drop", id="cap-drop"),
-        pytest.param("--security-opt", id="security-opt"),
         pytest.param("--network=host", id="network-equals"),
         pytest.param("--name=other", id="name-equals"),
         pytest.param("--annotation=a=b", id="annotation-equals"),
         pytest.param("--hooks-dir=/tmp", id="hooks-dir-equals"),
         pytest.param("--cap-add=NET_ADMIN", id="cap-add-equals"),
         pytest.param("--cap-drop=ALL", id="cap-drop-equals"),
-        pytest.param("--security-opt=no-new-privileges", id="security-opt-equals"),
     ],
 )
 def test_run_rejects_shield_managed_flags(


### PR DESCRIPTION
I was too eager to close down the containers against shield manipulation, instead also taking away their sudo rights. This retains the capos-based separation which is what's actually needed here, but returns the sudo access which is the repsponsibility of the container runner/orchestrator

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * "--security-opt" flag is no longer restricted and can be freely configured by users
  * Removed automatic enforcement of "no-new-privileges" security setting from container startup configuration
  * Container security options are now fully under user control without system-imposed restrictions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->