### PR TITLE
ci: add multi-distro test matrix workflow

### DIFF
--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+#
+# Multi-distro integration test matrix.
+# Requires a self-hosted runner with podman and --privileged support.
+# Will NOT work on GitHub-hosted runners (no nested containers).
+name: Test Matrix
+
+on:
+  workflow_dispatch:
+
+jobs:
+  matrix:
+    if: github.repository == 'terok-ai/terok-shield'
+    runs-on: self-hosted
+    strategy:
+      fail-fast: false
+      matrix:
+        distro: [debian12, ubuntu2404, debian13, fedora43]
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Run test matrix (${{ matrix.distro }})
+        run: ./tests/containers/run-matrix.sh ${{ matrix.distro }}


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow for running integration tests across all supported distros (Debian 12/13, Ubuntu 24.04, Fedora 43) in parallel.

- Manual trigger only (`workflow_dispatch`) - requires self-hosted runner with podman + privileged container support
- Uses the existing `run-matrix.sh` script and Containerfiles from `tests/containers/`
- Each distro runs as a separate matrix job with `fail-fast: false`
- Will NOT work on GitHub-hosted runners (no nested containers)

## Test plan

- [x] REUSE compliant (SPDX header)
- [x] Workflow syntax valid
- [ ] Manual trigger on self-hosted runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated multi-distribution integration testing across Debian 12, Ubuntu 24.04, Debian 13, and Fedora 43 to ensure improved platform compatibility and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->