### PR TITLE
add Debian 12 to list of tested distros

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ destinations — everything else is dropped.
 ### Requirements
 
 - Linux with nftables (`nft` binary)
-  - Tested on Fedora 43, Debian 13, and Ubuntu 24.04, probably also works on other modern Linux distros.
-- Podman (rootless, recommended > 5.6.0, untested < 4.9.3)
+  - Tested on Fedora 43, Debian 12 and 13, and Ubuntu 24.04, probably also works on other modern Linux distros.
+- Podman (rootless, recommended > 5.6.0, untested < 4.3.1)
 - Python 3.12+
 - `dig` (from `dnsutils` / `bind-utils`) for DNS resolution
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated system requirements documentation to reflect support for Debian 12 and 13.
  * Updated Podman version compatibility information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->