### PR TITLE
feat: NFQUEUE interactive mode — three-tier egress evaluation

### DIFF
--- a/src/terok_shield/__init__.py
+++ b/src/terok_shield/__init__.py
@@ -90,6 +90,28 @@ class EnvironmentCheck:
     setup_hint: str = ""
 
 
+def _read_installed_hook_version(hooks_dirs: list[Path]) -> int | None:
+    """Read ``_BUNDLE_VERSION`` from the installed hook entrypoint, or ``None``.
+
+    Scans each hooks directory for the entrypoint script and extracts the
+    version from the ``_BUNDLE_VERSION = N`` line.  Returns ``None`` if
+    not found or unparseable.
+    """
+    import re
+
+    pattern = re.compile(r"^_BUNDLE_VERSION\s*=\s*(\d+)", re.MULTILINE)
+    for d in hooks_dirs:
+        hook = d / "terok-shield-hook"
+        if hook.is_file():
+            try:
+                m = pattern.search(hook.read_text())
+                if m:
+                    return int(m.group(1))
+            except (OSError, ValueError):
+                pass
+    return None
+
+
 # ── Shield Facade ────────────────────────────────────────
 
 
@@ -188,6 +210,14 @@ class Shield:
                 sys_dir = system_hooks_dir()
                 hooks = "global-system" if has_global_hooks([sys_dir]) else "global-user"
                 health = "ok"
+                # Check hook version matches current package
+                hook_ver = _read_installed_hook_version(hooks_dirs)
+                if hook_ver is not None and hook_ver != state.BUNDLE_VERSION:
+                    health = "stale-hooks"
+                    issues.append(
+                        f"Installed hook version {hook_ver} != expected {state.BUNDLE_VERSION}. "
+                        "Run `terok-shield setup` to update."
+                    )
             else:
                 hooks = "not-installed"
                 health = "setup-needed"

--- a/src/terok_shield/__init__.py
+++ b/src/terok_shield/__init__.py
@@ -321,6 +321,7 @@ class Shield:
         return self.profiles.compose_profiles(names)
 
 
+from .interactive import run_interactive  # noqa: E402
 from .registry import COMMANDS, ArgDef, CommandDef  # noqa: E402
 
 __all__ = [
@@ -347,6 +348,7 @@ __all__ = [
     "SubprocessRunner",
     "USER_HOOKS_DIR",
     "ensure_containers_conf_hooks_dir",
+    "run_interactive",
     "setup_global_hooks",
     "system_hooks_dir",
 ]

--- a/src/terok_shield/__init__.py
+++ b/src/terok_shield/__init__.py
@@ -321,7 +321,6 @@ class Shield:
         return self.profiles.compose_profiles(names)
 
 
-from .interactive import run_interactive  # noqa: E402
 from .registry import COMMANDS, ArgDef, CommandDef  # noqa: E402
 
 __all__ = [
@@ -348,7 +347,6 @@ __all__ = [
     "SubprocessRunner",
     "USER_HOOKS_DIR",
     "ensure_containers_conf_hooks_dir",
-    "run_interactive",
     "setup_global_hooks",
     "system_hooks_dir",
 ]

--- a/src/terok_shield/cli.py
+++ b/src/terok_shield/cli.py
@@ -96,12 +96,14 @@ def _build_config(
     container: str | None = None,
     *,
     state_dir_override: Path | None = None,
+    interactive: bool | None = None,
 ) -> ShieldConfig:
     """Build a ShieldConfig from config.yml + env vars.
 
     Args:
         container: Container name (used for per-container state_dir).
         state_dir_override: Explicit state_dir from --state-dir flag.
+        interactive: Override config.yml interactive flag (CLI ``--interactive``).
     """
     file_cfg = _load_config_file()
 
@@ -130,7 +132,7 @@ def _build_config(
         loopback_ports=tuple(file_cfg.loopback_ports),
         audit_enabled=file_cfg.audit.enabled,
         profiles_dir=profiles_dir,
-        interactive=file_cfg.interactive,
+        interactive=interactive if interactive is not None else file_cfg.interactive,
         nfqueue_timeout=file_cfg.nfqueue_timeout,
     )
 
@@ -300,7 +302,10 @@ def _dispatch(args: argparse.Namespace) -> None:
 
     # All other commands need a per-container config + Shield
     container = getattr(args, "container", None)
-    config = _build_config(container, state_dir_override=state_dir_override)
+    interactive_override = getattr(args, "interactive", None) or None  # False → None
+    config = _build_config(
+        container, state_dir_override=state_dir_override, interactive=interactive_override
+    )
     shield = Shield(config)
 
     # CLI-only standalone commands with custom logic

--- a/src/terok_shield/cli.py
+++ b/src/terok_shield/cli.py
@@ -130,6 +130,8 @@ def _build_config(
         loopback_ports=tuple(file_cfg.loopback_ports),
         audit_enabled=file_cfg.audit.enabled,
         profiles_dir=profiles_dir,
+        interactive=file_cfg.interactive,
+        nfqueue_timeout=file_cfg.nfqueue_timeout,
     )
 
 

--- a/src/terok_shield/config.py
+++ b/src/terok_shield/config.py
@@ -24,6 +24,7 @@ ANNOTATION_VERSION_KEY = "terok.shield.version"
 ANNOTATION_AUDIT_ENABLED_KEY = "terok.shield.audit_enabled"
 ANNOTATION_UPSTREAM_DNS_KEY = "terok.shield.upstream_dns"
 ANNOTATION_DNS_TIER_KEY = "terok.shield.dns_tier"
+ANNOTATION_INTERACTIVE_KEY = "terok.shield.interactive"
 
 
 class DnsTier(enum.Enum):
@@ -111,6 +112,8 @@ class ShieldConfig:
     loopback_ports: tuple[int, ...] = ()
     audit_enabled: bool = True
     profiles_dir: Path | None = None
+    interactive: bool = False
+    nfqueue_timeout: int = 5
 
 
 # -- Config-file schema (Pydantic) ------------------------
@@ -144,6 +147,16 @@ class ShieldFileConfig(BaseModel):
     )
     audit: AuditFileConfig = Field(
         default_factory=AuditFileConfig, description="Audit logging settings"
+    )
+    interactive: bool = Field(
+        default=False,
+        description="Enable NFQUEUE interactive mode (queue unknown packets for operator verdict)",
+    )
+    nfqueue_timeout: int = Field(
+        default=5,
+        ge=1,
+        le=60,
+        description="Seconds to wait for operator verdict before dropping queued packets",
     )
     model_config = ConfigDict(extra="forbid")
 

--- a/src/terok_shield/config.py
+++ b/src/terok_shield/config.py
@@ -115,6 +115,11 @@ class ShieldConfig:
     interactive: bool = False
     nfqueue_timeout: int = 5
 
+    def __post_init__(self) -> None:
+        """Validate fields that Pydantic can't enforce for direct callers."""
+        if not 1 <= self.nfqueue_timeout <= 60:
+            raise ValueError(f"nfqueue_timeout must be 1–60, got {self.nfqueue_timeout}")
+
 
 # -- Config-file schema (Pydantic) ------------------------
 

--- a/src/terok_shield/interactive.py
+++ b/src/terok_shield/interactive.py
@@ -320,8 +320,9 @@ class InteractiveSession:
                     domain, ip = m.group(1).lower().rstrip("."), m.group(2)
                     new_map[ip] = domain
         except OSError:
-            pass
-        self._ip_to_domain = new_map
+            pass  # keep previous cache intact
+        else:
+            self._ip_to_domain = new_map
         self._last_domain_refresh = time.monotonic()
 
 

--- a/src/terok_shield/interactive.py
+++ b/src/terok_shield/interactive.py
@@ -41,6 +41,9 @@ logger = logging.getLogger(__name__)
 # Matches dnsmasq log lines:  "... reply <domain> is <ip>"
 _REPLY_RE = re.compile(r"reply\s+(\S+)\s+is\s+(\S+)")
 
+# How often (seconds) to refresh the domain cache from dnsmasq log.
+_DOMAIN_REFRESH_INTERVAL = 10.0
+
 _running = True
 
 
@@ -99,6 +102,7 @@ class InteractiveSession:
         self._timeout = timeout
         self._pending: dict[int, _PendingPacket] = {}
         self._ip_to_domain: dict[str, str] = {}
+        self._last_domain_refresh = 0.0
 
     def run(self) -> None:
         """Enter the main verdict loop.
@@ -115,7 +119,7 @@ class InteractiveSession:
             raise SystemExit(1)
 
         # Build initial domain cache from dnsmasq log
-        self._load_domain_cache()
+        self._refresh_domain_cache()
 
         # Make stdin non-blocking for select()
         stdin_fd = sys.stdin.fileno()
@@ -140,7 +144,7 @@ class InteractiveSession:
             # Read queued packets
             if handler.fileno() in (r if isinstance(r, int) else r.fileno() for r in readable):
                 for pkt in handler.poll():
-                    self._handle_queued(handler, pkt)
+                    self._handle_queued(pkt)
 
             # Read stdin commands
             if stdin_fd in (r if isinstance(r, int) else r.fileno() for r in readable):
@@ -151,7 +155,11 @@ class InteractiveSession:
             # Sweep timed-out packets
             self._sweep_timeouts(handler)
 
-    def _handle_queued(self, handler: NfqueueHandler, pkt: QueuedPacket) -> None:
+            # Periodically refresh domain cache
+            if time.monotonic() - self._last_domain_refresh > _DOMAIN_REFRESH_INTERVAL:
+                self._refresh_domain_cache()
+
+    def _handle_queued(self, pkt: QueuedPacket) -> None:
         """Process a newly queued packet: enrich, emit, track."""
         domain = self._ip_to_domain.get(pkt.dest, "")
         pending = _PendingPacket(packet=pkt, queued_at=time.monotonic(), domain=domain)
@@ -200,8 +208,13 @@ class InteractiveSession:
             return
 
         packet_id = cmd.get("id")
-        action = cmd.get("action", "").lower()
-        if packet_id is None or action not in ("accept", "deny"):
+        action = cmd.get("action")
+        if not isinstance(packet_id, int) or isinstance(packet_id, bool):
+            return
+        if not isinstance(action, str):
+            return
+        action = action.lower()
+        if action not in ("accept", "deny"):
             return
 
         pending = self._pending.pop(packet_id, None)
@@ -226,7 +239,6 @@ class InteractiveSession:
         """Persist the verdict to nft sets and state files."""
         ip = pending.packet.dest
         if accept:
-            # Add to allow set + persist to live.allowed
             from .nft import add_elements_dual
 
             nft_cmd = add_elements_dual([ip])
@@ -234,7 +246,6 @@ class InteractiveSession:
                 self._nft_apply(nft_cmd)
             _append_unique(state.live_allowed_path(self._state_dir), ip)
         else:
-            # Add to deny set + persist to deny.list
             from .nft import add_deny_elements_dual
 
             nft_cmd = add_deny_elements_dual([ip])
@@ -255,9 +266,7 @@ class InteractiveSession:
     def _sweep_timeouts(self, handler: NfqueueHandler) -> None:
         """Drop packets that have exceeded the verdict timeout."""
         now = time.monotonic()
-        expired = [
-            pid for pid, p in self._pending.items() if now - p.queued_at > self._timeout
-        ]
+        expired = [pid for pid, p in self._pending.items() if now - p.queued_at > self._timeout]
         for pid in expired:
             pending = self._pending.pop(pid)
             handler.verdict(pending.packet.packet_id, accept=False)
@@ -271,10 +280,11 @@ class InteractiveSession:
                 event["domain"] = pending.domain
             print(json.dumps(event, separators=(",", ":")), flush=True)
 
-    def _load_domain_cache(self) -> None:
-        """Build IP→domain cache from the dnsmasq query log.
+    def _refresh_domain_cache(self) -> None:
+        """Refresh IP→domain cache from the dnsmasq query log.
 
         Parses ``reply`` lines to map resolved IPs back to domain names.
+        Called periodically so long-running sessions learn new DNS replies.
         """
         log_path = state.dnsmasq_log_path(self._state_dir)
         if not log_path.is_file():
@@ -287,6 +297,7 @@ class InteractiveSession:
                     self._ip_to_domain[ip] = domain
         except OSError:
             pass
+        self._last_domain_refresh = time.monotonic()
 
 
 # ── Helpers ────────────────────────────────────────────
@@ -312,7 +323,7 @@ def _append_unique(path: Path, value: str) -> None:
 # ── Entry point ────────────────────────────────────────
 
 
-def run_interactive(state_dir: Path, container: str) -> None:
+def run_interactive(state_dir: Path, container: str, *, timeout: int = 5) -> None:
     """Start the interactive NFQUEUE verdict handler.
 
     Validates that interactive mode is enabled for this container,
@@ -322,6 +333,7 @@ def run_interactive(state_dir: Path, container: str) -> None:
     Args:
         state_dir: Per-container state directory.
         container: Container name.
+        timeout: Seconds before auto-dropping queued packets.
 
     Raises:
         SystemExit: If interactive mode is not enabled or NFQUEUE
@@ -336,5 +348,6 @@ def run_interactive(state_dir: Path, container: str) -> None:
         runner=runner,
         state_dir=state_dir,
         container=container,
+        timeout=timeout,
     )
     session.run()

--- a/src/terok_shield/interactive.py
+++ b/src/terok_shield/interactive.py
@@ -348,13 +348,17 @@ def _append_unique(path: Path, value: str) -> None:
 
 # ── Entry point ────────────────────────────────────────
 
+_NSENTER_ENV = "_TEROK_SHIELD_NSENTER"
+
 
 def run_interactive(state_dir: Path, container: str, *, timeout: int = 5) -> None:
     """Start the interactive NFQUEUE verdict handler.
 
-    Validates that interactive mode is enabled for this container,
-    then enters the verdict loop.  Blocks until SIGINT/SIGTERM or
-    stdin EOF.
+    The NFQUEUE socket lives in the container's network namespace, so the
+    handler must run inside it.  On first call (no ``_TEROK_SHIELD_NSENTER``
+    env var) this function re-executes itself under ``podman unshare nsenter``
+    with stdin/stdout passed through for the JSON-lines protocol.  The
+    re-executed process sees the env var and enters the verdict loop directly.
 
     Args:
         state_dir: Per-container state directory.
@@ -370,6 +374,14 @@ def run_interactive(state_dir: Path, container: str, *, timeout: int = 5) -> Non
         print("Error: interactive mode is not enabled for this container.", file=sys.stderr)
         raise SystemExit(1)
 
+    if os.environ.get(_NSENTER_ENV) == "1":
+        _run_verdict_loop(state_dir, container, timeout=timeout)
+    else:
+        _nsenter_reexec(state_dir, container, timeout=timeout)
+
+
+def _run_verdict_loop(state_dir: Path, container: str, *, timeout: int) -> None:
+    """Run the verdict loop directly (already inside the container netns)."""
     runner = SubprocessRunner()
     session = InteractiveSession(
         runner=runner,
@@ -378,3 +390,49 @@ def run_interactive(state_dir: Path, container: str, *, timeout: int = 5) -> Non
         timeout=timeout,
     )
     session.run()
+
+
+def _nsenter_reexec(state_dir: Path, container: str, *, timeout: int) -> None:
+    """Re-exec the handler inside the container's network namespace.
+
+    Uses ``podman unshare nsenter -t PID -n`` to enter the rootless
+    network namespace, then runs this module as ``python -m`` with
+    stdin/stdout passed through for the JSON-lines protocol.
+    """
+    import subprocess
+
+    runner = SubprocessRunner()
+    pid = runner.podman_inspect(container, "{{.State.Pid}}")
+    if not pid or pid == "0":
+        print(f"Error: container {container!r} is not running.", file=sys.stderr)
+        raise SystemExit(1)
+
+    cmd = [
+        "podman",
+        "unshare",
+        "nsenter",
+        "-t",
+        pid,
+        "-n",
+        "--",
+        sys.executable,
+        "-m",
+        "terok_shield.interactive",
+        str(state_dir),
+        container,
+        str(timeout),
+    ]
+    env = {**os.environ, _NSENTER_ENV: "1"}
+    result = subprocess.run(cmd, env=env)  # noqa: S603 — argv list, no shell
+    raise SystemExit(result.returncode)
+
+
+if __name__ == "__main__":
+    # Re-exec entry point: python -m terok_shield.interactive <state_dir> <container> <timeout>
+    if len(sys.argv) != 4:
+        print(
+            f"Usage: {sys.executable} -m terok_shield.interactive <state_dir> <container> <timeout>",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
+    _run_verdict_loop(Path(sys.argv[1]), sys.argv[2], timeout=int(sys.argv[3]))

--- a/src/terok_shield/interactive.py
+++ b/src/terok_shield/interactive.py
@@ -31,10 +31,12 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from . import state
+from .mode_hook import INTERACTIVE_TIER_NFQUEUE
 from .nfqueue import NfqueueHandler, QueuedPacket
 from .nft_constants import NFQUEUE_NUM
 from .run import CommandRunner, SubprocessRunner
-from .state import interactive_path
+from .state import read_interactive_tier
+from .watch import NflogWatcher, WatchEvent
 
 logger = logging.getLogger(__name__)
 
@@ -346,48 +348,272 @@ def _append_unique(path: Path, value: str) -> None:
             f.write(f"{value}\n")
 
 
+# ── NFLOG-based interactive session ───────────────────
+
+
+class NflogInteractiveSession:
+    """Interactive verdict session using NFLOG events (no NFQUEUE dependency).
+
+    Reads rejected-but-logged packets from :class:`NflogWatcher` (host-side,
+    no nsenter needed), deduplicates by destination IP, and emits the same
+    JSON-lines protocol as the NFQUEUE session.
+
+    Packets are already rejected by the nft rule — the operator's verdict
+    updates allow/deny sets so *future* connections to that IP succeed or
+    are explicitly denied.
+    """
+
+    def __init__(
+        self,
+        *,
+        runner: CommandRunner,
+        state_dir: Path,
+        container: str,
+    ) -> None:
+        """Initialise the NFLOG session.
+
+        Args:
+            runner: Command runner for nft set modifications.
+            state_dir: Per-container state directory.
+            container: Container name.
+        """
+        self._runner = runner
+        self._state_dir = state_dir
+        self._container = container
+        self._seen_ips: set[str] = set()
+        self._pending_by_ip: dict[str, _PendingPacket] = {}
+        self._ip_to_domain: dict[str, str] = {}
+        self._last_domain_refresh = 0.0
+        self._next_id = 1
+
+    def run(self) -> None:
+        """Enter the NFLOG-based verdict loop."""
+        watcher = NflogWatcher.create(self._container)
+        if watcher is None:
+            print(
+                "Error: cannot bind to NFLOG — check permissions or kernel module.",
+                file=sys.stderr,
+            )
+            raise SystemExit(1)
+
+        self._refresh_domain_cache()
+        stdin_fd = sys.stdin.fileno()
+        _set_nonblocking(stdin_fd)
+
+        global _running  # noqa: PLW0603
+        _running = True
+        signal.signal(signal.SIGINT, _handle_signal)
+        signal.signal(signal.SIGTERM, _handle_signal)
+
+        try:
+            self._loop(watcher, stdin_fd)
+        finally:
+            watcher.close()
+
+    def _loop(self, watcher: NflogWatcher, stdin_fd: int) -> None:
+        """Core select loop: NFLOG socket + stdin."""
+        stdin_buf = ""
+        while _running:
+            readable, _, _ = select.select([watcher, stdin_fd], [], [], 1.0)
+            ready = {r if isinstance(r, int) else r.fileno() for r in readable}
+
+            if watcher.fileno() in ready:
+                for event in watcher.poll():
+                    if event.action == "queued_connection" and event.dest:
+                        self._handle_nflog_event(event)
+
+            if stdin_fd in ready:
+                stdin_buf = self._read_stdin(stdin_buf)
+                if stdin_buf is None:
+                    break
+
+            if time.monotonic() - self._last_domain_refresh > _DOMAIN_REFRESH_INTERVAL:
+                self._refresh_domain_cache()
+
+    def _handle_nflog_event(self, event: WatchEvent) -> None:
+        """Process an NFLOG event for a queued connection."""
+        ip = event.dest
+        if ip in self._seen_ips:
+            return  # deduplicate — already presented to operator
+        self._seen_ips.add(ip)
+
+        domain = self._ip_to_domain.get(ip, "")
+        pkt = QueuedPacket(packet_id=self._next_id, dest=ip, port=event.port, proto=event.proto)
+        self._next_id += 1
+        pending = _PendingPacket(packet=pkt, queued_at=time.monotonic(), domain=domain)
+        self._pending_by_ip[ip] = pending
+
+        out: dict = {
+            "type": "pending",
+            "id": pkt.packet_id,
+            "dest": ip,
+            "port": event.port,
+            "proto": event.proto,
+        }
+        if domain:
+            out["domain"] = domain
+        print(json.dumps(out, separators=(",", ":")), flush=True)
+
+    def _read_stdin(self, buf: str) -> str | None:
+        """Read and process stdin verdict commands.  Returns None on EOF."""
+        try:
+            chunk = os.read(sys.stdin.fileno(), 4096).decode()
+        except OSError:
+            return buf
+        if not chunk:
+            return None
+        buf += chunk
+        while "\n" in buf:
+            line, buf = buf.split("\n", 1)
+            line = line.strip()
+            if line:
+                self._process_command(line)
+        return buf
+
+    def _process_command(self, line: str) -> None:
+        """Parse and execute a verdict command."""
+        try:
+            cmd = json.loads(line)
+        except json.JSONDecodeError:
+            logger.warning("Ignoring invalid JSON on stdin")
+            return
+        if not isinstance(cmd, dict) or cmd.get("type") != "verdict":
+            return
+        packet_id = cmd.get("id")
+        action = cmd.get("action")
+        if not isinstance(packet_id, int) or isinstance(packet_id, bool):
+            return
+        if not isinstance(action, str):
+            return
+        action = action.lower()
+        if action not in ("accept", "deny"):
+            return
+
+        # Find pending by packet_id
+        pending = next(
+            (p for p in self._pending_by_ip.values() if p.packet.packet_id == packet_id), None
+        )
+        if pending is None:
+            return
+        del self._pending_by_ip[pending.packet.dest]
+
+        accept = action == "accept"
+        ok = self._apply_verdict(pending, accept=accept)
+
+        result: dict = {
+            "type": "verdict_applied" if ok else "verdict_failed",
+            "id": packet_id,
+            "action": action,
+            "dest": pending.packet.dest,
+        }
+        if pending.domain:
+            result["domain"] = pending.domain
+        print(json.dumps(result, separators=(",", ":")), flush=True)
+
+    def _apply_verdict(self, pending: _PendingPacket, *, accept: bool) -> bool:
+        """Persist verdict to nft sets and state files."""
+        ip = pending.packet.dest
+        if accept:
+            from .nft import add_elements_dual
+
+            nft_cmd = add_elements_dual([ip], permanent=True)
+        else:
+            from .nft import add_deny_elements_dual
+
+            nft_cmd = add_deny_elements_dual([ip])
+
+        if nft_cmd:
+            for line in nft_cmd.strip().splitlines():
+                parts = line.strip().split()
+                if parts:
+                    try:
+                        self._runner.nft_via_nsenter(self._container, *parts)
+                    except Exception:
+                        logger.warning("Failed to apply nft command: %s", line)
+                        return False
+
+        target = (
+            state.live_allowed_path(self._state_dir) if accept else state.deny_path(self._state_dir)
+        )
+        _append_unique(target, ip)
+        return True
+
+    def _refresh_domain_cache(self) -> None:
+        """Refresh IP→domain cache from the dnsmasq query log."""
+        log_path = state.dnsmasq_log_path(self._state_dir)
+        if not log_path.is_file():
+            self._last_domain_refresh = time.monotonic()
+            return
+        new_map: dict[str, str] = {}
+        try:
+            for line in log_path.read_text().splitlines():
+                m = _REPLY_RE.search(line)
+                if m:
+                    domain, ip = m.group(1).lower().rstrip("."), m.group(2)
+                    new_map[ip] = domain
+        except OSError:
+            pass
+        else:
+            self._ip_to_domain = new_map
+        self._last_domain_refresh = time.monotonic()
+
+
 # ── Entry point ────────────────────────────────────────
 
 _NSENTER_ENV = "_TEROK_SHIELD_NSENTER"
 
 
 def run_interactive(state_dir: Path, container: str, *, timeout: int = 5) -> None:
-    """Start the interactive NFQUEUE verdict handler.
+    """Start the interactive verdict handler.
 
-    The NFQUEUE socket lives in the container's network namespace, so the
-    handler must run inside it.  On first call (no ``_TEROK_SHIELD_NSENTER``
-    env var) this function re-executes itself under ``podman unshare nsenter``
-    with stdin/stdout passed through for the JSON-lines protocol.  The
-    re-executed process sees the env var and enters the verdict loop directly.
+    Reads the interactive tier from the state dir and dispatches:
+    - **nfqueue**: re-execs under ``nsenter`` into the container's netns,
+      binds an NFQUEUE socket, and holds packets until operator verdict.
+    - **nflog**: runs on the host, reads NFLOG events for rejected packets,
+      and presents them for operator verdict (no kernel module needed).
 
     Args:
         state_dir: Per-container state directory.
         container: Container name.
-        timeout: Seconds before auto-dropping queued packets.
+        timeout: Seconds before auto-dropping queued packets (nfqueue tier only).
 
     Raises:
-        SystemExit: If interactive mode is not enabled or NFQUEUE
-            cannot be bound.
+        SystemExit: If interactive mode is not enabled or handler cannot bind.
     """
     state_dir = state_dir.resolve()
-    if not interactive_path(state_dir).is_file():
+    tier = read_interactive_tier(state_dir)
+    if tier is None:
         print("Error: interactive mode is not enabled for this container.", file=sys.stderr)
         raise SystemExit(1)
 
-    if os.environ.get(_NSENTER_ENV) == "1":
-        _run_verdict_loop(state_dir, container, timeout=timeout)
+    if tier == INTERACTIVE_TIER_NFQUEUE:
+        if os.environ.get(_NSENTER_ENV) == "1":
+            _run_nfqueue_loop(state_dir, container, timeout=timeout)
+        else:
+            _nsenter_reexec(state_dir, container, timeout=timeout)
     else:
-        _nsenter_reexec(state_dir, container, timeout=timeout)
+        _run_nflog_loop(state_dir, container)
 
 
-def _run_verdict_loop(state_dir: Path, container: str, *, timeout: int) -> None:
-    """Run the verdict loop directly (already inside the container netns)."""
+def _run_nfqueue_loop(state_dir: Path, container: str, *, timeout: int) -> None:
+    """Run the NFQUEUE verdict loop (inside container netns)."""
     runner = SubprocessRunner()
     session = InteractiveSession(
         runner=runner,
         state_dir=state_dir,
         container=container,
         timeout=timeout,
+    )
+    session.run()
+
+
+def _run_nflog_loop(state_dir: Path, container: str) -> None:
+    """Run the NFLOG verdict loop (host-side, no nsenter)."""
+    runner = SubprocessRunner()
+    session = NflogInteractiveSession(
+        runner=runner,
+        state_dir=state_dir,
+        container=container,
     )
     session.run()
 
@@ -435,4 +661,4 @@ if __name__ == "__main__":
             file=sys.stderr,
         )
         raise SystemExit(2)
-    _run_verdict_loop(Path(sys.argv[1]), sys.argv[2], timeout=int(sys.argv[3]))
+    _run_nfqueue_loop(Path(sys.argv[1]), sys.argv[2], timeout=int(sys.argv[3]))

--- a/src/terok_shield/interactive.py
+++ b/src/terok_shield/interactive.py
@@ -1,0 +1,340 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Interactive NFQUEUE verdict loop for operator-driven egress control.
+
+Orchestrates :class:`~terok_shield.nfqueue.NfqueueHandler` with state
+persistence, nft set updates, and a bidirectional JSON-lines protocol
+on stdin/stdout for consumer integration.
+
+Protocol::
+
+    Handler → stdout:  {"type":"pending","id":42,"dest":"1.2.3.4","port":443,"proto":6,"domain":"..."}
+    Consumer → stdin:  {"type":"verdict","id":42,"action":"accept"}
+    Handler → stdout:  {"type":"verdict_applied","id":42,"action":"accept","dest":"1.2.3.4"}
+
+Timeout: packets without a verdict within *nfqueue_timeout* seconds are
+auto-dropped (NF_DROP) without persisting to the deny list.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import select
+import signal
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+from . import state
+from .nfqueue import NfqueueHandler, QueuedPacket
+from .nft_constants import NFQUEUE_NUM
+from .run import CommandRunner, SubprocessRunner
+from .state import interactive_path
+
+logger = logging.getLogger(__name__)
+
+# Matches dnsmasq log lines:  "... reply <domain> is <ip>"
+_REPLY_RE = re.compile(r"reply\s+(\S+)\s+is\s+(\S+)")
+
+_running = True
+
+
+def _handle_signal(_signum: int, _frame: object) -> None:
+    """Set the stop flag on SIGINT/SIGTERM."""
+    global _running  # noqa: PLW0603
+    _running = False
+
+
+# ── Pending packet tracking ────────────────────────────
+
+
+@dataclass
+class _PendingPacket:
+    """A queued packet awaiting operator verdict."""
+
+    packet: QueuedPacket
+    queued_at: float
+    domain: str = ""
+
+
+# ── InteractiveSession ─────────────────────────────────
+
+
+class InteractiveSession:
+    """Orchestrates the NFQUEUE verdict loop with I/O and state.
+
+    Reads queued packets from :class:`NfqueueHandler`, enriches them
+    with domain information from the dnsmasq log, emits JSON-lines events
+    to stdout, reads verdict commands from stdin, and issues nft set
+    updates + kernel verdicts.
+    """
+
+    def __init__(
+        self,
+        *,
+        runner: CommandRunner,
+        state_dir: Path,
+        container: str,
+        nfqueue_num: int = NFQUEUE_NUM,
+        timeout: int = 5,
+    ) -> None:
+        """Initialise the session with validated parameters.
+
+        Args:
+            runner: Command runner for nft set modifications.
+            state_dir: Per-container state directory.
+            container: Container name (for nft_via_nsenter).
+            nfqueue_num: NFQUEUE group number to bind.
+            timeout: Seconds before auto-dropping queued packets.
+        """
+        self._runner = runner
+        self._state_dir = state_dir
+        self._container = container
+        self._nfqueue_num = nfqueue_num
+        self._timeout = timeout
+        self._pending: dict[int, _PendingPacket] = {}
+        self._ip_to_domain: dict[str, str] = {}
+
+    def run(self) -> None:
+        """Enter the main verdict loop.
+
+        Blocks until SIGINT/SIGTERM or stdin EOF.  Emits JSON-lines to stdout,
+        reads verdict commands from stdin.
+        """
+        handler = NfqueueHandler.create(self._nfqueue_num)
+        if handler is None:
+            print(
+                "Error: cannot bind to NFQUEUE — check permissions or kernel module.",
+                file=sys.stderr,
+            )
+            raise SystemExit(1)
+
+        # Build initial domain cache from dnsmasq log
+        self._load_domain_cache()
+
+        # Make stdin non-blocking for select()
+        stdin_fd = sys.stdin.fileno()
+        _set_nonblocking(stdin_fd)
+
+        global _running  # noqa: PLW0603
+        _running = True
+        signal.signal(signal.SIGINT, _handle_signal)
+        signal.signal(signal.SIGTERM, _handle_signal)
+
+        try:
+            self._loop(handler, stdin_fd)
+        finally:
+            handler.close()
+
+    def _loop(self, handler: NfqueueHandler, stdin_fd: int) -> None:
+        """Core select() loop: NFQUEUE socket + stdin + timeout sweep."""
+        stdin_buf = ""
+        while _running:
+            readable, _, _ = select.select([handler, stdin_fd], [], [], 1.0)
+
+            # Read queued packets
+            if handler.fileno() in (r if isinstance(r, int) else r.fileno() for r in readable):
+                for pkt in handler.poll():
+                    self._handle_queued(handler, pkt)
+
+            # Read stdin commands
+            if stdin_fd in (r if isinstance(r, int) else r.fileno() for r in readable):
+                stdin_buf = self._read_stdin(handler, stdin_buf)
+                if stdin_buf is None:
+                    break  # stdin closed
+
+            # Sweep timed-out packets
+            self._sweep_timeouts(handler)
+
+    def _handle_queued(self, handler: NfqueueHandler, pkt: QueuedPacket) -> None:
+        """Process a newly queued packet: enrich, emit, track."""
+        domain = self._ip_to_domain.get(pkt.dest, "")
+        pending = _PendingPacket(packet=pkt, queued_at=time.monotonic(), domain=domain)
+        self._pending[pkt.packet_id] = pending
+
+        event = {
+            "type": "pending",
+            "id": pkt.packet_id,
+            "dest": pkt.dest,
+            "port": pkt.port,
+            "proto": pkt.proto,
+        }
+        if domain:
+            event["domain"] = domain
+        print(json.dumps(event, separators=(",", ":")), flush=True)
+
+    def _read_stdin(self, handler: NfqueueHandler, buf: str) -> str | None:
+        """Read available stdin data and process complete JSON lines.
+
+        Returns updated buffer, or ``None`` if stdin was closed.
+        """
+        try:
+            chunk = os.read(sys.stdin.fileno(), 4096).decode()
+        except OSError:
+            return buf
+        if not chunk:
+            return None  # EOF
+
+        buf += chunk
+        while "\n" in buf:
+            line, buf = buf.split("\n", 1)
+            line = line.strip()
+            if line:
+                self._process_command(handler, line)
+        return buf
+
+    def _process_command(self, handler: NfqueueHandler, line: str) -> None:
+        """Parse and execute a single JSON verdict command."""
+        try:
+            cmd = json.loads(line)
+        except json.JSONDecodeError:
+            logger.warning("Ignoring invalid JSON on stdin")
+            return
+
+        if not isinstance(cmd, dict) or cmd.get("type") != "verdict":
+            return
+
+        packet_id = cmd.get("id")
+        action = cmd.get("action", "").lower()
+        if packet_id is None or action not in ("accept", "deny"):
+            return
+
+        pending = self._pending.pop(packet_id, None)
+        if pending is None:
+            return  # already timed out or unknown
+
+        accept = action == "accept"
+        handler.verdict(pending.packet.packet_id, accept=accept)
+        self._apply_verdict(pending, accept=accept)
+
+        result = {
+            "type": "verdict_applied",
+            "id": packet_id,
+            "action": action,
+            "dest": pending.packet.dest,
+        }
+        if pending.domain:
+            result["domain"] = pending.domain
+        print(json.dumps(result, separators=(",", ":")), flush=True)
+
+    def _apply_verdict(self, pending: _PendingPacket, *, accept: bool) -> None:
+        """Persist the verdict to nft sets and state files."""
+        ip = pending.packet.dest
+        if accept:
+            # Add to allow set + persist to live.allowed
+            from .nft import add_elements_dual
+
+            nft_cmd = add_elements_dual([ip])
+            if nft_cmd:
+                self._nft_apply(nft_cmd)
+            _append_unique(state.live_allowed_path(self._state_dir), ip)
+        else:
+            # Add to deny set + persist to deny.list
+            from .nft import add_deny_elements_dual
+
+            nft_cmd = add_deny_elements_dual([ip])
+            if nft_cmd:
+                self._nft_apply(nft_cmd)
+            _append_unique(state.deny_path(self._state_dir), ip)
+
+    def _nft_apply(self, nft_cmd: str) -> None:
+        """Apply nft commands via nsenter into the container's netns."""
+        for line in nft_cmd.strip().splitlines():
+            parts = line.strip().split()
+            if parts:
+                try:
+                    self._runner.nft_via_nsenter(self._container, *parts)
+                except Exception:
+                    logger.warning("Failed to apply nft command: %s", line)
+
+    def _sweep_timeouts(self, handler: NfqueueHandler) -> None:
+        """Drop packets that have exceeded the verdict timeout."""
+        now = time.monotonic()
+        expired = [
+            pid for pid, p in self._pending.items() if now - p.queued_at > self._timeout
+        ]
+        for pid in expired:
+            pending = self._pending.pop(pid)
+            handler.verdict(pending.packet.packet_id, accept=False)
+            event = {
+                "type": "verdict_timeout",
+                "id": pid,
+                "dest": pending.packet.dest,
+                "port": pending.packet.port,
+            }
+            if pending.domain:
+                event["domain"] = pending.domain
+            print(json.dumps(event, separators=(",", ":")), flush=True)
+
+    def _load_domain_cache(self) -> None:
+        """Build IP→domain cache from the dnsmasq query log.
+
+        Parses ``reply`` lines to map resolved IPs back to domain names.
+        """
+        log_path = state.dnsmasq_log_path(self._state_dir)
+        if not log_path.is_file():
+            return
+        try:
+            for line in log_path.read_text().splitlines():
+                m = _REPLY_RE.search(line)
+                if m:
+                    domain, ip = m.group(1).lower().rstrip("."), m.group(2)
+                    self._ip_to_domain[ip] = domain
+        except OSError:
+            pass
+
+
+# ── Helpers ────────────────────────────────────────────
+
+
+def _set_nonblocking(fd: int) -> None:
+    """Set a file descriptor to non-blocking mode."""
+    import fcntl
+
+    flags = fcntl.fcntl(fd, fcntl.F_GETFL)
+    fcntl.fcntl(fd, fcntl.F_SETFL, flags | os.O_NONBLOCK)
+
+
+def _append_unique(path: Path, value: str) -> None:
+    """Append *value* to a newline-separated file if not already present."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    existing = set(path.read_text().splitlines()) if path.is_file() else set()
+    if value not in existing:
+        with path.open("a") as f:
+            f.write(f"{value}\n")
+
+
+# ── Entry point ────────────────────────────────────────
+
+
+def run_interactive(state_dir: Path, container: str) -> None:
+    """Start the interactive NFQUEUE verdict handler.
+
+    Validates that interactive mode is enabled for this container,
+    then enters the verdict loop.  Blocks until SIGINT/SIGTERM or
+    stdin EOF.
+
+    Args:
+        state_dir: Per-container state directory.
+        container: Container name.
+
+    Raises:
+        SystemExit: If interactive mode is not enabled or NFQUEUE
+            cannot be bound.
+    """
+    if not interactive_path(state_dir).is_file():
+        print("Error: interactive mode is not enabled for this container.", file=sys.stderr)
+        raise SystemExit(1)
+
+    runner = SubprocessRunner()
+    session = InteractiveSession(
+        runner=runner,
+        state_dir=state_dir,
+        container=container,
+    )
+    session.run()

--- a/src/terok_shield/interactive.py
+++ b/src/terok_shield/interactive.py
@@ -118,10 +118,7 @@ class InteractiveSession:
             )
             raise SystemExit(1)
 
-        # Build initial domain cache from dnsmasq log
         self._refresh_domain_cache()
-
-        # Make stdin non-blocking for select()
         stdin_fd = sys.stdin.fileno()
         _set_nonblocking(stdin_fd)
 
@@ -133,31 +130,48 @@ class InteractiveSession:
         try:
             self._loop(handler, stdin_fd)
         finally:
+            self._drain_pending(handler)
             handler.close()
+
+    def _drain_pending(self, handler: NfqueueHandler) -> None:
+        """Reject all remaining pending packets on shutdown."""
+        for _pid, pending in self._pending.items():
+            handler.verdict(pending.packet.packet_id, accept=False)
+        self._pending.clear()
 
     def _loop(self, handler: NfqueueHandler, stdin_fd: int) -> None:
         """Core select() loop: NFQUEUE socket + stdin + timeout sweep."""
         stdin_buf = ""
         while _running:
-            readable, _, _ = select.select([handler, stdin_fd], [], [], 1.0)
-
-            # Read queued packets
-            if handler.fileno() in (r if isinstance(r, int) else r.fileno() for r in readable):
-                for pkt in handler.poll():
-                    self._handle_queued(pkt)
-
-            # Read stdin commands
-            if stdin_fd in (r if isinstance(r, int) else r.fileno() for r in readable):
-                stdin_buf = self._read_stdin(handler, stdin_buf)
-                if stdin_buf is None:
-                    break  # stdin closed
-
-            # Sweep timed-out packets
+            readable = self._select_readable(handler, stdin_fd)
+            self._poll_nfqueue(handler, readable)
+            stdin_buf = self._poll_stdin(handler, stdin_buf, readable)
+            if stdin_buf is None:
+                break
             self._sweep_timeouts(handler)
+            self._maybe_refresh_domains()
 
-            # Periodically refresh domain cache
-            if time.monotonic() - self._last_domain_refresh > _DOMAIN_REFRESH_INTERVAL:
-                self._refresh_domain_cache()
+    def _select_readable(self, handler: NfqueueHandler, stdin_fd: int) -> set[int]:
+        """Run select() and return a set of ready file descriptors."""
+        readable, _, _ = select.select([handler, stdin_fd], [], [], 1.0)
+        return {r if isinstance(r, int) else r.fileno() for r in readable}
+
+    def _poll_nfqueue(self, handler: NfqueueHandler, ready: set[int]) -> None:
+        """Read queued packets if the NFQUEUE socket is ready."""
+        if handler.fileno() in ready:
+            for pkt in handler.poll():
+                self._handle_queued(pkt)
+
+    def _poll_stdin(self, handler: NfqueueHandler, buf: str, ready: set[int]) -> str | None:
+        """Read and process stdin commands if stdin is ready."""
+        if sys.stdin.fileno() not in ready:
+            return buf
+        return self._read_stdin(handler, buf)
+
+    def _maybe_refresh_domains(self) -> None:
+        """Refresh domain cache if the refresh interval has elapsed."""
+        if time.monotonic() - self._last_domain_refresh > _DOMAIN_REFRESH_INTERVAL:
+            self._refresh_domain_cache()
 
     def _handle_queued(self, pkt: QueuedPacket) -> None:
         """Process a newly queued packet: enrich, emit, track."""
@@ -165,7 +179,7 @@ class InteractiveSession:
         pending = _PendingPacket(packet=pkt, queued_at=time.monotonic(), domain=domain)
         self._pending[pkt.packet_id] = pending
 
-        event = {
+        event: dict = {
             "type": "pending",
             "id": pkt.packet_id,
             "dest": pkt.dest,
@@ -223,10 +237,10 @@ class InteractiveSession:
 
         accept = action == "accept"
         handler.verdict(pending.packet.packet_id, accept=accept)
-        self._apply_verdict(pending, accept=accept)
+        ok = self._apply_verdict(pending, accept=accept)
 
-        result = {
-            "type": "verdict_applied",
+        result: dict = {
+            "type": "verdict_applied" if ok else "verdict_failed",
             "id": packet_id,
             "action": action,
             "dest": pending.packet.dest,
@@ -235,26 +249,32 @@ class InteractiveSession:
             result["domain"] = pending.domain
         print(json.dumps(result, separators=(",", ":")), flush=True)
 
-    def _apply_verdict(self, pending: _PendingPacket, *, accept: bool) -> None:
-        """Persist the verdict to nft sets and state files."""
+    def _apply_verdict(self, pending: _PendingPacket, *, accept: bool) -> bool:
+        """Persist the verdict to nft sets and state files.
+
+        Returns True on success, False if the nft update failed.
+        """
         ip = pending.packet.dest
         if accept:
             from .nft import add_elements_dual
 
             nft_cmd = add_elements_dual([ip])
-            if nft_cmd:
-                self._nft_apply(nft_cmd)
-            _append_unique(state.live_allowed_path(self._state_dir), ip)
         else:
             from .nft import add_deny_elements_dual
 
             nft_cmd = add_deny_elements_dual([ip])
-            if nft_cmd:
-                self._nft_apply(nft_cmd)
-            _append_unique(state.deny_path(self._state_dir), ip)
 
-    def _nft_apply(self, nft_cmd: str) -> None:
-        """Apply nft commands via nsenter into the container's netns."""
+        if nft_cmd and not self._nft_apply(nft_cmd):
+            return False
+
+        target = (
+            state.live_allowed_path(self._state_dir) if accept else state.deny_path(self._state_dir)
+        )
+        _append_unique(target, ip)
+        return True
+
+    def _nft_apply(self, nft_cmd: str) -> bool:
+        """Apply nft commands via nsenter.  Returns True on success."""
         for line in nft_cmd.strip().splitlines():
             parts = line.strip().split()
             if parts:
@@ -262,6 +282,8 @@ class InteractiveSession:
                     self._runner.nft_via_nsenter(self._container, *parts)
                 except Exception:
                     logger.warning("Failed to apply nft command: %s", line)
+                    return False
+        return True
 
     def _sweep_timeouts(self, handler: NfqueueHandler) -> None:
         """Drop packets that have exceeded the verdict timeout."""
@@ -270,7 +292,7 @@ class InteractiveSession:
         for pid in expired:
             pending = self._pending.pop(pid)
             handler.verdict(pending.packet.packet_id, accept=False)
-            event = {
+            event: dict = {
                 "type": "verdict_timeout",
                 "id": pid,
                 "dest": pending.packet.dest,
@@ -283,20 +305,23 @@ class InteractiveSession:
     def _refresh_domain_cache(self) -> None:
         """Refresh IP→domain cache from the dnsmasq query log.
 
-        Parses ``reply`` lines to map resolved IPs back to domain names.
-        Called periodically so long-running sessions learn new DNS replies.
+        Builds a fresh cache on each call so log rotation doesn't leave
+        stale entries.  Called periodically during the select loop.
         """
         log_path = state.dnsmasq_log_path(self._state_dir)
         if not log_path.is_file():
+            self._last_domain_refresh = time.monotonic()
             return
+        new_map: dict[str, str] = {}
         try:
             for line in log_path.read_text().splitlines():
                 m = _REPLY_RE.search(line)
                 if m:
                     domain, ip = m.group(1).lower().rstrip("."), m.group(2)
-                    self._ip_to_domain[ip] = domain
+                    new_map[ip] = domain
         except OSError:
             pass
+        self._ip_to_domain = new_map
         self._last_domain_refresh = time.monotonic()
 
 

--- a/src/terok_shield/interactive.py
+++ b/src/terok_shield/interactive.py
@@ -258,7 +258,7 @@ class InteractiveSession:
         if accept:
             from .nft import add_elements_dual
 
-            nft_cmd = add_elements_dual([ip])
+            nft_cmd = add_elements_dual([ip], permanent=True)
         else:
             from .nft import add_deny_elements_dual
 
@@ -365,6 +365,7 @@ def run_interactive(state_dir: Path, container: str, *, timeout: int = 5) -> Non
         SystemExit: If interactive mode is not enabled or NFQUEUE
             cannot be bound.
     """
+    state_dir = state_dir.resolve()
     if not interactive_path(state_dir).is_file():
         print("Error: interactive mode is not enabled for this container.", file=sys.stderr)
         raise SystemExit(1)

--- a/src/terok_shield/mode_hook.py
+++ b/src/terok_shield/mode_hook.py
@@ -481,6 +481,16 @@ class HookMode:
         """Return the resolved path to live.allowed (prevents path traversal)."""
         return state.live_allowed_path(self._config.state_dir).resolve()
 
+    def _nft_apply_best_effort(self, container: str, nft_cmd: str) -> None:
+        """Run multi-line nft commands via nsenter, swallowing errors."""
+        for line in nft_cmd.strip().splitlines():
+            parts = line.strip().split()
+            if parts:
+                try:
+                    self._runner.nft_via_nsenter(container, *parts)
+                except ExecError:
+                    pass
+
     def allow_ip(self, container: str, ip: str) -> None:
         """Live-allow an IP for a running container via nsenter."""
         ip = safe_ip(ip)
@@ -493,16 +503,9 @@ class HookMode:
             if ip in denied:
                 denied.discard(ip)
                 dp.write_text("".join(f"{d}\n" for d in sorted(denied)))
-                # Remove from nft deny set (best-effort)
                 nft_cmd = delete_deny_elements_dual([ip])
                 if nft_cmd:
-                    for line in nft_cmd.strip().splitlines():
-                        parts = line.strip().split()
-                        if parts:
-                            try:
-                                self._runner.nft_via_nsenter(container, *parts)
-                            except ExecError:
-                                pass
+                    self._nft_apply_best_effort(container, nft_cmd)
 
         # When the dnsmasq set has a default timeout (30 m), permanent IPs must use
         # 'timeout 0s' so they are never evicted by the set's per-element expiry clock.
@@ -567,13 +570,7 @@ class HookMode:
         # Add to nft deny set (prevents dnsmasq from re-allowing)
         nft_cmd = add_deny_elements_dual([ip])
         if nft_cmd:
-            for line in nft_cmd.strip().splitlines():
-                parts = line.strip().split()
-                if parts:
-                    try:
-                        self._runner.nft_via_nsenter(container, *parts)
-                    except ExecError:
-                        pass  # best-effort
+            self._nft_apply_best_effort(container, nft_cmd)
 
         # Persist to deny.list so deny sets survive shield_up / restart.
         # In interactive mode: always persist (operator rejects must stick).
@@ -582,15 +579,12 @@ class HookMode:
         should_persist = state.interactive_path(sd).is_file()
         if not should_persist:
             profile_path = state.profile_allowed_path(sd)
-            if profile_path.is_file():
-                profile_ips = {
-                    line.strip() for line in profile_path.read_text().splitlines() if line.strip()
-                }
-                should_persist = ip in profile_ips
+            should_persist = profile_path.is_file() and ip in {
+                ln.strip() for ln in profile_path.read_text().splitlines() if ln.strip()
+            }
         if should_persist:
             dp = state.deny_path(sd)
-            existing = state.read_denied_ips(sd)
-            if ip not in existing:
+            if ip not in state.read_denied_ips(sd):
                 with dp.open("a") as f:
                     f.write(f"{ip}\n")
 

--- a/src/terok_shield/mode_hook.py
+++ b/src/terok_shield/mode_hook.py
@@ -575,18 +575,24 @@ class HookMode:
                     except ExecError:
                         pass  # best-effort
 
-        # Persist to deny.list if IP is in profile.allowed
-        profile_path = state.profile_allowed_path(sd)
-        if profile_path.is_file():
-            profile_ips = {
-                line.strip() for line in profile_path.read_text().splitlines() if line.strip()
-            }
-            if ip in profile_ips:
-                dp = state.deny_path(sd)
-                existing = state.read_denied_ips(sd)
-                if ip not in existing:
-                    with dp.open("a") as f:
-                        f.write(f"{ip}\n")
+        # Persist to deny.list so deny sets survive shield_up / restart.
+        # In interactive mode: always persist (operator rejects must stick).
+        # In strict mode: only persist when the IP came from a profile
+        # (non-profile IPs are already blocked by the default-deny rule).
+        should_persist = self._config.interactive
+        if not should_persist:
+            profile_path = state.profile_allowed_path(sd)
+            if profile_path.is_file():
+                profile_ips = {
+                    line.strip() for line in profile_path.read_text().splitlines() if line.strip()
+                }
+                should_persist = ip in profile_ips
+        if should_persist:
+            dp = state.deny_path(sd)
+            existing = state.read_denied_ips(sd)
+            if ip not in existing:
+                with dp.open("a") as f:
+                    f.write(f"{ip}\n")
 
     def allow_domain(self, domain: str) -> None:
         """Add a domain to the dnsmasq config and signal reload.

--- a/src/terok_shield/mode_hook.py
+++ b/src/terok_shield/mode_hook.py
@@ -26,6 +26,7 @@ from . import dnsmasq, state
 from .config import (
     ANNOTATION_AUDIT_ENABLED_KEY,
     ANNOTATION_DNS_TIER_KEY,
+    ANNOTATION_INTERACTIVE_KEY,
     ANNOTATION_KEY,
     ANNOTATION_LOOPBACK_PORTS_KEY,
     ANNOTATION_NAME_KEY,
@@ -37,7 +38,13 @@ from .config import (
     ShieldState,
     detect_dns_tier,
 )
-from .nft import NFT_TABLE, RulesetBuilder, safe_ip
+from .nft import (
+    NFT_TABLE,
+    RulesetBuilder,
+    add_deny_elements_dual,
+    delete_deny_elements_dual,
+    safe_ip,
+)
 from .nft_constants import (
     NFT_SET_TIMEOUT_DNSMASQ,
     PASTA_DNS,
@@ -308,15 +315,25 @@ class HookMode:
 
         # Pre-generate complete nft ruleset (gateway sets start empty; hook populates them)
         set_timeout = NFT_SET_TIMEOUT_DNSMASQ if tier == DnsTier.DNSMASQ else ""
+        interactive = self._config.interactive
         ruleset_builder = RulesetBuilder(
             dns=upstream_dns,
             loopback_ports=self._config.loopback_ports,
             set_timeout=set_timeout,
         )
         ips = state.read_effective_ips(sd)
-        state.ruleset_path(sd).write_text(
-            ruleset_builder.build_hook() + ruleset_builder.add_elements_dual(ips)
-        )
+        denied_ips = list(state.read_denied_ips(sd))
+        ruleset = ruleset_builder.build_hook(interactive=interactive)
+        ruleset += ruleset_builder.add_elements_dual(ips)
+        if denied_ips:
+            ruleset += add_deny_elements_dual(denied_ips)
+        state.ruleset_path(sd).write_text(ruleset)
+
+        # Persist interactive mode flag for shield_up() and the verdict handler
+        if interactive:
+            state.interactive_path(sd).write_text("1\n")
+        else:
+            state.interactive_path(sd).unlink(missing_ok=True)
 
         # Pre-generate dnsmasq config if using dnsmasq tier; otherwise scrub
         # stale artifacts so hook_entrypoint.py does not launch dnsmasq when
@@ -410,6 +427,8 @@ class HookMode:
             f"{ANNOTATION_UPSTREAM_DNS_KEY}={upstream_dns}",
             "--annotation",
             f"{ANNOTATION_DNS_TIER_KEY}={tier.value}",
+            "--annotation",
+            f"{ANNOTATION_INTERACTIVE_KEY}={str(interactive).lower()}",
         ]
 
         # Hooks dir: per-container on modern podman, global on old podman
@@ -466,7 +485,7 @@ class HookMode:
         """Live-allow an IP for a running container via nsenter."""
         ip = safe_ip(ip)
 
-        # Un-deny: remove from deny.list if present
+        # Un-deny: remove from deny.list and nft deny set if present
         sd = self._config.state_dir.resolve()
         dp = state.deny_path(sd)
         if dp.is_file():
@@ -474,6 +493,16 @@ class HookMode:
             if ip in denied:
                 denied.discard(ip)
                 dp.write_text("".join(f"{d}\n" for d in sorted(denied)))
+                # Remove from nft deny set (best-effort)
+                nft_cmd = delete_deny_elements_dual([ip])
+                if nft_cmd:
+                    for line in nft_cmd.strip().splitlines():
+                        parts = line.strip().split()
+                        if parts:
+                            try:
+                                self._runner.nft_via_nsenter(container, *parts)
+                            except ExecError:
+                                pass
 
         # When the dnsmasq set has a default timeout (30 m), permanent IPs must use
         # 'timeout 0s' so they are never evicted by the set's per-element expiry clock.
@@ -534,6 +563,17 @@ class HookMode:
             lines = live_path.read_text().splitlines()
             lines = [line for line in lines if line.strip() != ip]
             live_path.write_text("\n".join(lines) + "\n" if lines else "")
+
+        # Add to nft deny set (prevents dnsmasq from re-allowing)
+        nft_cmd = add_deny_elements_dual([ip])
+        if nft_cmd:
+            for line in nft_cmd.strip().splitlines():
+                parts = line.strip().split()
+                if parts:
+                    try:
+                        self._runner.nft_via_nsenter(container, *parts)
+                    except ExecError:
+                        pass  # best-effort
 
         # Persist to deny.list if IP is in profile.allowed
         profile_path = state.profile_allowed_path(sd)
@@ -688,8 +728,11 @@ class HookMode:
 
     def shield_up(self, container: str) -> None:
         """Restore normal deny-all mode for a running container."""
+        sd = self._config.state_dir.resolve()
+        interactive = state.interactive_path(sd).is_file()
+
         ruleset = self._container_ruleset(container)
-        rs = ruleset.build_hook()
+        rs = ruleset.build_hook(interactive=interactive)
         current = self.shield_state(container)
         if current == ShieldState.INACTIVE:
             stdin = rs
@@ -698,13 +741,18 @@ class HookMode:
         self._runner.nft_via_nsenter(container, stdin=stdin)
 
         # Re-add effective IPs (allowed minus denied)
-        sd = self._config.state_dir.resolve()
         unique_ips = state.read_effective_ips(sd)
-
         if unique_ips:
             elements_cmd = ruleset.add_elements_dual(unique_ips)
             if elements_cmd:
                 self._runner.nft_via_nsenter(container, stdin=elements_cmd)
+
+        # Repopulate deny sets from deny.list
+        denied_ips = list(state.read_denied_ips(sd))
+        if denied_ips:
+            deny_cmd = add_deny_elements_dual(denied_ips)
+            if deny_cmd:
+                self._runner.nft_via_nsenter(container, stdin=deny_cmd)
 
         # Repopulate gateway sets from persisted discovery (hook wrote them at container start)
         for gw_path, set_name in (
@@ -725,7 +773,7 @@ class HookMode:
                     )
 
         output = self._runner.nft_via_nsenter(container, "list", "ruleset")
-        errors = ruleset.verify_hook(output)
+        errors = ruleset.verify_hook(output, interactive=interactive)
         if errors:
             raise RuntimeError(f"Ruleset verification failed: {'; '.join(errors)}")
 
@@ -741,7 +789,10 @@ class HookMode:
         if not self._ruleset.verify_bypass(output, allow_all=True):
             return ShieldState.DOWN_ALL
 
+        # Check both strict and interactive hook rulesets
         if not self._ruleset.verify_hook(output):
+            return ShieldState.UP
+        if not self._ruleset.verify_hook(output, interactive=True):
             return ShieldState.UP
 
         return ShieldState.ERROR
@@ -750,4 +801,4 @@ class HookMode:
         """Generate the ruleset that would be applied to a container."""
         if down:
             return self._ruleset.build_bypass(allow_all=allow_all)
-        return self._ruleset.build_hook()
+        return self._ruleset.build_hook(interactive=self._config.interactive)

--- a/src/terok_shield/mode_hook.py
+++ b/src/terok_shield/mode_hook.py
@@ -63,6 +63,33 @@ from .util import is_ip as _is_ip, is_ipv4
 
 logger = logging.getLogger(__name__)
 
+# ── Interactive tier detection ────────────────────────
+
+
+INTERACTIVE_TIER_NFQUEUE = "nfqueue"
+INTERACTIVE_TIER_NFLOG = "nflog"
+
+
+def _nfqueue_kernel_support() -> bool:
+    """Check if the kernel supports NFQUEUE (module loaded or built-in).
+
+    Reads ``/proc/modules`` and ``modules.builtin`` — pure read-only,
+    no root needed.  Returns ``False`` when support cannot be confirmed.
+    """
+    try:
+        if "nfnetlink_queue" in Path("/proc/modules").read_text():
+            return True
+    except OSError:
+        pass
+    try:
+        release = os.uname().release
+        builtins = Path("/lib/modules", release, "modules.builtin").read_text()
+        return "nfnetlink_queue" in builtins
+    except OSError:
+        pass
+    return False
+
+
 if TYPE_CHECKING:
     from .audit import AuditLogger
     from .dns import DnsResolver
@@ -323,15 +350,26 @@ class HookMode:
         )
         ips = state.read_effective_ips(sd)
         denied_ips = list(state.read_denied_ips(sd))
-        ruleset = ruleset_builder.build_hook(interactive=interactive)
+        # Detect interactive tier: prefer NFQUEUE (packet queuing) but fall
+        # back to NFLOG+reject when the kernel module is unavailable.
+        use_nfqueue = interactive and _nfqueue_kernel_support()
+        if interactive and not use_nfqueue:
+            logger.warning(
+                "nfnetlink_queue kernel module not available — "
+                "interactive mode will use NFLOG (reject + log) instead of NFQUEUE"
+            )
+
+        ruleset = ruleset_builder.build_hook(interactive=interactive, nfqueue=use_nfqueue)
         ruleset += ruleset_builder.add_elements_dual(ips)
         if denied_ips:
             ruleset += add_deny_elements_dual(denied_ips)
         state.ruleset_path(sd).write_text(ruleset)
 
-        # Persist interactive mode flag for shield_up() and the verdict handler
+        # Persist interactive tier for shield_up() and the verdict handler.
+        # "nfqueue" or "nflog" — handler reads this to choose its socket type.
         if interactive:
-            state.interactive_path(sd).write_text("1\n")
+            tier_value = INTERACTIVE_TIER_NFQUEUE if use_nfqueue else INTERACTIVE_TIER_NFLOG
+            state.interactive_path(sd).write_text(f"{tier_value}\n")
         else:
             state.interactive_path(sd).unlink(missing_ok=True)
 
@@ -729,10 +767,12 @@ class HookMode:
     def shield_up(self, container: str) -> None:
         """Restore normal deny-all mode for a running container."""
         sd = self._config.state_dir.resolve()
-        interactive = state.interactive_path(sd).is_file()
+        interactive_tier = state.read_interactive_tier(sd)
+        interactive = interactive_tier is not None
 
         ruleset = self._container_ruleset(container)
-        rs = ruleset.build_hook(interactive=interactive)
+        use_nfqueue = interactive_tier == INTERACTIVE_TIER_NFQUEUE
+        rs = ruleset.build_hook(interactive=interactive, nfqueue=use_nfqueue)
         current = self.shield_state(container)
         if current == ShieldState.INACTIVE:
             stdin = rs
@@ -801,4 +841,6 @@ class HookMode:
         """Generate the ruleset that would be applied to a container."""
         if down:
             return self._ruleset.build_bypass(allow_all=allow_all)
-        return self._ruleset.build_hook(interactive=self._config.interactive)
+        interactive = self._config.interactive
+        use_nfqueue = interactive and _nfqueue_kernel_support()
+        return self._ruleset.build_hook(interactive=interactive, nfqueue=use_nfqueue)

--- a/src/terok_shield/mode_hook.py
+++ b/src/terok_shield/mode_hook.py
@@ -579,7 +579,7 @@ class HookMode:
         # In interactive mode: always persist (operator rejects must stick).
         # In strict mode: only persist when the IP came from a profile
         # (non-profile IPs are already blocked by the default-deny rule).
-        should_persist = self._config.interactive
+        should_persist = state.interactive_path(sd).is_file()
         if not should_persist:
             profile_path = state.profile_allowed_path(sd)
             if profile_path.is_file():

--- a/src/terok_shield/netlink.py
+++ b/src/terok_shield/netlink.py
@@ -1,0 +1,96 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared netlink and IP packet parsing utilities.
+
+Stdlib-only module used by both :mod:`watch` (NFLOG) and :mod:`nfqueue`
+(NFQUEUE) to extract destination address, protocol, and port from raw
+IP packets delivered via ``AF_NETLINK``.
+"""
+
+import socket
+import struct
+
+# ── IP protocol numbers ────────────────────────────────
+
+IPPROTO_TCP = 6
+IPPROTO_UDP = 17
+
+# ── Netlink / nfnetlink struct formats ─────────────────
+
+# Netlink message header: length(4) + type(2) + flags(2) + seq(4) + pid(4)
+NLMSG_HDR = struct.Struct("=IHHII")
+# nfgenmsg: family(1) + version(1) + res_id(2)
+NFGEN_HDR = struct.Struct("=BBH")
+# nflog/nfqueue TLV attribute header: length(2) + type(2)
+NFA_HDR = struct.Struct("=HH")
+
+NLM_F_REQUEST = 1
+NLM_F_ACK = 4
+AF_INET = 2
+
+# Netlink netfilter protocol number
+NETLINK_NETFILTER = 12
+
+
+# ── Packet parsing ─────────────────────────────────────
+
+
+def extract_ip_dest(payload: bytes) -> tuple[str, int, int]:
+    """Extract destination IP, protocol, and port from a raw IP packet.
+
+    Handles both IPv4 and IPv6 headers as delivered by nflog/nfqueue
+    in ``inet`` family tables.
+
+    Returns:
+        Tuple of ``(dest_ip, protocol_number, dest_port)``.
+        Returns ``("", 0, 0)`` if the packet cannot be parsed.
+    """
+    if len(payload) < 20:
+        return ("", 0, 0)
+    version = (payload[0] >> 4) & 0xF
+    if version == 6:
+        return _extract_ipv6_dest(payload)
+    if version != 4:
+        return ("", 0, 0)
+    ihl = (payload[0] & 0xF) * 4
+    if ihl < 20:
+        return ("", 0, 0)
+    proto = payload[9]
+    dest = socket.inet_ntop(socket.AF_INET, payload[16:20])
+    port = 0
+    if proto in (IPPROTO_TCP, IPPROTO_UDP) and len(payload) >= ihl + 4:
+        port = struct.unpack_from("!H", payload, ihl + 2)[0]  # dest port
+    return (dest, proto, port)
+
+
+def _extract_ipv6_dest(payload: bytes) -> tuple[str, int, int]:
+    """Extract destination from an IPv6 packet (40-byte header minimum)."""
+    if len(payload) < 40:
+        return ("", 0, 0)
+    dest = socket.inet_ntop(socket.AF_INET6, payload[24:40])
+    proto = payload[6]  # Next Header
+    port = 0
+    if proto in (IPPROTO_TCP, IPPROTO_UDP) and len(payload) >= 44:
+        port = struct.unpack_from("!H", payload, 42)[0]  # dest port
+    return (dest, proto, port)
+
+
+def parse_nflog_attrs(data: bytes) -> dict[int, bytes]:
+    """Parse TLV attributes from an nflog/nfqueue packet message.
+
+    Returns a dict mapping attribute type to raw attribute value bytes.
+    Attribute types are masked to strip nested/byteorder flags.
+    """
+    attrs: dict[int, bytes] = {}
+    offset = 0
+    while offset + NFA_HDR.size <= len(data):
+        nfa_len, nfa_type = NFA_HDR.unpack_from(data, offset)
+        if nfa_len < NFA_HDR.size:
+            break
+        nfa_type &= 0x7FFF
+        value = data[offset + NFA_HDR.size : offset + nfa_len]
+        attrs[nfa_type] = value
+        # Attributes are 4-byte aligned
+        offset += (nfa_len + 3) & ~3
+    return attrs

--- a/src/terok_shield/netlink.py
+++ b/src/terok_shield/netlink.py
@@ -65,7 +65,11 @@ def extract_ip_dest(payload: bytes) -> tuple[str, int, int]:
 
 
 def _extract_ipv6_dest(payload: bytes) -> tuple[str, int, int]:
-    """Extract destination from an IPv6 packet (40-byte header minimum)."""
+    """Extract destination from an IPv6 packet (40-byte header minimum).
+
+    Does not traverse extension headers.  If Next Header indicates an
+    extension header rather than TCP/UDP, port will be reported as 0.
+    """
     if len(payload) < 40:
         return ("", 0, 0)
     dest = socket.inet_ntop(socket.AF_INET6, payload[24:40])

--- a/src/terok_shield/nfqueue.py
+++ b/src/terok_shield/nfqueue.py
@@ -1,0 +1,284 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""NFQUEUE netlink handler for interactive egress control.
+
+Mirrors the :class:`~terok_shield.watch.NflogWatcher` pattern but uses
+the kernel's NFQUEUE subsystem to intercept packets and issue verdicts
+(accept/drop) rather than just observing copies.
+
+Stdlib-only — no external dependencies.  Uses raw ``AF_NETLINK`` sockets
+with the ``NETLINK_NETFILTER`` protocol, speaking the ``nfnetlink_queue``
+wire format directly.
+"""
+
+from __future__ import annotations
+
+import logging
+import socket
+import struct
+from dataclasses import dataclass
+
+from .netlink import (
+    AF_INET,
+    NETLINK_NETFILTER,
+    NFA_HDR,
+    NFGEN_HDR,
+    NLM_F_ACK,
+    NLM_F_REQUEST,
+    NLMSG_HDR,
+    extract_ip_dest,
+    parse_nflog_attrs,
+)
+from .nft_constants import NFQUEUE_NUM
+
+logger = logging.getLogger(__name__)
+
+# ── NFQUEUE netlink constants ──────────────────────────
+
+# nfnetlink subsystem for queues
+_NFNL_SUBSYS_QUEUE = 1
+
+# nfqueue message types
+_NFQNL_MSG_PACKET = 0  # kernel → userspace: queued packet
+_NFQNL_MSG_VERDICT = 1  # userspace → kernel: verdict
+_NFQNL_MSG_CONFIG = 2  # configuration message
+
+# nfqueue config commands
+_NFQNL_CFG_CMD_BIND = 1
+_NFQNL_CFG_CMD_UNBIND = 2
+_NFQNL_CFG_CMD_PF_BIND = 3
+_NFQNL_CFG_CMD_PF_UNBIND = 4
+
+# nfqueue attribute types
+_NFQA_PACKET_HDR = 1  # contains packet_id, hw_protocol, hook
+_NFQA_VERDICT_HDR = 2  # verdict: verdict(4) + id(4)
+_NFQA_MARK = 3
+_NFQA_TIMESTAMP = 4
+_NFQA_IFINDEX_INDEV = 5
+_NFQA_IFINDEX_OUTDEV = 6
+_NFQA_IFINDEX_PHYSINDEV = 7
+_NFQA_IFINDEX_PHYSOUTDEV = 8
+_NFQA_HWADDR = 9
+_NFQA_PAYLOAD = 10  # raw packet payload
+_NFQA_CFG_CMD = 11  # config command
+_NFQA_CFG_PARAMS = 12  # config params (copy_range, copy_mode)
+
+# nfqueue config copy modes
+_NFQNL_COPY_PACKET = 2  # copy full packet payload to userspace
+
+# nfqueue verdicts
+NF_DROP = 0
+NF_ACCEPT = 1
+
+# nfqueue config command struct: command(1) + pad(1) + pf(2)
+_NFQNL_CFG_CMD_STRUCT = struct.Struct("=BBH")
+# nfqueue config params struct: copy_range(4) + copy_mode(1) + pad(3)
+_NFQNL_CFG_PARAMS = struct.Struct("!IBxxx")
+# nfqueue packet header struct: packet_id(4) + hw_protocol(2) + hook(1) + pad(1)
+_NFQNL_PACKET_HDR = struct.Struct("!IHBx")
+# nfqueue verdict header struct: verdict(4) + id(4)
+_NFQNL_VERDICT_HDR = struct.Struct("!II")
+
+
+# ── Data types ─────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class QueuedPacket:
+    """A packet intercepted by NFQUEUE awaiting a verdict.
+
+    Attributes:
+        packet_id: Kernel-assigned ID used to issue the verdict.
+        dest: Destination IP address (IPv4 or IPv6).
+        port: Destination port (0 if not TCP/UDP).
+        proto: IP protocol number (6=TCP, 17=UDP, etc.).
+    """
+
+    packet_id: int
+    dest: str
+    port: int
+    proto: int
+
+
+# ── NfqueueHandler ─────────────────────────────────────
+
+
+class NfqueueHandler:
+    """Read NFQUEUE packets via ``AF_NETLINK`` and issue verdicts.
+
+    Subscribes to an NFQUEUE group to intercept packets that matched
+    ``queue num`` rules in the nft ruleset.  Extracts destination IP,
+    port, and protocol.  The caller decides and issues verdicts via
+    :meth:`verdict`.
+
+    Optional — :meth:`create` returns ``None`` if the netlink socket
+    cannot be created (e.g. insufficient permissions, missing module).
+    """
+
+    def __init__(self, sock: socket.socket, queue_num: int) -> None:
+        """Wrap an already-bound NFQUEUE netlink socket.
+
+        Use :meth:`create` instead of calling this directly.
+        """
+        self._sock = sock
+        self._queue_num = queue_num
+
+    @classmethod
+    def create(cls, queue_num: int = NFQUEUE_NUM) -> NfqueueHandler | None:
+        """Create and bind an NFQUEUE handler, or return ``None`` on failure.
+
+        Binds to the specified queue number, sets copy mode to full packet,
+        and configures a reasonable copy range for IP header extraction.
+
+        Args:
+            queue_num: NFQUEUE group number to bind to.
+        """
+        try:
+            sock = socket.socket(socket.AF_NETLINK, socket.SOCK_RAW, NETLINK_NETFILTER)
+            sock.bind((0, 0))
+            sock.setblocking(False)
+
+            # Bind to the queue
+            sock.send(_build_config_cmd(queue_num, _NFQNL_CFG_CMD_BIND))
+            if not _check_ack(sock):
+                sock.close()
+                return None
+
+            # Set copy mode to COPY_PACKET with enough range for IP headers
+            sock.send(_build_config_params(queue_num, copy_range=256))
+            if not _check_ack(sock):
+                sock.close()
+                return None
+
+            return cls(sock, queue_num)
+        except (OSError, AttributeError):
+            logger.debug("NFQUEUE socket unavailable — interactive mode disabled")
+            return None
+
+    def fileno(self) -> int:
+        """Return the file descriptor for ``select.select()`` multiplexing."""
+        return self._sock.fileno()
+
+    def close(self) -> None:
+        """Close the netlink socket."""
+        self._sock.close()
+
+    def poll(self) -> list[QueuedPacket]:
+        """Read pending NFQUEUE messages and return queued packets."""
+        packets: list[QueuedPacket] = []
+        while True:
+            try:
+                data = self._sock.recv(65535)
+            except OSError:
+                break
+            if not data:
+                break
+            packets.extend(self._parse_messages(data))
+        return packets
+
+    def verdict(self, packet_id: int, *, accept: bool) -> None:
+        """Issue a verdict (accept or drop) for a queued packet.
+
+        Args:
+            packet_id: The kernel-assigned packet ID from :class:`QueuedPacket`.
+            accept: ``True`` for NF_ACCEPT, ``False`` for NF_DROP.
+        """
+        verdict_val = NF_ACCEPT if accept else NF_DROP
+        msg = _build_verdict_msg(self._queue_num, packet_id, verdict_val)
+        try:
+            self._sock.send(msg)
+        except OSError:
+            logger.warning("Failed to send verdict for packet %d", packet_id)
+
+    def _parse_messages(self, data: bytes) -> list[QueuedPacket]:
+        """Parse one or more netlink messages from raw *data*."""
+        packets: list[QueuedPacket] = []
+        offset = 0
+        while offset + NLMSG_HDR.size <= len(data):
+            nl_len, nl_type, _flags, _seq, _pid = NLMSG_HDR.unpack_from(data, offset)
+            if nl_len < NLMSG_HDR.size or offset + nl_len > len(data):
+                break
+            subsys = (nl_type >> 8) & 0xFF
+            msg = nl_type & 0xFF
+            if subsys == _NFNL_SUBSYS_QUEUE and msg == _NFQNL_MSG_PACKET:
+                attr_offset = NLMSG_HDR.size + NFGEN_HDR.size
+                if offset + attr_offset < offset + nl_len:
+                    attrs = parse_nflog_attrs(data[offset + attr_offset : offset + nl_len])
+                    pkt = self._attrs_to_packet(attrs)
+                    if pkt:
+                        packets.append(pkt)
+            offset += (nl_len + 3) & ~3
+        return packets
+
+    @staticmethod
+    def _attrs_to_packet(attrs: dict[int, bytes]) -> QueuedPacket | None:
+        """Convert parsed NFQUEUE attributes into a :class:`QueuedPacket`."""
+        pkt_hdr = attrs.get(_NFQA_PACKET_HDR)
+        if not pkt_hdr or len(pkt_hdr) < _NFQNL_PACKET_HDR.size:
+            return None
+        packet_id, _hw_proto, _hook = _NFQNL_PACKET_HDR.unpack_from(pkt_hdr)
+
+        payload = attrs.get(_NFQA_PAYLOAD, b"")
+        dest, proto, port = extract_ip_dest(payload)
+        if not dest:
+            return None
+
+        return QueuedPacket(packet_id=packet_id, dest=dest, port=port, proto=proto)
+
+
+# ── Message builders ───────────────────────────────────
+
+
+def _build_config_cmd(queue_num: int, cmd: int) -> bytes:
+    """Build a netlink config command message (bind/unbind)."""
+    msg_type = (_NFNL_SUBSYS_QUEUE << 8) | _NFQNL_MSG_CONFIG
+    nfgen = NFGEN_HDR.pack(AF_INET, 0, socket.htons(queue_num))
+    cmd_payload = _NFQNL_CFG_CMD_STRUCT.pack(cmd, 0, socket.htons(AF_INET))
+    attr = NFA_HDR.pack(NFA_HDR.size + len(cmd_payload), _NFQA_CFG_CMD) + cmd_payload
+    payload = nfgen + attr
+    return NLMSG_HDR.pack(
+        NLMSG_HDR.size + len(payload), msg_type, NLM_F_REQUEST | NLM_F_ACK, 0, 0
+    ) + payload
+
+
+def _build_config_params(queue_num: int, *, copy_range: int = 256) -> bytes:
+    """Build a netlink config params message (set copy mode + range)."""
+    msg_type = (_NFNL_SUBSYS_QUEUE << 8) | _NFQNL_MSG_CONFIG
+    nfgen = NFGEN_HDR.pack(AF_INET, 0, socket.htons(queue_num))
+    params_payload = _NFQNL_CFG_PARAMS.pack(copy_range, _NFQNL_COPY_PACKET)
+    attr = NFA_HDR.pack(NFA_HDR.size + len(params_payload), _NFQA_CFG_PARAMS) + params_payload
+    payload = nfgen + attr
+    return NLMSG_HDR.pack(
+        NLMSG_HDR.size + len(payload), msg_type, NLM_F_REQUEST | NLM_F_ACK, 0, 0
+    ) + payload
+
+
+def _build_verdict_msg(queue_num: int, packet_id: int, verdict: int) -> bytes:
+    """Build a netlink verdict message for a queued packet."""
+    msg_type = (_NFNL_SUBSYS_QUEUE << 8) | _NFQNL_MSG_VERDICT
+    nfgen = NFGEN_HDR.pack(AF_INET, 0, socket.htons(queue_num))
+    verdict_payload = _NFQNL_VERDICT_HDR.pack(verdict, packet_id)
+    attr = NFA_HDR.pack(NFA_HDR.size + len(verdict_payload), _NFQA_VERDICT_HDR) + verdict_payload
+    payload = nfgen + attr
+    return NLMSG_HDR.pack(
+        NLMSG_HDR.size + len(payload), msg_type, NLM_F_REQUEST, 0, 0
+    ) + payload
+
+
+def _check_ack(sock: socket.socket) -> bool:
+    """Read and check an NLMSG_ERROR ACK from the kernel.
+
+    Returns ``True`` if the ACK indicates success (error code 0),
+    ``False`` otherwise.
+    """
+    try:
+        ack = sock.recv(4096)
+        if len(ack) >= NLMSG_HDR.size + 4:
+            err = struct.unpack_from("=i", ack, NLMSG_HDR.size)[0]
+            if err < 0:
+                logger.debug("NFQUEUE config rejected (errno %d)", -err)
+                return False
+        return True
+    except BlockingIOError:
+        return True  # ACK not yet available; proceed optimistically

--- a/src/terok_shield/nfqueue.py
+++ b/src/terok_shield/nfqueue.py
@@ -137,20 +137,20 @@ class NfqueueHandler:
         try:
             sock = socket.socket(socket.AF_NETLINK, socket.SOCK_RAW, NETLINK_NETFILTER)
             sock.bind((0, 0))
-            sock.setblocking(False)
 
-            # Bind to the queue
+            # Handshake in blocking mode so ACKs are reliably received
+            sock.settimeout(2.0)
             sock.send(_build_config_cmd(queue_num, _NFQNL_CFG_CMD_BIND))
             if not _check_ack(sock):
                 sock.close()
                 return None
-
-            # Set copy mode to COPY_PACKET with enough range for IP headers
             sock.send(_build_config_params(queue_num, copy_range=256))
             if not _check_ack(sock):
                 sock.close()
                 return None
 
+            # Switch to non-blocking for the poll() loop
+            sock.setblocking(False)
             return cls(sock, queue_num)
         except (OSError, AttributeError):
             logger.debug("NFQUEUE socket unavailable — interactive mode disabled")
@@ -205,26 +205,37 @@ class NfqueueHandler:
                 attr_offset = NLMSG_HDR.size + NFGEN_HDR.size
                 if offset + attr_offset < offset + nl_len:
                     attrs = parse_nflog_attrs(data[offset + attr_offset : offset + nl_len])
-                    pkt = self._attrs_to_packet(attrs)
+                    pkt = _attrs_to_packet(attrs)
                     if pkt:
                         packets.append(pkt)
+                    else:
+                        # Unparseable payload but we have a packet_id — must
+                        # still issue a verdict or the packet stays stuck.
+                        pid = _extract_packet_id(attrs)
+                        if pid is not None:
+                            self.verdict(pid, accept=False)
             offset += (nl_len + 3) & ~3
         return packets
 
-    @staticmethod
-    def _attrs_to_packet(attrs: dict[int, bytes]) -> QueuedPacket | None:
-        """Convert parsed NFQUEUE attributes into a :class:`QueuedPacket`."""
-        pkt_hdr = attrs.get(_NFQA_PACKET_HDR)
-        if not pkt_hdr or len(pkt_hdr) < _NFQNL_PACKET_HDR.size:
-            return None
-        packet_id, _hw_proto, _hook = _NFQNL_PACKET_HDR.unpack_from(pkt_hdr)
 
-        payload = attrs.get(_NFQA_PAYLOAD, b"")
-        dest, proto, port = extract_ip_dest(payload)
-        if not dest:
-            return None
+def _extract_packet_id(attrs: dict[int, bytes]) -> int | None:
+    """Extract just the packet_id from NFQUEUE attributes, or None."""
+    pkt_hdr = attrs.get(_NFQA_PACKET_HDR)
+    if not pkt_hdr or len(pkt_hdr) < _NFQNL_PACKET_HDR.size:
+        return None
+    return _NFQNL_PACKET_HDR.unpack_from(pkt_hdr)[0]
 
-        return QueuedPacket(packet_id=packet_id, dest=dest, port=port, proto=proto)
+
+def _attrs_to_packet(attrs: dict[int, bytes]) -> QueuedPacket | None:
+    """Convert parsed NFQUEUE attributes into a :class:`QueuedPacket`."""
+    packet_id = _extract_packet_id(attrs)
+    if packet_id is None:
+        return None
+    payload = attrs.get(_NFQA_PAYLOAD, b"")
+    dest, proto, port = extract_ip_dest(payload)
+    if not dest:
+        return None
+    return QueuedPacket(packet_id=packet_id, dest=dest, port=port, proto=proto)
 
 
 # ── Message builders ───────────────────────────────────
@@ -237,9 +248,10 @@ def _build_config_cmd(queue_num: int, cmd: int) -> bytes:
     cmd_payload = _NFQNL_CFG_CMD_STRUCT.pack(cmd, 0, socket.htons(AF_INET))
     attr = NFA_HDR.pack(NFA_HDR.size + len(cmd_payload), _NFQA_CFG_CMD) + cmd_payload
     payload = nfgen + attr
-    return NLMSG_HDR.pack(
-        NLMSG_HDR.size + len(payload), msg_type, NLM_F_REQUEST | NLM_F_ACK, 0, 0
-    ) + payload
+    return (
+        NLMSG_HDR.pack(NLMSG_HDR.size + len(payload), msg_type, NLM_F_REQUEST | NLM_F_ACK, 0, 0)
+        + payload
+    )
 
 
 def _build_config_params(queue_num: int, *, copy_range: int = 256) -> bytes:
@@ -249,9 +261,10 @@ def _build_config_params(queue_num: int, *, copy_range: int = 256) -> bytes:
     params_payload = _NFQNL_CFG_PARAMS.pack(copy_range, _NFQNL_COPY_PACKET)
     attr = NFA_HDR.pack(NFA_HDR.size + len(params_payload), _NFQA_CFG_PARAMS) + params_payload
     payload = nfgen + attr
-    return NLMSG_HDR.pack(
-        NLMSG_HDR.size + len(payload), msg_type, NLM_F_REQUEST | NLM_F_ACK, 0, 0
-    ) + payload
+    return (
+        NLMSG_HDR.pack(NLMSG_HDR.size + len(payload), msg_type, NLM_F_REQUEST | NLM_F_ACK, 0, 0)
+        + payload
+    )
 
 
 def _build_verdict_msg(queue_num: int, packet_id: int, verdict: int) -> bytes:
@@ -261,9 +274,7 @@ def _build_verdict_msg(queue_num: int, packet_id: int, verdict: int) -> bytes:
     verdict_payload = _NFQNL_VERDICT_HDR.pack(verdict, packet_id)
     attr = NFA_HDR.pack(NFA_HDR.size + len(verdict_payload), _NFQA_VERDICT_HDR) + verdict_payload
     payload = nfgen + attr
-    return NLMSG_HDR.pack(
-        NLMSG_HDR.size + len(payload), msg_type, NLM_F_REQUEST, 0, 0
-    ) + payload
+    return NLMSG_HDR.pack(NLMSG_HDR.size + len(payload), msg_type, NLM_F_REQUEST, 0, 0) + payload
 
 
 def _check_ack(sock: socket.socket) -> bool:
@@ -280,5 +291,6 @@ def _check_ack(sock: socket.socket) -> bool:
                 logger.debug("NFQUEUE config rejected (errno %d)", -err)
                 return False
         return True
-    except BlockingIOError:
-        return True  # ACK not yet available; proceed optimistically
+    except (OSError, TimeoutError):
+        logger.debug("NFQUEUE ACK not received")
+        return False

--- a/src/terok_shield/nfqueue.py
+++ b/src/terok_shield/nfqueue.py
@@ -199,23 +199,33 @@ class NfqueueHandler:
             nl_len, nl_type, _flags, _seq, _pid = NLMSG_HDR.unpack_from(data, offset)
             if nl_len < NLMSG_HDR.size or offset + nl_len > len(data):
                 break
-            subsys = (nl_type >> 8) & 0xFF
-            msg = nl_type & 0xFF
-            if subsys == _NFNL_SUBSYS_QUEUE and msg == _NFQNL_MSG_PACKET:
-                attr_offset = NLMSG_HDR.size + NFGEN_HDR.size
-                if offset + attr_offset < offset + nl_len:
-                    attrs = parse_nflog_attrs(data[offset + attr_offset : offset + nl_len])
-                    pkt = _attrs_to_packet(attrs)
-                    if pkt:
-                        packets.append(pkt)
-                    else:
-                        # Unparseable payload but we have a packet_id — must
-                        # still issue a verdict or the packet stays stuck.
-                        pid = _extract_packet_id(attrs)
-                        if pid is not None:
-                            self.verdict(pid, accept=False)
+            pkt = self._handle_one_message(data, offset, nl_len, nl_type)
+            if pkt:
+                packets.append(pkt)
             offset += (nl_len + 3) & ~3
         return packets
+
+    def _handle_one_message(
+        self, data: bytes, offset: int, nl_len: int, nl_type: int
+    ) -> QueuedPacket | None:
+        """Parse a single netlink message, auto-dropping unparseable packets."""
+        subsys = (nl_type >> 8) & 0xFF
+        msg = nl_type & 0xFF
+        if subsys != _NFNL_SUBSYS_QUEUE or msg != _NFQNL_MSG_PACKET:
+            return None
+        attr_offset = NLMSG_HDR.size + NFGEN_HDR.size
+        if offset + attr_offset >= offset + nl_len:
+            return None
+        attrs = parse_nflog_attrs(data[offset + attr_offset : offset + nl_len])
+        pkt = _attrs_to_packet(attrs)
+        if pkt:
+            return pkt
+        # Unparseable payload but we have a packet_id — must still issue
+        # a verdict or the packet stays stuck in the kernel queue.
+        pid = _extract_packet_id(attrs)
+        if pid is not None:
+            self.verdict(pid, accept=False)
+        return None
 
 
 def _extract_packet_id(attrs: dict[int, bytes]) -> int | None:
@@ -291,6 +301,6 @@ def _check_ack(sock: socket.socket) -> bool:
                 logger.debug("NFQUEUE config rejected (errno %d)", -err)
                 return False
         return True
-    except (OSError, TimeoutError):
+    except OSError:
         logger.debug("NFQUEUE ACK not received")
         return False

--- a/src/terok_shield/nfqueue.py
+++ b/src/terok_shield/nfqueue.py
@@ -134,6 +134,7 @@ class NfqueueHandler:
         Args:
             queue_num: NFQUEUE group number to bind to.
         """
+        sock: socket.socket | None = None
         try:
             sock = socket.socket(socket.AF_NETLINK, socket.SOCK_RAW, NETLINK_NETFILTER)
             sock.bind((0, 0))
@@ -154,6 +155,8 @@ class NfqueueHandler:
             return cls(sock, queue_num)
         except (OSError, AttributeError):
             logger.debug("NFQUEUE socket unavailable — interactive mode disabled")
+            if sock is not None:
+                sock.close()
             return None
 
     def fileno(self) -> int:

--- a/src/terok_shield/nft.py
+++ b/src/terok_shield/nft.py
@@ -633,6 +633,16 @@ def verify_ruleset(
     for name in ("allow_v4", "allow_v6", "deny_v4", "deny_v6"):
         if name not in nft_output:
             errors.append(f"{name} set missing")
+    errors.extend(
+        _verify_interactive_mode(nft_output, interactive=interactive, nfqueue_num=nfqueue_num)
+    )
+    errors.extend(_verify_private_blocks(nft_output))
+    return errors
+
+
+def _verify_interactive_mode(nft_output: str, *, interactive: bool, nfqueue_num: int) -> list[str]:
+    """Verify interactive/strict mode invariants in the ruleset."""
+    errors: list[str] = []
     if interactive:
         if QUEUED_LOG_PREFIX not in nft_output:
             errors.append("queued nflog prefix missing")
@@ -644,7 +654,6 @@ def verify_ruleset(
             errors.append("queued nflog prefix present in strict mode")
         if "queue num" in nft_output:
             errors.append("nfqueue rule present in strict mode")
-    errors.extend(_verify_private_blocks(nft_output))
     return errors
 
 

--- a/src/terok_shield/nft.py
+++ b/src/terok_shield/nft.py
@@ -21,11 +21,13 @@ from .nft_constants import (
     BYPASS_LOG_PREFIX,
     DENIED_LOG_PREFIX,
     NFLOG_GROUP,
+    NFQUEUE_NUM,
     NFT_TABLE,
     PASTA_DNS,
     PASTA_HOST_LOOPBACK_MAP,
     PRIVATE_LOG_PREFIX,
     PRIVATE_RANGES,
+    QUEUED_LOG_PREFIX,
 )
 
 _SAFE_TIMEOUT_RE = re.compile(r"^\d+[smhd]$")
@@ -80,6 +82,15 @@ def _try_validate(ip: str) -> bool:
         return False
 
 
+def _safe_nfqueue_num(value: int) -> int:
+    """Validate an NFQUEUE group number.  Raises ValueError for invalid input."""
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"NFQUEUE num must be an integer, got {type(value).__name__}")
+    if not 0 <= value <= 65535:
+        raise ValueError(f"NFQUEUE num out of range: {value}")
+    return value
+
+
 def _safe_timeout(value: str) -> str:
     """Validate an nft timeout value (e.g. ``30m``, ``1h``, ``60s``).
 
@@ -128,6 +139,30 @@ def _audit_allow_rules() -> str:
     return (
         f'        ip daddr @allow_v4 log group {NFLOG_GROUP} prefix "{ALLOWED_LOG_PREFIX}: " counter accept\n'
         f'        ip6 daddr @allow_v6 log group {NFLOG_GROUP} prefix "{ALLOWED_LOG_PREFIX}: " counter accept'
+    )
+
+
+def _deny_set_rules() -> str:
+    """Generate deny-set match rules (IPv4 + IPv6).
+
+    Packets matching the deny sets are immediately rejected with an ICMP
+    error.  Placed after allow-set rules, before private-range reject.
+    """
+    return (
+        f'        ip daddr @deny_v4 log group {NFLOG_GROUP} prefix "{DENIED_LOG_PREFIX}: " counter reject with icmpx admin-prohibited\n'
+        f'        ip6 daddr @deny_v6 log group {NFLOG_GROUP} prefix "{DENIED_LOG_PREFIX}: " counter reject with icmpx admin-prohibited'
+    )
+
+
+def _nfqueue_rule(nfqueue_num: int) -> str:
+    """Generate the NFQUEUE terminal rule for interactive mode.
+
+    Queues unmatched packets to userspace for operator verdict instead
+    of rejecting them immediately.
+    """
+    return (
+        f'        log group {NFLOG_GROUP} prefix "{QUEUED_LOG_PREFIX}: " counter\n'
+        f"        queue num {nfqueue_num}"
     )
 
 
@@ -183,6 +218,7 @@ class RulesetBuilder:
         dns: str = PASTA_DNS,
         loopback_ports: tuple[int, ...] = (),
         set_timeout: str = "",
+        nfqueue_num: int = NFQUEUE_NUM,
     ) -> None:
         """Create a builder with validated DNS and loopback port config.
 
@@ -194,22 +230,32 @@ class RulesetBuilder:
             set_timeout: nft set element timeout (e.g. ``30m``).  When set,
                 allow sets use ``flags interval, timeout`` so dnsmasq-populated
                 IPs expire and are refreshed on the next DNS query.
+            nfqueue_num: NFQUEUE group number for interactive mode.
         """
         dns = safe_ip(dns)
         for p in loopback_ports:
             _safe_port(p)
         if set_timeout:
             _safe_timeout(set_timeout)
+        _safe_nfqueue_num(nfqueue_num)
         self._dns = dns
         self._loopback_ports = loopback_ports
         self._set_timeout = set_timeout
+        self._nfqueue_num = nfqueue_num
 
-    def build_hook(self) -> str:
-        """Generate the hook-mode (deny-all) nftables ruleset."""
+    def build_hook(self, *, interactive: bool = False) -> str:
+        """Generate the hook-mode nftables ruleset.
+
+        Args:
+            interactive: When ``True``, unknown packets are queued via
+                NFQUEUE instead of being rejected immediately.
+        """
         return hook_ruleset(
             dns=self._dns,
             loopback_ports=self._loopback_ports,
             set_timeout=self._set_timeout,
+            interactive=interactive,
+            nfqueue_num=self._nfqueue_num,
         )
 
     def build_bypass(self, *, allow_all: bool = False) -> str:
@@ -221,9 +267,9 @@ class RulesetBuilder:
             set_timeout=self._set_timeout,
         )
 
-    def verify_hook(self, nft_output: str) -> list[str]:
+    def verify_hook(self, nft_output: str, *, interactive: bool = False) -> list[str]:
         """Check applied hook ruleset invariants.  Returns errors (empty = OK)."""
-        return verify_ruleset(nft_output)
+        return verify_ruleset(nft_output, interactive=interactive)
 
     def verify_bypass(self, nft_output: str, *, allow_all: bool = False) -> list[str]:
         """Check applied bypass ruleset invariants.  Returns errors (empty = OK)."""
@@ -260,6 +306,9 @@ def hook_ruleset(
     dns: str = PASTA_DNS,
     loopback_ports: tuple[int, ...] = (),
     set_timeout: str = "",
+    *,
+    interactive: bool = False,
+    nfqueue_num: int = NFQUEUE_NUM,
 ) -> str:
     """Generate a per-container nftables ruleset for hook mode.
 
@@ -272,19 +321,25 @@ def hook_ruleset(
     the persisted ``state/gateway`` file.
 
     Chain order (output):
-        loopback -> established -> DNS -> gateway ports -> loopback ports
-        -> allow sets -> private-range reject -> deny
+        loopback → established → DNS → gateway ports → loopback ports
+        → allow sets → deny sets → private-range reject → terminal
+        (strict: reject | interactive: NFQUEUE)
 
     Args:
         dns: DNS server address (pasta default forwarder).
         loopback_ports: TCP ports to allow on the loopback interface.
         set_timeout: nft set element timeout (e.g. ``30m``).
+        interactive: When ``True``, unknown packets are queued to userspace
+            via NFQUEUE instead of being rejected immediately.
+        nfqueue_num: NFQUEUE group number (only used when *interactive*).
     """
     dns = safe_ip(dns)
     if set_timeout:
         _safe_timeout(set_timeout)
     for p in loopback_ports:
         _safe_port(p)
+    if interactive:
+        _safe_nfqueue_num(nfqueue_num)
     port_rules = _loopback_port_rules(loopback_ports)
     gw_rules = _gateway_port_rules(loopback_ports)
     infra_block = ""
@@ -296,10 +351,13 @@ def hook_ruleset(
     dns_af = "ip" if _is_v4(dns) else "ip6"
     set_v4 = _set_declaration("allow_v4", "ipv4_addr", set_timeout)
     set_v6 = _set_declaration("allow_v6", "ipv6_addr", set_timeout)
+    terminal = _nfqueue_rule(nfqueue_num) if interactive else _audit_deny_rule()
     return textwrap.dedent(f"""\
         table {NFT_TABLE} {{
             {set_v4}
             {set_v6}
+            set deny_v4 {{ type ipv4_addr; flags interval; }}
+            set deny_v6 {{ type ipv6_addr; flags interval; }}
             set gateway_v4 {{ type ipv4_addr; }}
             set gateway_v6 {{ type ipv6_addr; }}
 
@@ -310,8 +368,9 @@ def hook_ruleset(
                 udp dport 53 {dns_af} daddr {dns} accept
                 tcp dport 53 {dns_af} daddr {dns} accept{infra_block}\
         {_audit_allow_rules()}
+        {_deny_set_rules()}
         {_private_range_rules()}
-        {_audit_deny_rule()}
+        {terminal}
             }}
 
             chain input {{
@@ -370,6 +429,8 @@ def bypass_ruleset(
         table {NFT_TABLE} {{
             {set_v4}
             {set_v6}
+            set deny_v4 {{ type ipv4_addr; flags interval; }}
+            set deny_v6 {{ type ipv6_addr; flags interval; }}
             set gateway_v4 {{ type ipv4_addr; }}
             set gateway_v6 {{ type ipv6_addr; }}
 
@@ -400,6 +461,8 @@ def bypass_ruleset(
 _SAFE_IDENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 _ALLOW_V4 = "allow_v4"
 _ALLOW_V6 = "allow_v6"
+_DENY_V4 = "deny_v4"
+_DENY_V6 = "deny_v6"
 
 
 def _safe_ident(value: str) -> str:
@@ -470,6 +533,55 @@ def add_elements_dual(ips: list[str], *, permanent: bool = False) -> str:
     return "".join(parts)
 
 
+def _elements_dual(
+    ips: list[str], v4_set: str, v6_set: str, *, op: str = "add", timeout_zero: bool = False
+) -> str:
+    """Classify IPs by family and generate element commands for a set pair.
+
+    Shared implementation for both allow and deny set operations.
+    """
+    v4: list[str] = []
+    v6: list[str] = []
+    for ip in ips:
+        try:
+            sanitized = safe_ip(ip)
+        except ValueError:
+            continue
+        (v4 if _is_v4(sanitized) else v6).append(sanitized)
+
+    parts: list[str] = []
+    for set_name, bucket in ((v4_set, v4), (v6_set, v6)):
+        if not bucket:
+            continue
+        _safe_ident(set_name)
+        for part in NFT_TABLE.split():
+            _safe_ident(part)
+        if timeout_zero:
+            elements = ", ".join(f"{ip} timeout 0s" for ip in bucket)
+        else:
+            elements = ", ".join(bucket)
+        parts.append(f"{op} element {NFT_TABLE} {set_name} {{ {elements} }}\n")
+    return "".join(parts)
+
+
+def add_deny_elements_dual(ips: list[str]) -> str:
+    """Classify IPs by family and generate add-element commands for deny sets.
+
+    IPv4 addresses go to ``deny_v4``, IPv6 to ``deny_v6``.
+    Returns empty string if no valid IPs.
+    """
+    return _elements_dual(ips, _DENY_V4, _DENY_V6)
+
+
+def delete_deny_elements_dual(ips: list[str]) -> str:
+    """Classify IPs by family and generate delete-element commands for deny sets.
+
+    Used by ``allow_ip()`` to un-deny an IP before adding it to the allow set.
+    Returns empty string if no valid IPs.
+    """
+    return _elements_dual(ips, _DENY_V4, _DENY_V6, op="delete")
+
+
 # ── Verification ─────────────────────────────────────────
 
 
@@ -489,16 +601,21 @@ def _verify_private_blocks(nft_output: str) -> list[str]:
     return errors
 
 
-def verify_ruleset(nft_output: str) -> list[str]:
+def verify_ruleset(nft_output: str, *, interactive: bool = False) -> list[str]:
     """Check applied ruleset invariants.  Returns errors (empty = OK).
 
     Verifies:
     - Default policy is drop
     - Both output and input chains exist
-    - Reject type is present
-    - Deny nflog prefix is present
+    - Reject type is present (deny sets always have it)
+    - Deny nflog prefix is present (deny sets always log with DENIED prefix)
     - All private ranges are present (RFC 1918 + RFC 4193/4291)
-    - Dual-stack allow sets are declared
+    - Dual-stack allow and deny sets are declared
+    - Interactive: QUEUED prefix and ``queue num`` present
+
+    Args:
+        interactive: When ``True``, additionally checks for NFQUEUE-specific
+            invariants (QUEUED log prefix, queue rule).
     """
     errors: list[str] = []
     if "policy drop" not in nft_output:
@@ -510,10 +627,14 @@ def verify_ruleset(nft_output: str) -> list[str]:
         errors.append("reject type missing")
     if DENIED_LOG_PREFIX not in nft_output:
         errors.append("deny nflog prefix missing")
-    if "allow_v4" not in nft_output:
-        errors.append("allow_v4 set missing")
-    if "allow_v6" not in nft_output:
-        errors.append("allow_v6 set missing")
+    for name in ("allow_v4", "allow_v6", "deny_v4", "deny_v6"):
+        if name not in nft_output:
+            errors.append(f"{name} set missing")
+    if interactive:
+        if QUEUED_LOG_PREFIX not in nft_output:
+            errors.append("queued nflog prefix missing")
+        if "queue num" not in nft_output:
+            errors.append("nfqueue rule missing")
     errors.extend(_verify_private_blocks(nft_output))
     return errors
 
@@ -538,10 +659,9 @@ def verify_bypass_ruleset(nft_output: str, *, allow_all: bool = False) -> list[s
             errors.append(f"{chain} chain missing")
     if BYPASS_LOG_PREFIX not in nft_output:
         errors.append("bypass nflog prefix missing")
-    if "allow_v4" not in nft_output:
-        errors.append("allow_v4 set missing")
-    if "allow_v6" not in nft_output:
-        errors.append("allow_v6 set missing")
+    for name in ("allow_v4", "allow_v6", "deny_v4", "deny_v6"):
+        if name not in nft_output:
+            errors.append(f"{name} set missing")
     if not allow_all:
         errors.extend(_verify_private_blocks(nft_output))
     return errors

--- a/src/terok_shield/nft.py
+++ b/src/terok_shield/nft.py
@@ -269,7 +269,7 @@ class RulesetBuilder:
 
     def verify_hook(self, nft_output: str, *, interactive: bool = False) -> list[str]:
         """Check applied hook ruleset invariants.  Returns errors (empty = OK)."""
-        return verify_ruleset(nft_output, interactive=interactive)
+        return verify_ruleset(nft_output, interactive=interactive, nfqueue_num=self._nfqueue_num)
 
     def verify_bypass(self, nft_output: str, *, allow_all: bool = False) -> list[str]:
         """Check applied bypass ruleset invariants.  Returns errors (empty = OK)."""
@@ -601,7 +601,9 @@ def _verify_private_blocks(nft_output: str) -> list[str]:
     return errors
 
 
-def verify_ruleset(nft_output: str, *, interactive: bool = False) -> list[str]:
+def verify_ruleset(
+    nft_output: str, *, interactive: bool = False, nfqueue_num: int = NFQUEUE_NUM
+) -> list[str]:
     """Check applied ruleset invariants.  Returns errors (empty = OK).
 
     Verifies:
@@ -611,11 +613,12 @@ def verify_ruleset(nft_output: str, *, interactive: bool = False) -> list[str]:
     - Deny nflog prefix is present (deny sets always log with DENIED prefix)
     - All private ranges are present (RFC 1918 + RFC 4193/4291)
     - Dual-stack allow and deny sets are declared
-    - Interactive: QUEUED prefix and ``queue num`` present
+    - Interactive: QUEUED prefix and specific ``queue num`` present
+    - Strict: no QUEUED prefix or queue rule present
 
     Args:
-        interactive: When ``True``, additionally checks for NFQUEUE-specific
-            invariants (QUEUED log prefix, queue rule).
+        interactive: When ``True``, checks for NFQUEUE-specific invariants.
+        nfqueue_num: Expected queue number (only checked when *interactive*).
     """
     errors: list[str] = []
     if "policy drop" not in nft_output:
@@ -633,8 +636,14 @@ def verify_ruleset(nft_output: str, *, interactive: bool = False) -> list[str]:
     if interactive:
         if QUEUED_LOG_PREFIX not in nft_output:
             errors.append("queued nflog prefix missing")
-        if "queue num" not in nft_output:
-            errors.append("nfqueue rule missing")
+        expected = f"queue num {nfqueue_num}"
+        if expected not in nft_output:
+            errors.append(f"nfqueue rule missing (expected {expected})")
+    else:
+        if QUEUED_LOG_PREFIX in nft_output:
+            errors.append("queued nflog prefix present in strict mode")
+        if "queue num" in nft_output:
+            errors.append("nfqueue rule present in strict mode")
     errors.extend(_verify_private_blocks(nft_output))
     return errors
 

--- a/src/terok_shield/nft.py
+++ b/src/terok_shield/nft.py
@@ -158,11 +158,24 @@ def _nfqueue_rule(nfqueue_num: int) -> str:
     """Generate the NFQUEUE terminal rule for interactive mode.
 
     Queues unmatched packets to userspace for operator verdict instead
-    of rejecting them immediately.
+    of rejecting them immediately.  Requires ``nfnetlink_queue`` kernel module.
     """
     return (
         f'        log group {NFLOG_GROUP} prefix "{QUEUED_LOG_PREFIX}: " counter\n'
         f"        queue num {nfqueue_num}"
+    )
+
+
+def _interactive_reject_rule() -> str:
+    """Generate the NFLOG+reject terminal rule for interactive mode without NFQUEUE.
+
+    Rejects unmatched packets immediately (like strict mode) but logs them
+    with the QUEUED prefix so the interactive handler can detect them via
+    NFLOG and present them for operator verdict.
+    """
+    return (
+        f'        log group {NFLOG_GROUP} prefix "{QUEUED_LOG_PREFIX}: " '
+        f"counter reject with icmpx admin-prohibited"
     )
 
 
@@ -243,18 +256,20 @@ class RulesetBuilder:
         self._set_timeout = set_timeout
         self._nfqueue_num = nfqueue_num
 
-    def build_hook(self, *, interactive: bool = False) -> str:
+    def build_hook(self, *, interactive: bool = False, nfqueue: bool = True) -> str:
         """Generate the hook-mode nftables ruleset.
 
         Args:
-            interactive: When ``True``, unknown packets are queued via
-                NFQUEUE instead of being rejected immediately.
+            interactive: When ``True``, enables interactive verdict mode.
+            nfqueue: When ``True`` (and *interactive*), uses NFQUEUE.
+                When ``False``, uses NFLOG+reject (no kernel module needed).
         """
         return hook_ruleset(
             dns=self._dns,
             loopback_ports=self._loopback_ports,
             set_timeout=self._set_timeout,
             interactive=interactive,
+            nfqueue=nfqueue,
             nfqueue_num=self._nfqueue_num,
         )
 
@@ -308,6 +323,7 @@ def hook_ruleset(
     set_timeout: str = "",
     *,
     interactive: bool = False,
+    nfqueue: bool = True,
     nfqueue_num: int = NFQUEUE_NUM,
 ) -> str:
     """Generate a per-container nftables ruleset for hook mode.
@@ -323,22 +339,24 @@ def hook_ruleset(
     Chain order (output):
         loopback → established → DNS → gateway ports → loopback ports
         → allow sets → deny sets → private-range reject → terminal
-        (strict: reject | interactive: NFQUEUE)
+        (strict: reject | interactive+nfqueue: NFQUEUE | interactive: NFLOG+reject)
 
     Args:
         dns: DNS server address (pasta default forwarder).
         loopback_ports: TCP ports to allow on the loopback interface.
         set_timeout: nft set element timeout (e.g. ``30m``).
-        interactive: When ``True``, unknown packets are queued to userspace
-            via NFQUEUE instead of being rejected immediately.
-        nfqueue_num: NFQUEUE group number (only used when *interactive*).
+        interactive: When ``True``, enables interactive verdict mode.
+        nfqueue: When ``True`` (and *interactive*), uses NFQUEUE to hold
+            packets.  When ``False``, uses NFLOG+reject (no kernel module
+            dependency).  Ignored when *interactive* is ``False``.
+        nfqueue_num: NFQUEUE group number (only used when *interactive* + *nfqueue*).
     """
     dns = safe_ip(dns)
     if set_timeout:
         _safe_timeout(set_timeout)
     for p in loopback_ports:
         _safe_port(p)
-    if interactive:
+    if interactive and nfqueue:
         _safe_nfqueue_num(nfqueue_num)
     port_rules = _loopback_port_rules(loopback_ports)
     gw_rules = _gateway_port_rules(loopback_ports)
@@ -351,7 +369,10 @@ def hook_ruleset(
     dns_af = "ip" if _is_v4(dns) else "ip6"
     set_v4 = _set_declaration("allow_v4", "ipv4_addr", set_timeout)
     set_v6 = _set_declaration("allow_v6", "ipv6_addr", set_timeout)
-    terminal = _nfqueue_rule(nfqueue_num) if interactive else _audit_deny_rule()
+    if interactive:
+        terminal = _nfqueue_rule(nfqueue_num) if nfqueue else _interactive_reject_rule()
+    else:
+        terminal = _audit_deny_rule()
     return textwrap.dedent(f"""\
         table {NFT_TABLE} {{
             {set_v4}
@@ -641,14 +662,20 @@ def verify_ruleset(
 
 
 def _verify_interactive_mode(nft_output: str, *, interactive: bool, nfqueue_num: int) -> list[str]:
-    """Verify interactive/strict mode invariants in the ruleset."""
+    """Verify interactive/strict mode invariants in the ruleset.
+
+    Interactive mode accepts either NFQUEUE (``queue num``) or NFLOG+reject
+    as valid terminal rules — the tier is auto-detected at pre_start time.
+    """
     errors: list[str] = []
     if interactive:
         if QUEUED_LOG_PREFIX not in nft_output:
             errors.append("queued nflog prefix missing")
-        expected = f"queue num {nfqueue_num}"
-        if expected not in nft_output:
-            errors.append(f"nfqueue rule missing (expected {expected})")
+        # Accept either nfqueue or nflog+reject tier
+        has_queue = f"queue num {nfqueue_num}" in nft_output
+        has_reject = "admin-prohibited" in nft_output and QUEUED_LOG_PREFIX in nft_output
+        if not has_queue and not has_reject:
+            errors.append("interactive terminal rule missing (expected queue or QUEUED+reject)")
     else:
         if QUEUED_LOG_PREFIX in nft_output:
             errors.append("queued nflog prefix present in strict mode")

--- a/src/terok_shield/nft_constants.py
+++ b/src/terok_shield/nft_constants.py
@@ -48,13 +48,15 @@ SLIRP4NETNS_DNS = "10.0.2.3"  # slirp4netns default DNS forwarder
 DNSMASQ_BIND = "127.0.0.1"  # dnsmasq listen address inside container
 NFT_SET_TIMEOUT_DNSMASQ = "30m"  # set element timeout when dnsmasq manages IPs
 
-# ── NFLOG ──────────────────────────────────────────────
+# ── NFLOG / NFQUEUE ────────────────────────────────────
 # nflog is a superset of log — it still writes to the kernel log AND makes
 # packets available via AF_NETLINK for userspace consumers (shield watch).
 NFLOG_GROUP = 100  # nflog group number for terok-shield rules
+NFQUEUE_NUM = 200  # nfqueue group number for interactive mode (distinct from NFLOG_GROUP)
 
 # ── Log prefixes ───────────────────────────────────────
 DENIED_LOG_PREFIX = "TEROK_SHIELD_DENIED"
 PRIVATE_LOG_PREFIX = "TEROK_SHIELD_PRIVATE"
 ALLOWED_LOG_PREFIX = "TEROK_SHIELD_ALLOWED"
 BYPASS_LOG_PREFIX = "TEROK_SHIELD_BYPASS"
+QUEUED_LOG_PREFIX = "TEROK_SHIELD_QUEUED"

--- a/src/terok_shield/registry.py
+++ b/src/terok_shield/registry.py
@@ -213,6 +213,11 @@ COMMANDS: tuple[CommandDef, ...] = (
         standalone_only=True,
         args=(
             ArgDef(name="--profiles", nargs="+", help="Override default profiles"),
+            ArgDef(
+                name="--interactive",
+                action="store_true",
+                help="Enable NFQUEUE interactive verdict mode",
+            ),
             ArgDef(name="--json", action="store_true", dest="output_json", help="JSON output"),
         ),
     ),
@@ -221,7 +226,14 @@ COMMANDS: tuple[CommandDef, ...] = (
         help="Launch a shielded container via podman",
         needs_container=True,
         standalone_only=True,
-        args=(ArgDef(name="--profiles", nargs="+", help="Override default profiles"),),
+        args=(
+            ArgDef(name="--profiles", nargs="+", help="Override default profiles"),
+            ArgDef(
+                name="--interactive",
+                action="store_true",
+                help="Enable NFQUEUE interactive verdict mode",
+            ),
+        ),
     ),
     CommandDef(
         name="resolve",

--- a/src/terok_shield/registry.py
+++ b/src/terok_shield/registry.py
@@ -172,6 +172,13 @@ def _handle_watch(shield: Shield, container: str) -> None:
     run_watch(shield.config.state_dir, container)
 
 
+def _handle_interactive(shield: Shield, container: str) -> None:
+    """Start the interactive NFQUEUE verdict handler."""
+    from .interactive import run_interactive
+
+    run_interactive(shield.config.state_dir, container)
+
+
 def _handle_preview(shield: Shield, *, down: bool = False, allow_all: bool = False) -> None:
     """Show ruleset that would be applied."""
     if allow_all and not down:
@@ -267,6 +274,12 @@ COMMANDS: tuple[CommandDef, ...] = (
         name="watch",
         help="Stream shield events — DNS blocks, audit log, NFLOG packets (requires dnsmasq tier)",
         handler=_handle_watch,
+        needs_container=True,
+    ),
+    CommandDef(
+        name="interactive",
+        help="Start NFQUEUE verdict handler — queue unknown packets for operator accept/deny",
+        handler=_handle_interactive,
         needs_container=True,
     ),
     # NOTE: CLI special-cases logs with --container optional for aggregated mode.

--- a/src/terok_shield/registry.py
+++ b/src/terok_shield/registry.py
@@ -176,7 +176,7 @@ def _handle_interactive(shield: Shield, container: str) -> None:
     """Start the interactive NFQUEUE verdict handler."""
     from .interactive import run_interactive
 
-    run_interactive(shield.config.state_dir, container)
+    run_interactive(shield.config.state_dir, container, timeout=shield.config.nfqueue_timeout)
 
 
 def _handle_preview(shield: Shield, *, down: bool = False, allow_all: bool = False) -> None:

--- a/src/terok_shield/resources/hook_entrypoint.py
+++ b/src/terok_shield/resources/hook_entrypoint.py
@@ -40,7 +40,7 @@ from pathlib import Path
 #   "dnsmasq.pid"    ↔  state.dnsmasq_pid_path()
 _ANN_STATE_DIR = "terok.shield.state_dir"
 _ANN_VERSION = "terok.shield.version"
-_BUNDLE_VERSION = 3
+_BUNDLE_VERSION = 4
 _TABLE = "inet terok_shield"
 
 

--- a/src/terok_shield/state.py
+++ b/src/terok_shield/state.py
@@ -25,12 +25,13 @@ Bundle layout::
     ├── dnsmasq.pid                    # dnsmasq PID (in container netns)
     ├── dnsmasq.log                    # dnsmasq query log (for shield watch)
     ├── resolv.conf                    # bind-mounted over /etc/resolv.conf (dnsmasq tier)
+    ├── interactive                    # interactive mode flag (NFQUEUE enabled)
     └── audit.jsonl                    # per-container audit log
 """
 
 from pathlib import Path
 
-BUNDLE_VERSION = 3
+BUNDLE_VERSION = 4
 """Integer version of the state bundle layout.
 
 Bumped whenever the file layout changes in a backwards-incompatible way.
@@ -126,6 +127,16 @@ def live_domains_path(state_dir: Path) -> Path:
 def denied_domains_path(state_dir: Path) -> Path:
     """Return the path to the denied domains file (from deny_domain)."""
     return state_dir / "denied.domains"
+
+
+def interactive_path(state_dir: Path) -> Path:
+    """Return the path to the interactive mode flag file.
+
+    Written by ``pre_start()`` when interactive mode is enabled.
+    Read by ``shield_up()`` and the interactive verdict handler to
+    determine whether NFQUEUE rules should be used.
+    """
+    return state_dir / "interactive"
 
 
 def resolv_conf_path(state_dir: Path) -> Path:

--- a/src/terok_shield/state.py
+++ b/src/terok_shield/state.py
@@ -130,13 +130,28 @@ def denied_domains_path(state_dir: Path) -> Path:
 
 
 def interactive_path(state_dir: Path) -> Path:
-    """Return the path to the interactive mode flag file.
+    """Return the path to the interactive mode tier file.
 
-    Written by ``pre_start()`` when interactive mode is enabled.
-    Read by ``shield_up()`` and the interactive verdict handler to
-    determine whether NFQUEUE rules should be used.
+    Written by ``pre_start()`` with the interactive tier value
+    (``nfqueue`` or ``nflog``).  Read by ``shield_up()`` and the
+    interactive verdict handler to choose the socket type.
     """
     return state_dir / "interactive"
+
+
+def read_interactive_tier(state_dir: Path) -> str | None:
+    """Read the interactive tier from the state dir, or ``None`` if not set.
+
+    Returns ``"nfqueue"`` or ``"nflog"``.  Legacy value ``"1"`` (from
+    earlier versions) maps to ``"nflog"`` as the safe default.
+    """
+    p = interactive_path(state_dir)
+    if not p.is_file():
+        return None
+    value = p.read_text().strip()
+    if value in ("nfqueue", "nflog"):
+        return value
+    return "nflog"  # legacy "1" or unknown → safe fallback
 
 
 def resolv_conf_path(state_dir: Path) -> Path:

--- a/src/terok_shield/watch.py
+++ b/src/terok_shield/watch.py
@@ -276,8 +276,6 @@ def _build_nflog_bind_msg(group: int) -> bytes:
     return nlmsg
 
 
-
-
 class NflogWatcher:
     """Read NFLOG messages via ``AF_NETLINK`` and yield events for denied packets.
 
@@ -391,6 +389,8 @@ class NflogWatcher:
             action = "allowed_connection"
         elif "BYPASS" in prefix:
             action = "bypass_connection"
+        elif "QUEUED" in prefix:
+            action = "queued_connection"
         else:
             action = "nflog"
 

--- a/src/terok_shield/watch.py
+++ b/src/terok_shield/watch.py
@@ -32,6 +32,17 @@ from pathlib import Path
 
 from . import dnsmasq, state
 from .config import DnsTier
+from .netlink import (
+    AF_INET,
+    NETLINK_NETFILTER,
+    NFA_HDR,
+    NFGEN_HDR,
+    NLM_F_ACK,
+    NLM_F_REQUEST,
+    NLMSG_HDR,
+    extract_ip_dest,
+    parse_nflog_attrs,
+)
 from .nft_constants import NFLOG_GROUP
 
 logger = logging.getLogger(__name__)
@@ -224,38 +235,19 @@ class AuditLogWatcher:
 
 # Linux netlink / nflog constants (from linux/netfilter/nfnetlink.h and
 # linux/netfilter/nfnetlink_log.h).
-_NETLINK_NETFILTER = 12
 _NFNL_SUBSYS_ULOG = 4
 _NFULNL_MSG_CONFIG = 1
 _NFULNL_MSG_PACKET = 0
 
 # nflog config commands
 _NFULNL_CFG_CMD_BIND = 1
-_NFULNL_CFG_CMD_UNBIND = 0
 
 # nflog attribute types (TLV in the packet payload)
-_NFULA_PACKET_HDR = 1
 _NFULA_PREFIX = 3
 _NFULA_PAYLOAD = 9
 
-# IP protocol numbers
-_IPPROTO_TCP = 6
-_IPPROTO_UDP = 17
-
-# Netlink message header: length(4) + type(2) + flags(2) + seq(4) + pid(4)
-_NLMSG_HDR = struct.Struct("=IHHII")
-# nfgenmsg: family(1) + version(1) + res_id(2)
-_NFGEN_HDR = struct.Struct("=BBH")
-# nflog config command: command(1) + pad(1) + pf(2)
+# nflog config command struct: command(1) + pad(1) + pf(2)
 _NFULNL_CFG_CMD = struct.Struct("=BBH")
-# nflog TLV attribute header: length(2) + type(2)
-_NFA_HDR = struct.Struct("=HH")
-
-_NLM_F_REQUEST = 1
-_NLM_F_ACK = 4
-
-# AF_INET is 2 on all Linux platforms
-_AF_INET = 2
 
 
 def _build_nflog_bind_msg(group: int) -> bytes:
@@ -265,17 +257,17 @@ def _build_nflog_bind_msg(group: int) -> bytes:
     for the specified NFLOG group number.
     """
     msg_type = (_NFNL_SUBSYS_ULOG << 8) | _NFULNL_MSG_CONFIG
-    nfgen = _NFGEN_HDR.pack(_AF_INET, 0, socket.htons(group))
+    nfgen = NFGEN_HDR.pack(AF_INET, 0, socket.htons(group))
     # Config command attribute: NFULA_CFG_CMD
-    cmd_payload = _NFULNL_CFG_CMD.pack(_NFULNL_CFG_CMD_BIND, 0, socket.htons(_AF_INET))
+    cmd_payload = _NFULNL_CFG_CMD.pack(_NFULNL_CFG_CMD_BIND, 0, socket.htons(AF_INET))
     # Attribute TLV: type=1 (NFULA_CFG_CMD), length=header+payload
-    attr = _NFA_HDR.pack(_NFA_HDR.size + len(cmd_payload), 1) + cmd_payload
+    attr = NFA_HDR.pack(NFA_HDR.size + len(cmd_payload), 1) + cmd_payload
     payload = nfgen + attr
     nlmsg = (
-        _NLMSG_HDR.pack(
-            _NLMSG_HDR.size + len(payload),
+        NLMSG_HDR.pack(
+            NLMSG_HDR.size + len(payload),
             msg_type,
-            _NLM_F_REQUEST | _NLM_F_ACK,
+            NLM_F_REQUEST | NLM_F_ACK,
             0,
             0,
         )
@@ -284,55 +276,6 @@ def _build_nflog_bind_msg(group: int) -> bytes:
     return nlmsg
 
 
-def _parse_nflog_attrs(data: bytes) -> dict[int, bytes]:
-    """Parse TLV attributes from an NFLOG packet message.
-
-    Returns a dict mapping attribute type to raw attribute value bytes.
-    """
-    attrs: dict[int, bytes] = {}
-    offset = 0
-    while offset + _NFA_HDR.size <= len(data):
-        nfa_len, nfa_type = _NFA_HDR.unpack_from(data, offset)
-        if nfa_len < _NFA_HDR.size:
-            break
-        # Mask out the nested/byteorder flags from the type field
-        nfa_type &= 0x7FFF
-        value = data[offset + _NFA_HDR.size : offset + nfa_len]
-        attrs[nfa_type] = value
-        # Attributes are 4-byte aligned
-        offset += (nfa_len + 3) & ~3
-    return attrs
-
-
-def _extract_ip_dest(payload: bytes) -> tuple[str, int, int]:
-    """Extract destination IP, protocol, and port from a raw IP packet.
-
-    Handles IPv4 only (NFLOG in inet tables delivers the IP header).
-    Returns ``("", 0, 0)`` if the packet cannot be parsed.
-    """
-    if len(payload) < 20:
-        return ("", 0, 0)
-    version = (payload[0] >> 4) & 0xF
-    if version != 4:
-        # IPv6 parsing: 40-byte header, dest at offset 24
-        if version == 6 and len(payload) >= 40:
-            dest_bytes = payload[24:40]
-            dest = socket.inet_ntop(socket.AF_INET6, dest_bytes)
-            proto = payload[6]  # Next Header
-            port = 0
-            if proto in (_IPPROTO_TCP, _IPPROTO_UDP) and len(payload) >= 44:
-                port = struct.unpack_from("!H", payload, 42)[0]  # dest port
-            return (dest, proto, port)
-        return ("", 0, 0)
-    ihl = (payload[0] & 0xF) * 4
-    if ihl < 20:
-        return ("", 0, 0)
-    proto = payload[9]
-    dest = socket.inet_ntop(socket.AF_INET, payload[16:20])
-    port = 0
-    if proto in (_IPPROTO_TCP, _IPPROTO_UDP) and len(payload) >= ihl + 4:
-        port = struct.unpack_from("!H", payload, ihl + 2)[0]  # dest port
-    return (dest, proto, port)
 
 
 class NflogWatcher:
@@ -367,7 +310,7 @@ class NflogWatcher:
             group: NFLOG group number to subscribe to.
         """
         try:
-            sock = socket.socket(socket.AF_NETLINK, socket.SOCK_RAW, _NETLINK_NETFILTER)
+            sock = socket.socket(socket.AF_NETLINK, socket.SOCK_RAW, NETLINK_NETFILTER)
             sock.bind((0, 0))
             sock.setblocking(False)
             sock.send(_build_nflog_bind_msg(group))
@@ -375,8 +318,8 @@ class NflogWatcher:
             # NLMSG_ERROR layout: nlmsghdr (16 bytes) + error (int32).
             try:
                 ack = sock.recv(4096)
-                if len(ack) >= _NLMSG_HDR.size + 4:
-                    err = struct.unpack_from("=i", ack, _NLMSG_HDR.size)[0]
+                if len(ack) >= NLMSG_HDR.size + 4:
+                    err = struct.unpack_from("=i", ack, NLMSG_HDR.size)[0]
                     if err < 0:
                         sock.close()
                         logger.debug("NFLOG bind rejected (errno %d) — skipping", -err)
@@ -415,18 +358,18 @@ class NflogWatcher:
         """Parse one or more netlink messages from raw *data*."""
         events: list[WatchEvent] = []
         offset = 0
-        while offset + _NLMSG_HDR.size <= len(data):
-            nl_len, nl_type, _flags, _seq, _pid = _NLMSG_HDR.unpack_from(data, offset)
-            if nl_len < _NLMSG_HDR.size or offset + nl_len > len(data):
+        while offset + NLMSG_HDR.size <= len(data):
+            nl_len, nl_type, _flags, _seq, _pid = NLMSG_HDR.unpack_from(data, offset)
+            if nl_len < NLMSG_HDR.size or offset + nl_len > len(data):
                 break
             # Check this is an NFLOG packet message
             subsys = (nl_type >> 8) & 0xFF
             msg = nl_type & 0xFF
             if subsys == _NFNL_SUBSYS_ULOG and msg == _NFULNL_MSG_PACKET:
                 # Skip nlmsg header + nfgenmsg (4 bytes)
-                attr_offset = _NLMSG_HDR.size + _NFGEN_HDR.size
+                attr_offset = NLMSG_HDR.size + NFGEN_HDR.size
                 if offset + attr_offset < offset + nl_len:
-                    attrs = _parse_nflog_attrs(data[offset + attr_offset : offset + nl_len])
+                    attrs = parse_nflog_attrs(data[offset + attr_offset : offset + nl_len])
                     event = self._attr_to_event(attrs)
                     if event:
                         events.append(event)
@@ -452,7 +395,7 @@ class NflogWatcher:
             action = "nflog"
 
         payload = attrs.get(_NFULA_PAYLOAD, b"")
-        dest, proto, port = _extract_ip_dest(payload)
+        dest, proto, port = extract_ip_dest(payload)
         if not dest:
             return None
 

--- a/tach.toml
+++ b/tach.toml
@@ -45,6 +45,11 @@ depends_on = []
 path = "terok_shield.util"
 depends_on = []
 
+# Shared netlink / packet parsing utilities — stdlib-only
+[[modules]]
+path = "terok_shield.netlink"
+depends_on = []
+
 # Shared validators — standalone, no internal deps
 [[modules]]
 path = "terok_shield.validation"
@@ -80,6 +85,25 @@ depends_on = [
     "terok_shield.validation",
 ]
 
+# NFQUEUE netlink handler for interactive mode
+[[modules]]
+path = "terok_shield.nfqueue"
+depends_on = [
+    "terok_shield.nft_constants",
+    "terok_shield.netlink",
+]
+
+# Interactive verdict loop — orchestration for NFQUEUE mode
+[[modules]]
+path = "terok_shield.interactive"
+depends_on = [
+    "terok_shield.nft",
+    "terok_shield.nft_constants",
+    "terok_shield.nfqueue",
+    "terok_shield.run",
+    "terok_shield.state",
+]
+
 # dnsmasq lifecycle — config generation, launch, cleanup
 [[modules]]
 path = "terok_shield.dnsmasq"
@@ -95,6 +119,7 @@ path = "terok_shield.watch"
 depends_on = [
     "terok_shield.config",
     "terok_shield.dnsmasq",
+    "terok_shield.netlink",
     "terok_shield.nft_constants",
     "terok_shield.state",
 ]
@@ -113,10 +138,11 @@ depends_on = [
     "terok_shield.util",
 ]
 
-# Command registry — depends on watch for lazy-imported handler
+# Command registry — depends on watch + interactive for lazy-imported handlers
 [[modules]]
 path = "terok_shield.registry"
 depends_on = [
+    "terok_shield.interactive",
     "terok_shield.watch",
 ]
 
@@ -142,6 +168,7 @@ depends_on = [
     "terok_shield.config",
     "terok_shield.dns",
     "terok_shield.dnsmasq",
+    "terok_shield.interactive",
     "terok_shield.mode_hook",
     "terok_shield.nft",
     "terok_shield.podman_info",

--- a/tach.toml
+++ b/tach.toml
@@ -93,15 +93,17 @@ depends_on = [
     "terok_shield.netlink",
 ]
 
-# Interactive verdict loop — orchestration for NFQUEUE mode
+# Interactive verdict loop — dual-tier (NFQUEUE or NFLOG)
 [[modules]]
 path = "terok_shield.interactive"
 depends_on = [
+    "terok_shield.mode_hook",
     "terok_shield.nft",
     "terok_shield.nft_constants",
     "terok_shield.nfqueue",
     "terok_shield.run",
     "terok_shield.state",
+    "terok_shield.watch",
 ]
 
 # dnsmasq lifecycle — config generation, launch, cleanup

--- a/tach.toml
+++ b/tach.toml
@@ -168,7 +168,6 @@ depends_on = [
     "terok_shield.config",
     "terok_shield.dns",
     "terok_shield.dnsmasq",
-    "terok_shield.interactive",
     "terok_shield.mode_hook",
     "terok_shield.nft",
     "terok_shield.podman_info",

--- a/tests/testnet.py
+++ b/tests/testnet.py
@@ -91,6 +91,11 @@ CLOUDFLARE_DOMAIN = "one.one.one.one"  # Cloudflare DNS (always resolves)
 GOOGLE_DNS_DOMAIN = "dns.google"  # Google DNS (always resolves)
 NONEXISTENT_DOMAIN = "this-domain-does-not-exist.invalid"  # RFC 2606 reserved
 ALIAS_DOMAIN = "alias.example.com."  # CNAME-style answer for dig output filtering tests
+DNSMASQ_DOMAIN = "example.com"  # Generic domain for dnsmasq log parsing tests
+DNSMASQ_DOMAIN2 = "other.com"  # Secondary domain for dnsmasq cache tests
+STALE_DOMAIN = "old.com"  # Domain used to test cache rotation (replaced by new entries)
+FRESH_DOMAIN = "new.com"  # Domain used to test cache rotation (replaces stale entries)
+KEPT_DOMAIN = "kept.com"  # Domain that should survive OSError during cache refresh
 
 # ── IPv6 targets (used to verify IPv6 allowlisting and blocking) ──
 

--- a/tests/unit/test_api_surface.py
+++ b/tests/unit/test_api_surface.py
@@ -46,6 +46,7 @@ EXPECTED_ALL = [
     "SubprocessRunner",
     "USER_HOOKS_DIR",
     "ensure_containers_conf_hooks_dir",
+    "run_interactive",
     "setup_global_hooks",
     "system_hooks_dir",
 ]
@@ -90,6 +91,8 @@ class TestAPISurface:
             "loopback_ports",
             "audit_enabled",
             "profiles_dir",
+            "interactive",
+            "nfqueue_timeout",
         ]
 
         cfg = make_config()
@@ -98,6 +101,8 @@ class TestAPISurface:
         assert cfg.loopback_ports == ()
         assert cfg.audit_enabled is True
         assert cfg.profiles_dir is None
+        assert cfg.interactive is False
+        assert cfg.nfqueue_timeout == 5
 
     def test_shield_config_frozen(self, make_config):
         """ShieldConfig is frozen — assignment raises FrozenInstanceError."""

--- a/tests/unit/test_api_surface.py
+++ b/tests/unit/test_api_surface.py
@@ -46,7 +46,6 @@ EXPECTED_ALL = [
     "SubprocessRunner",
     "USER_HOOKS_DIR",
     "ensure_containers_conf_hooks_dir",
-    "run_interactive",
     "setup_global_hooks",
     "system_hooks_dir",
 ]

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -182,12 +182,30 @@ def test_prepare_parser_supports_profiles(parser: argparse.ArgumentParser) -> No
     assert parsed.profiles == ["base", "extra"]
 
 
+def test_prepare_parser_supports_interactive(parser: argparse.ArgumentParser) -> None:
+    """prepare accepts --interactive flag."""
+    parsed = parser.parse_args(["prepare", "my-ctr", "--interactive"])
+    assert parsed.interactive is True
+
+
+def test_prepare_interactive_default_false(parser: argparse.ArgumentParser) -> None:
+    """prepare defaults interactive to False."""
+    parsed = parser.parse_args(["prepare", "my-ctr"])
+    assert parsed.interactive is False
+
+
 def test_run_parser_supports_profiles(parser: argparse.ArgumentParser) -> None:
     """run accepts a positional container plus profile overrides."""
     parsed = parser.parse_args(["run", "my-ctr", "--profiles", "base"])
     assert parsed.command == "run"
     assert parsed.container == "my-ctr"
     assert parsed.profiles == ["base"]
+
+
+def test_run_parser_supports_interactive(parser: argparse.ArgumentParser) -> None:
+    """run accepts --interactive flag."""
+    parsed = parser.parse_args(["run", "my-ctr", "--interactive"])
+    assert parsed.interactive is True
 
 
 def test_logs_parser_supports_optional_container_and_count(parser: argparse.ArgumentParser) -> None:
@@ -279,6 +297,17 @@ def test_prepare_dispatches_and_prints_flags(
     assert "--annotation" in output
     assert "--name" in output
     assert _CONTAINER in output
+
+
+def test_prepare_interactive_passes_to_build_config(
+    cli_dispatch: CliDispatchHarness, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """prepare --interactive passes interactive=True to _build_config."""
+    cli_dispatch.shield.pre_start.return_value = ["--annotation", "a=b"]
+    main(["prepare", _CONTAINER, "--interactive"])
+    cli_dispatch.build_config.assert_called_once_with(
+        _CONTAINER, state_dir_override=None, interactive=True
+    )
 
 
 def test_prepare_json_output(

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -299,6 +299,17 @@ def test_prepare_dispatches_and_prints_flags(
     assert _CONTAINER in output
 
 
+def test_prepare_default_passes_interactive_none(
+    cli_dispatch: CliDispatchHarness, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """prepare without --interactive passes interactive=None to _build_config."""
+    cli_dispatch.shield.pre_start.return_value = ["--annotation", "a=b"]
+    main(["prepare", _CONTAINER])
+    cli_dispatch.build_config.assert_called_once_with(
+        _CONTAINER, state_dir_override=None, interactive=None
+    )
+
+
 def test_prepare_interactive_passes_to_build_config(
     cli_dispatch: CliDispatchHarness, capsys: pytest.CaptureFixture[str]
 ) -> None:
@@ -308,6 +319,14 @@ def test_prepare_interactive_passes_to_build_config(
     cli_dispatch.build_config.assert_called_once_with(
         _CONTAINER, state_dir_override=None, interactive=True
     )
+
+
+def test_interactive_command_dispatches_to_handler(cli_dispatch: CliDispatchHarness) -> None:
+    """interactive command routes through registry to _handle_interactive."""
+    with mock.patch("terok_shield.interactive.run_interactive") as mock_run:
+        main(["interactive", _CONTAINER])
+    mock_run.assert_called_once()
+    assert mock_run.call_args[0][1] == _CONTAINER
 
 
 def test_prepare_json_output(

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -244,6 +244,14 @@ class TestInteractiveConfig:
         assert cfg.interactive is True
         assert cfg.nfqueue_timeout == 30
 
+    def test_file_config_accepts_boundary_low(self) -> None:
+        """nfqueue_timeout=1 (lower bound) is accepted."""
+        assert ShieldFileConfig(nfqueue_timeout=1).nfqueue_timeout == 1
+
+    def test_file_config_accepts_boundary_high(self) -> None:
+        """nfqueue_timeout=60 (upper bound) is accepted."""
+        assert ShieldFileConfig(nfqueue_timeout=60).nfqueue_timeout == 60
+
     def test_file_config_rejects_timeout_zero(self) -> None:
         """nfqueue_timeout=0 is rejected by Pydantic (ge=1)."""
         with pytest.raises(ValidationError):
@@ -274,3 +282,13 @@ class TestInteractiveConfig:
         cfg = ShieldConfig(state_dir=tmp_path, interactive=True, nfqueue_timeout=10)
         assert cfg.interactive is True
         assert cfg.nfqueue_timeout == 10
+
+    def test_shield_config_accepts_boundary_low(self, tmp_path: Path) -> None:
+        """ShieldConfig accepts nfqueue_timeout=1 (lower bound)."""
+        cfg = ShieldConfig(state_dir=tmp_path, interactive=True, nfqueue_timeout=1)
+        assert cfg.nfqueue_timeout == 1
+
+    def test_shield_config_accepts_boundary_high(self, tmp_path: Path) -> None:
+        """ShieldConfig accepts nfqueue_timeout=60 (upper bound)."""
+        cfg = ShieldConfig(state_dir=tmp_path, interactive=True, nfqueue_timeout=60)
+        assert cfg.nfqueue_timeout == 60

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -224,3 +224,53 @@ class TestShieldFileConfigAuditValidation:
         """audit.enabled must be a boolean."""
         with pytest.raises(ValidationError):
             ShieldFileConfig(audit={"enabled": "yes-please"})  # type: ignore[arg-type]
+
+
+# ── Interactive / NFQUEUE config fields ────────────────
+
+
+class TestInteractiveConfig:
+    """Pydantic + dataclass validation for interactive mode fields."""
+
+    def test_file_config_defaults(self) -> None:
+        """ShieldFileConfig defaults: interactive=False, nfqueue_timeout=5."""
+        cfg = ShieldFileConfig()
+        assert cfg.interactive is False
+        assert cfg.nfqueue_timeout == 5
+
+    def test_file_config_accepts_valid(self) -> None:
+        """Valid interactive + nfqueue_timeout are accepted."""
+        cfg = ShieldFileConfig(interactive=True, nfqueue_timeout=30)
+        assert cfg.interactive is True
+        assert cfg.nfqueue_timeout == 30
+
+    def test_file_config_rejects_timeout_zero(self) -> None:
+        """nfqueue_timeout=0 is rejected by Pydantic (ge=1)."""
+        with pytest.raises(ValidationError):
+            ShieldFileConfig(nfqueue_timeout=0)
+
+    def test_file_config_rejects_timeout_too_large(self) -> None:
+        """nfqueue_timeout=61 is rejected by Pydantic (le=60)."""
+        with pytest.raises(ValidationError):
+            ShieldFileConfig(nfqueue_timeout=61)
+
+    def test_shield_config_rejects_timeout_zero(self, tmp_path: Path) -> None:
+        """ShieldConfig.__post_init__ rejects nfqueue_timeout=0."""
+        with pytest.raises(ValueError, match="nfqueue_timeout"):
+            ShieldConfig(state_dir=tmp_path, nfqueue_timeout=0)
+
+    def test_shield_config_rejects_timeout_negative(self, tmp_path: Path) -> None:
+        """ShieldConfig.__post_init__ rejects negative nfqueue_timeout."""
+        with pytest.raises(ValueError, match="nfqueue_timeout"):
+            ShieldConfig(state_dir=tmp_path, nfqueue_timeout=-1)
+
+    def test_shield_config_rejects_timeout_too_large(self, tmp_path: Path) -> None:
+        """ShieldConfig.__post_init__ rejects nfqueue_timeout > 60."""
+        with pytest.raises(ValueError, match="nfqueue_timeout"):
+            ShieldConfig(state_dir=tmp_path, nfqueue_timeout=100)
+
+    def test_shield_config_accepts_valid(self, tmp_path: Path) -> None:
+        """ShieldConfig accepts valid nfqueue_timeout."""
+        cfg = ShieldConfig(state_dir=tmp_path, interactive=True, nfqueue_timeout=10)
+        assert cfg.interactive is True
+        assert cfg.nfqueue_timeout == 10

--- a/tests/unit/test_hook_entrypoint.py
+++ b/tests/unit/test_hook_entrypoint.py
@@ -40,7 +40,7 @@ _ROUTE_NO_DEFAULT = (
 )
 
 
-def _oci_json(pid: int = 42, state_dir: str = "/tmp/sd", version: int = 3) -> str:
+def _oci_json(pid: int = 42, state_dir: str = "/tmp/sd", version: int = 4) -> str:
     """Return a minimal OCI state JSON for hook_entrypoint.main()."""
     return json.dumps(
         {
@@ -648,7 +648,7 @@ def test_main_returns_1_when_pid_missing_for_createruntime(tmp_path: Path) -> No
             "pid": 0,
             "annotations": {
                 "terok.shield.state_dir": str(tmp_path),
-                "terok.shield.version": "3",
+                "terok.shield.version": "4",
             },
         }
     )
@@ -734,7 +734,7 @@ def test_main_returns_1_for_relative_state_dir() -> None:
             "pid": 42,
             "annotations": {
                 "terok.shield.state_dir": "relative/path",
-                "terok.shield.version": "3",
+                "terok.shield.version": "4",
             },
         }
     )

--- a/tests/unit/test_hook_mode_class.py
+++ b/tests/unit/test_hook_mode_class.py
@@ -246,9 +246,10 @@ def test_allow_and_deny_use_expected_nft_set(
 
     getattr(harness.mode, method)("test-ctr", ip)
 
-    nft_args = harness.runner.nft_via_nsenter.call_args.args
-    assert expected_action in nft_args
-    assert expected_set in nft_args
+    # deny_ip now does add-to-deny-set then delete-from-allow-set;
+    # check that the expected action+set pair appears in any call.
+    all_calls = harness.runner.nft_via_nsenter.call_args_list
+    assert any(expected_action in c.args and expected_set in c.args for c in all_calls)
 
 
 def test_allow_persists_and_deduplicates_live_allowed(

--- a/tests/unit/test_interactive.py
+++ b/tests/unit/test_interactive.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import json
+import os
 import time
 from pathlib import Path
 from unittest import mock
@@ -397,3 +398,199 @@ class TestRunInteractive:
         ):
             with pytest.raises(SystemExit, match="1"):
                 run_interactive(tmp_path, "ctr")
+
+
+# ── InteractiveSession._loop / select helpers ────────
+
+
+class TestLoopHelpers:
+    """Cover the small select-loop helper methods."""
+
+    def test_select_readable(self, tmp_path: Path) -> None:
+        """_select_readable returns fd set from select() results."""
+        session = _make_session(tmp_path)
+        handler = mock.MagicMock()
+        handler.fileno.return_value = 5
+        with mock.patch("terok_shield.interactive.select") as sel:
+            sel.select.return_value = ([handler, 3], [], [])
+            result = session._select_readable(handler, 3)
+        assert result == {5, 3}
+
+    def test_poll_nfqueue_triggers_handle(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """_poll_nfqueue calls _handle_queued when handler fd is ready."""
+        session = _make_session(tmp_path)
+        handler = mock.MagicMock()
+        handler.fileno.return_value = 5
+        handler.poll.return_value = [_make_pkt(packet_id=88)]
+        session._poll_nfqueue(handler, {5})
+        assert 88 in session._pending
+
+    def test_poll_nfqueue_noop_when_not_ready(self, tmp_path: Path) -> None:
+        """_poll_nfqueue does nothing when handler fd not in ready set."""
+        session = _make_session(tmp_path)
+        handler = mock.MagicMock()
+        handler.fileno.return_value = 5
+        session._poll_nfqueue(handler, {3})
+        handler.poll.assert_not_called()
+
+    def test_poll_stdin_returns_buf_when_not_ready(self, tmp_path: Path) -> None:
+        """_poll_stdin returns buffer unchanged when stdin not in ready set."""
+        session = _make_session(tmp_path)
+        with mock.patch("sys.stdin") as stdin:
+            stdin.fileno.return_value = 0
+            result = session._poll_stdin(mock.MagicMock(), "partial", {5})
+        assert result == "partial"
+
+    def test_maybe_refresh_domains_triggers_refresh(self, tmp_path: Path) -> None:
+        """_maybe_refresh_domains calls refresh when interval elapsed."""
+        session = _make_session(tmp_path)
+        session._last_domain_refresh = 0.0  # far in the past
+        with mock.patch.object(session, "_refresh_domain_cache") as refresh:
+            session._maybe_refresh_domains()
+        refresh.assert_called_once()
+
+    def test_maybe_refresh_domains_skips_when_fresh(self, tmp_path: Path) -> None:
+        """_maybe_refresh_domains does nothing when recently refreshed."""
+        session = _make_session(tmp_path)
+        session._last_domain_refresh = time.monotonic()
+        with mock.patch.object(session, "_refresh_domain_cache") as refresh:
+            session._maybe_refresh_domains()
+        refresh.assert_not_called()
+
+
+# ── InteractiveSession._read_stdin ────────────────────
+
+
+class TestReadStdin:
+    """Cover the _read_stdin I/O method."""
+
+    def _patch_stdin_fd(self) -> mock._patch:
+        """Return a context manager that stubs sys.stdin.fileno → 0."""
+        return mock.patch("sys.stdin", **{"fileno.return_value": 0})
+
+    def test_returns_none_on_eof(self, tmp_path: Path) -> None:
+        """Returns None when os.read returns empty bytes (EOF)."""
+        session = _make_session(tmp_path)
+        handler = mock.MagicMock()
+        with self._patch_stdin_fd(), mock.patch("os.read", return_value=b""):
+            result = session._read_stdin(handler, "")
+        assert result is None
+
+    def test_returns_buf_on_oserror(self, tmp_path: Path) -> None:
+        """Returns existing buffer on OSError."""
+        session = _make_session(tmp_path)
+        handler = mock.MagicMock()
+        with self._patch_stdin_fd(), mock.patch("os.read", side_effect=OSError):
+            result = session._read_stdin(handler, "leftover")
+        assert result == "leftover"
+
+    def test_processes_complete_line(self, tmp_path: Path) -> None:
+        """Complete JSON line is processed, remainder returned as buffer."""
+        session = _make_session(tmp_path)
+        handler = mock.MagicMock()
+        line = json.dumps({"type": "verdict", "id": 77, "action": "accept"})
+        pkt = _make_pkt(packet_id=77)
+        session._pending[77] = _PendingPacket(packet=pkt, queued_at=time.monotonic())
+
+        with (
+            self._patch_stdin_fd(),
+            mock.patch("os.read", return_value=f"{line}\nremainder".encode()),
+        ):
+            result = session._read_stdin(handler, "")
+        assert result == "remainder"
+        handler.verdict.assert_called_once()
+
+    def test_buffers_incomplete_line(self, tmp_path: Path) -> None:
+        """Incomplete line is buffered for next read."""
+        session = _make_session(tmp_path)
+        handler = mock.MagicMock()
+        with self._patch_stdin_fd(), mock.patch("os.read", return_value=b"partial"):
+            result = session._read_stdin(handler, "")
+        assert result == "partial"
+        handler.verdict.assert_not_called()
+
+
+# ── InteractiveSession._loop ─────────────────────────
+
+
+class TestLoop:
+    """Cover the main _loop method."""
+
+    def test_loop_exits_on_stdin_eof(self, tmp_path: Path) -> None:
+        """_loop exits when _poll_stdin returns None (EOF)."""
+        session = _make_session(tmp_path)
+        handler = mock.MagicMock()
+        handler.fileno.return_value = 5
+
+        with mock.patch("terok_shield.interactive.select") as sel:
+            sel.select.return_value = ([0], [], [])
+            with mock.patch("os.read", return_value=b""):
+                with mock.patch("sys.stdin") as stdin:
+                    stdin.fileno.return_value = 0
+                    import terok_shield.interactive as mod
+
+                    mod._running = True
+                    session._loop(handler, 0)
+        # If we get here, _loop exited (didn't hang)
+
+    def test_loop_exits_on_running_false(self, tmp_path: Path) -> None:
+        """_loop exits when _running flag is cleared."""
+        session = _make_session(tmp_path)
+        handler = mock.MagicMock()
+        handler.fileno.return_value = 5
+
+        import terok_shield.interactive as mod
+
+        mod._running = False
+        session._loop(handler, 0)
+
+
+# ── InteractiveSession.run (success path) ────────────
+
+
+class TestRunMethod:
+    """Cover the run() orchestration method."""
+
+    def test_run_creates_handler_and_loops(self, tmp_path: Path) -> None:
+        """run() creates handler, sets up signals, calls _loop, then drains."""
+        session = _make_session(tmp_path)
+        mock_handler = mock.MagicMock()
+        mock_handler.fileno.return_value = 5
+
+        import terok_shield.interactive as mod
+
+        mod._running = True
+
+        with (
+            mock.patch.object(type(session), "_loop", side_effect=lambda h, fd: None),
+            mock.patch("terok_shield.interactive.NfqueueHandler.create", return_value=mock_handler),
+            mock.patch("terok_shield.interactive._set_nonblocking"),
+            mock.patch("sys.stdin", **{"fileno.return_value": 0}),
+        ):
+            session.run()
+
+        mock_handler.close.assert_called_once()
+
+
+# ── _set_nonblocking ─────────────────────────────────
+
+
+class TestSetNonblocking:
+    """Cover the _set_nonblocking helper."""
+
+    def test_sets_o_nonblock_flag(self) -> None:
+        """_set_nonblocking sets O_NONBLOCK on the fd via a real pipe."""
+        import fcntl
+
+        from terok_shield.interactive import _set_nonblocking
+
+        r, w = os.pipe()
+        try:
+            _set_nonblocking(r)
+            flags = fcntl.fcntl(r, fcntl.F_GETFL)
+            assert flags & os.O_NONBLOCK
+        finally:
+            os.close(r)
+            os.close(w)

--- a/tests/unit/test_interactive.py
+++ b/tests/unit/test_interactive.py
@@ -404,7 +404,7 @@ class TestApplyVerdict:
 
 
 class TestRunInteractive:
-    """run_interactive validates state before starting."""
+    """run_interactive dispatches based on interactive tier."""
 
     def test_exits_if_not_interactive(self, tmp_path: Path) -> None:
         """Exits with code 1 if interactive flag file is missing."""
@@ -412,28 +412,46 @@ class TestRunInteractive:
         with pytest.raises(SystemExit, match="1"):
             run_interactive(tmp_path, "ctr")
 
-    def test_delegates_to_nsenter_reexec(self, tmp_path: Path) -> None:
-        """Without env var, run_interactive delegates to _nsenter_reexec."""
+    def test_nfqueue_tier_delegates_to_nsenter(self, tmp_path: Path) -> None:
+        """nfqueue tier without env var delegates to _nsenter_reexec."""
         state.ensure_state_dirs(tmp_path)
-        state.interactive_path(tmp_path).write_text("1\n")
+        state.interactive_path(tmp_path).write_text("nfqueue\n")
 
         with mock.patch("terok_shield.interactive._nsenter_reexec") as reexec:
             run_interactive(tmp_path, "ctr")
         reexec.assert_called_once()
         assert reexec.call_args[0][1] == "ctr"
 
-    def test_runs_directly_when_nsenter_env_set(self, tmp_path: Path) -> None:
-        """With _TEROK_SHIELD_NSENTER=1, runs verdict loop directly."""
+    def test_nfqueue_tier_runs_directly_when_env_set(self, tmp_path: Path) -> None:
+        """nfqueue tier with _TEROK_SHIELD_NSENTER=1 runs loop directly."""
         state.ensure_state_dirs(tmp_path)
-        state.interactive_path(tmp_path).write_text("1\n")
+        state.interactive_path(tmp_path).write_text("nfqueue\n")
 
         with (
             mock.patch.dict(os.environ, {"_TEROK_SHIELD_NSENTER": "1"}),
-            mock.patch("terok_shield.interactive._run_verdict_loop") as loop,
+            mock.patch("terok_shield.interactive._run_nfqueue_loop") as loop,
         ):
             run_interactive(tmp_path, "ctr", timeout=10)
         loop.assert_called_once()
         assert loop.call_args.kwargs["timeout"] == 10
+
+    def test_nflog_tier_runs_on_host(self, tmp_path: Path) -> None:
+        """nflog tier runs NflogInteractiveSession directly (no nsenter)."""
+        state.ensure_state_dirs(tmp_path)
+        state.interactive_path(tmp_path).write_text("nflog\n")
+
+        with mock.patch("terok_shield.interactive._run_nflog_loop") as loop:
+            run_interactive(tmp_path, "ctr")
+        loop.assert_called_once()
+
+    def test_legacy_value_falls_back_to_nflog(self, tmp_path: Path) -> None:
+        """Legacy "1" in interactive file maps to nflog tier."""
+        state.ensure_state_dirs(tmp_path)
+        state.interactive_path(tmp_path).write_text("1\n")
+
+        with mock.patch("terok_shield.interactive._run_nflog_loop") as loop:
+            run_interactive(tmp_path, "ctr")
+        loop.assert_called_once()
 
 
 class TestNsenterReexec:

--- a/tests/unit/test_interactive.py
+++ b/tests/unit/test_interactive.py
@@ -412,17 +412,66 @@ class TestRunInteractive:
         with pytest.raises(SystemExit, match="1"):
             run_interactive(tmp_path, "ctr")
 
-    def test_starts_if_interactive_enabled(self, tmp_path: Path) -> None:
-        """Creates session when interactive flag is present (NFQUEUE bind fails → exit 1)."""
+    def test_delegates_to_nsenter_reexec(self, tmp_path: Path) -> None:
+        """Without env var, run_interactive delegates to _nsenter_reexec."""
+        state.ensure_state_dirs(tmp_path)
+        state.interactive_path(tmp_path).write_text("1\n")
+
+        with mock.patch("terok_shield.interactive._nsenter_reexec") as reexec:
+            run_interactive(tmp_path, "ctr")
+        reexec.assert_called_once()
+        assert reexec.call_args[0][1] == "ctr"
+
+    def test_runs_directly_when_nsenter_env_set(self, tmp_path: Path) -> None:
+        """With _TEROK_SHIELD_NSENTER=1, runs verdict loop directly."""
         state.ensure_state_dirs(tmp_path)
         state.interactive_path(tmp_path).write_text("1\n")
 
         with (
-            mock.patch("terok_shield.interactive.SubprocessRunner"),
-            mock.patch("terok_shield.interactive.NfqueueHandler.create", return_value=None),
+            mock.patch.dict(os.environ, {"_TEROK_SHIELD_NSENTER": "1"}),
+            mock.patch("terok_shield.interactive._run_verdict_loop") as loop,
         ):
-            with pytest.raises(SystemExit, match="1"):
-                run_interactive(tmp_path, "ctr")
+            run_interactive(tmp_path, "ctr", timeout=10)
+        loop.assert_called_once()
+        assert loop.call_args.kwargs["timeout"] == 10
+
+
+class TestNsenterReexec:
+    """_nsenter_reexec builds the correct subprocess command."""
+
+    def test_reexecs_via_podman_unshare(self, tmp_path: Path) -> None:
+        """Subprocess command uses podman unshare nsenter."""
+        mock_runner = mock.MagicMock()
+        mock_runner.podman_inspect.return_value = "12345"
+
+        with (
+            mock.patch("terok_shield.interactive.SubprocessRunner", return_value=mock_runner),
+            mock.patch("subprocess.run", return_value=mock.MagicMock(returncode=0)) as mock_run,
+            pytest.raises(SystemExit, match="0"),
+        ):
+            from terok_shield.interactive import _nsenter_reexec
+
+            _nsenter_reexec(tmp_path, "my-ctr", timeout=5)
+
+        cmd = mock_run.call_args[0][0]
+        assert cmd[:3] == ["podman", "unshare", "nsenter"]
+        assert "-n" in cmd
+        assert "12345" in cmd
+        assert "terok_shield.interactive" in cmd
+        assert mock_run.call_args[1]["env"]["_TEROK_SHIELD_NSENTER"] == "1"
+
+    def test_exits_if_container_not_running(self, tmp_path: Path) -> None:
+        """Exits with code 1 if container PID is 0."""
+        mock_runner = mock.MagicMock()
+        mock_runner.podman_inspect.return_value = "0"
+
+        with (
+            mock.patch("terok_shield.interactive.SubprocessRunner", return_value=mock_runner),
+            pytest.raises(SystemExit, match="1"),
+        ):
+            from terok_shield.interactive import _nsenter_reexec
+
+            _nsenter_reexec(tmp_path, "dead-ctr", timeout=5)
 
 
 # ── InteractiveSession._loop / select helpers ────────

--- a/tests/unit/test_interactive.py
+++ b/tests/unit/test_interactive.py
@@ -335,6 +335,21 @@ class TestRefreshDomainCache:
         session._refresh_domain_cache()  # should not raise
         assert session._ip_to_domain == {}
 
+    def test_oserror_preserves_previous_cache(self, tmp_path: Path) -> None:
+        """OSError during read keeps the previous cache intact."""
+        state.ensure_state_dirs(tmp_path)
+        log = state.dnsmasq_log_path(tmp_path)
+        log.write_text(f"reply kept.com is {TEST_IP1}\n")
+
+        session = _make_session(tmp_path)
+        session._refresh_domain_cache()
+        assert session._ip_to_domain[TEST_IP1] == "kept.com"
+
+        # Simulate OSError on next read (e.g. permission denied mid-rotation)
+        with mock.patch.object(type(log), "read_text", side_effect=OSError("perm")):
+            session._refresh_domain_cache()
+        assert session._ip_to_domain[TEST_IP1] == "kept.com"
+
 
 # ── InteractiveSession._apply_verdict ──────────────────
 

--- a/tests/unit/test_interactive.py
+++ b/tests/unit/test_interactive.py
@@ -1,0 +1,399 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the interactive NFQUEUE verdict loop."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from terok_shield import state
+from terok_shield.interactive import (
+    InteractiveSession,
+    _append_unique,
+    _handle_signal,
+    _PendingPacket,
+    run_interactive,
+)
+from terok_shield.nfqueue import QueuedPacket
+
+from ..testnet import TEST_IP1, TEST_IP2
+
+
+def _make_session(tmp_path: Path, **kwargs) -> InteractiveSession:
+    """Create an InteractiveSession with a mock runner."""
+    state.ensure_state_dirs(tmp_path)
+    return InteractiveSession(
+        runner=mock.MagicMock(),
+        state_dir=tmp_path,
+        container="test-ctr",
+        **kwargs,
+    )
+
+
+def _make_pkt(packet_id: int = 1, dest: str = TEST_IP1, port: int = 443) -> QueuedPacket:
+    """Create a test QueuedPacket."""
+    return QueuedPacket(packet_id=packet_id, dest=dest, port=port, proto=6)
+
+
+# ── _handle_signal ────────────────────────────────────
+
+
+class TestHandleSignal:
+    """Signal handler sets the stop flag."""
+
+    def test_sets_running_false(self) -> None:
+        """_handle_signal sets _running to False."""
+        import terok_shield.interactive as mod
+
+        mod._running = True
+        _handle_signal(2, None)
+        assert mod._running is False
+
+
+# ── _append_unique ─────────────────────────────────────
+
+
+class TestAppendUnique:
+    """File append helper deduplicates entries."""
+
+    def test_appends_new_entry(self, tmp_path: Path) -> None:
+        """New value is appended."""
+        p = tmp_path / "test.txt"
+        _append_unique(p, "a")
+        assert p.read_text() == "a\n"
+
+    def test_deduplicates(self, tmp_path: Path) -> None:
+        """Duplicate value is not appended twice."""
+        p = tmp_path / "test.txt"
+        _append_unique(p, "a")
+        _append_unique(p, "a")
+        assert p.read_text() == "a\n"
+
+    def test_creates_parent_dirs(self, tmp_path: Path) -> None:
+        """Parent directories are created if missing."""
+        p = tmp_path / "sub" / "dir" / "test.txt"
+        _append_unique(p, "x")
+        assert p.read_text() == "x\n"
+
+
+# ── _PendingPacket ─────────────────────────────────────
+
+
+class TestPendingPacket:
+    """PendingPacket dataclass."""
+
+    def test_fields(self) -> None:
+        """Stores packet, queued_at, domain."""
+        pkt = _make_pkt()
+        pp = _PendingPacket(packet=pkt, queued_at=1.0, domain="example.com")
+        assert pp.packet is pkt
+        assert pp.queued_at == 1.0
+        assert pp.domain == "example.com"
+
+    def test_default_domain(self) -> None:
+        """Domain defaults to empty string."""
+        pp = _PendingPacket(packet=_make_pkt(), queued_at=0.0)
+        assert pp.domain == ""
+
+
+# ── InteractiveSession._handle_queued ──────────────────
+
+
+class TestHandleQueued:
+    """_handle_queued emits pending events and tracks packets."""
+
+    def test_emits_pending_event(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+        """Queued packet produces a JSON pending event on stdout."""
+        session = _make_session(tmp_path)
+        pkt = _make_pkt(packet_id=42)
+        session._handle_queued(pkt)
+
+        out = capsys.readouterr().out.strip()
+        event = json.loads(out)
+        assert event["type"] == "pending"
+        assert event["id"] == 42
+        assert event["dest"] == TEST_IP1
+
+    def test_tracks_in_pending(self, tmp_path: Path) -> None:
+        """Queued packet is added to _pending dict."""
+        session = _make_session(tmp_path)
+        pkt = _make_pkt(packet_id=7)
+        session._handle_queued(pkt)
+        assert 7 in session._pending
+
+    def test_includes_domain_when_cached(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Domain is included when IP is in the domain cache."""
+        session = _make_session(tmp_path)
+        session._ip_to_domain[TEST_IP1] = "example.com"
+        session._handle_queued(_make_pkt())
+
+        event = json.loads(capsys.readouterr().out.strip())
+        assert event["domain"] == "example.com"
+
+
+# ── InteractiveSession._process_command ────────────────
+
+
+class TestProcessCommand:
+    """_process_command handles verdict JSON commands."""
+
+    def test_accept_verdict(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+        """Accept verdict issues NF_ACCEPT and emits verdict_applied."""
+        session = _make_session(tmp_path)
+        handler = mock.MagicMock()
+        pkt = _make_pkt(packet_id=10)
+        session._pending[10] = _PendingPacket(packet=pkt, queued_at=time.monotonic())
+
+        session._process_command(
+            handler, json.dumps({"type": "verdict", "id": 10, "action": "accept"})
+        )
+
+        handler.verdict.assert_called_once_with(10, accept=True)
+        event = json.loads(capsys.readouterr().out.strip())
+        assert event["type"] == "verdict_applied"
+        assert event["action"] == "accept"
+        # Check file persistence
+        assert TEST_IP1 in state.live_allowed_path(tmp_path).read_text()
+
+    def test_deny_verdict(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+        """Deny verdict issues NF_DROP and persists to deny.list."""
+        session = _make_session(tmp_path)
+        handler = mock.MagicMock()
+        pkt = _make_pkt(packet_id=20)
+        session._pending[20] = _PendingPacket(packet=pkt, queued_at=time.monotonic())
+
+        session._process_command(
+            handler, json.dumps({"type": "verdict", "id": 20, "action": "deny"})
+        )
+
+        handler.verdict.assert_called_once_with(20, accept=False)
+        event = json.loads(capsys.readouterr().out.strip())
+        assert event["type"] == "verdict_applied"
+        assert TEST_IP1 in state.deny_path(tmp_path).read_text()
+
+    def test_invalid_json_ignored(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+        """Invalid JSON is logged and ignored."""
+        import logging
+
+        session = _make_session(tmp_path)
+        handler = mock.MagicMock()
+        with caplog.at_level(logging.WARNING):
+            session._process_command(handler, "not json")
+        handler.verdict.assert_not_called()
+        assert "invalid JSON" in caplog.text
+
+    def test_wrong_type_ignored(self, tmp_path: Path) -> None:
+        """Non-verdict type is silently ignored."""
+        session = _make_session(tmp_path)
+        handler = mock.MagicMock()
+        session._process_command(handler, json.dumps({"type": "other", "id": 1}))
+        handler.verdict.assert_not_called()
+
+    def test_bool_id_rejected(self, tmp_path: Path) -> None:
+        """Boolean packet_id is rejected (type guard)."""
+        session = _make_session(tmp_path)
+        handler = mock.MagicMock()
+        session._process_command(
+            handler, json.dumps({"type": "verdict", "id": True, "action": "accept"})
+        )
+        handler.verdict.assert_not_called()
+
+    def test_non_string_action_rejected(self, tmp_path: Path) -> None:
+        """Non-string action is rejected (type guard)."""
+        session = _make_session(tmp_path)
+        handler = mock.MagicMock()
+        session._process_command(handler, json.dumps({"type": "verdict", "id": 1, "action": 42}))
+        handler.verdict.assert_not_called()
+
+    def test_unknown_packet_id_ignored(self, tmp_path: Path) -> None:
+        """Verdict for unknown/timed-out packet_id is silently ignored."""
+        session = _make_session(tmp_path)
+        handler = mock.MagicMock()
+        session._process_command(
+            handler, json.dumps({"type": "verdict", "id": 999, "action": "accept"})
+        )
+        handler.verdict.assert_not_called()
+
+    def test_nft_failure_emits_verdict_failed(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Failed nft update emits verdict_failed instead of verdict_applied."""
+        session = _make_session(tmp_path)
+        session._runner.nft_via_nsenter.side_effect = RuntimeError("nft failed")
+        handler = mock.MagicMock()
+        pkt = _make_pkt(packet_id=30)
+        session._pending[30] = _PendingPacket(packet=pkt, queued_at=time.monotonic())
+
+        session._process_command(
+            handler, json.dumps({"type": "verdict", "id": 30, "action": "accept"})
+        )
+
+        event = json.loads(capsys.readouterr().out.strip())
+        assert event["type"] == "verdict_failed"
+
+
+# ── InteractiveSession._sweep_timeouts ─────────────────
+
+
+class TestSweepTimeouts:
+    """Timeout sweep drops expired packets."""
+
+    def test_expired_packet_dropped(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+        """Packet past timeout is dropped with verdict_timeout event."""
+        session = _make_session(tmp_path, timeout=1)
+        handler = mock.MagicMock()
+        pkt = _make_pkt(packet_id=50)
+        session._pending[50] = _PendingPacket(packet=pkt, queued_at=time.monotonic() - 2.0)
+
+        session._sweep_timeouts(handler)
+
+        handler.verdict.assert_called_once_with(50, accept=False)
+        assert 50 not in session._pending
+        event = json.loads(capsys.readouterr().out.strip())
+        assert event["type"] == "verdict_timeout"
+
+    def test_fresh_packet_not_dropped(self, tmp_path: Path) -> None:
+        """Packet within timeout is not dropped."""
+        session = _make_session(tmp_path, timeout=60)
+        handler = mock.MagicMock()
+        pkt = _make_pkt(packet_id=51)
+        session._pending[51] = _PendingPacket(packet=pkt, queued_at=time.monotonic())
+
+        session._sweep_timeouts(handler)
+
+        handler.verdict.assert_not_called()
+        assert 51 in session._pending
+
+
+# ── InteractiveSession._drain_pending ──────────────────
+
+
+class TestDrainPending:
+    """Drain drops all remaining packets on shutdown."""
+
+    def test_drains_all(self, tmp_path: Path) -> None:
+        """All pending packets are rejected on drain."""
+        session = _make_session(tmp_path)
+        handler = mock.MagicMock()
+        for i in range(3):
+            session._pending[i] = _PendingPacket(
+                packet=_make_pkt(packet_id=i), queued_at=time.monotonic()
+            )
+
+        session._drain_pending(handler)
+
+        assert handler.verdict.call_count == 3
+        assert len(session._pending) == 0
+
+
+# ── InteractiveSession._refresh_domain_cache ───────────
+
+
+class TestRefreshDomainCache:
+    """Domain cache refresh from dnsmasq log."""
+
+    def test_parses_reply_lines(self, tmp_path: Path) -> None:
+        """Reply lines in dnsmasq log populate the IP→domain cache."""
+        state.ensure_state_dirs(tmp_path)
+        log = state.dnsmasq_log_path(tmp_path)
+        log.write_text(f"reply example.com is {TEST_IP1}\nreply other.com is {TEST_IP2}\n")
+
+        session = _make_session(tmp_path)
+        session._refresh_domain_cache()
+
+        assert session._ip_to_domain[TEST_IP1] == "example.com"
+        assert session._ip_to_domain[TEST_IP2] == "other.com"
+
+    def test_rebuilds_fresh_on_each_call(self, tmp_path: Path) -> None:
+        """Cache is rebuilt from scratch, dropping stale entries after log rotation."""
+        state.ensure_state_dirs(tmp_path)
+        log = state.dnsmasq_log_path(tmp_path)
+        log.write_text(f"reply old.com is {TEST_IP1}\n")
+
+        session = _make_session(tmp_path)
+        session._refresh_domain_cache()
+        assert TEST_IP1 in session._ip_to_domain
+
+        # Simulate log rotation
+        log.write_text(f"reply new.com is {TEST_IP2}\n")
+        session._refresh_domain_cache()
+        assert TEST_IP1 not in session._ip_to_domain
+        assert session._ip_to_domain[TEST_IP2] == "new.com"
+
+    def test_missing_log_no_error(self, tmp_path: Path) -> None:
+        """Missing log file doesn't raise."""
+        session = _make_session(tmp_path)
+        session._refresh_domain_cache()  # should not raise
+        assert session._ip_to_domain == {}
+
+
+# ── InteractiveSession._apply_verdict ──────────────────
+
+
+class TestApplyVerdict:
+    """Verdict persistence logic."""
+
+    def test_accept_persists_to_live_allowed(self, tmp_path: Path) -> None:
+        """Accept writes IP to live.allowed."""
+        session = _make_session(tmp_path)
+        pkt = _make_pkt()
+        pending = _PendingPacket(packet=pkt, queued_at=time.monotonic())
+
+        ok = session._apply_verdict(pending, accept=True)
+
+        assert ok is True
+        assert TEST_IP1 in state.live_allowed_path(tmp_path).read_text()
+
+    def test_deny_persists_to_deny_list(self, tmp_path: Path) -> None:
+        """Deny writes IP to deny.list."""
+        session = _make_session(tmp_path)
+        pkt = _make_pkt()
+        pending = _PendingPacket(packet=pkt, queued_at=time.monotonic())
+
+        ok = session._apply_verdict(pending, accept=False)
+
+        assert ok is True
+        assert TEST_IP1 in state.deny_path(tmp_path).read_text()
+
+    def test_nft_failure_returns_false(self, tmp_path: Path) -> None:
+        """Failed nft command returns False."""
+        session = _make_session(tmp_path)
+        session._runner.nft_via_nsenter.side_effect = RuntimeError("fail")
+        pkt = _make_pkt()
+        pending = _PendingPacket(packet=pkt, queued_at=time.monotonic())
+
+        ok = session._apply_verdict(pending, accept=True)
+        assert ok is False
+
+
+# ── run_interactive entry point ────────────────────────
+
+
+class TestRunInteractive:
+    """run_interactive validates state before starting."""
+
+    def test_exits_if_not_interactive(self, tmp_path: Path) -> None:
+        """Exits with code 1 if interactive flag file is missing."""
+        state.ensure_state_dirs(tmp_path)
+        with pytest.raises(SystemExit, match="1"):
+            run_interactive(tmp_path, "ctr")
+
+    def test_starts_if_interactive_enabled(self, tmp_path: Path) -> None:
+        """Creates session when interactive flag is present (NFQUEUE bind fails → exit 1)."""
+        state.ensure_state_dirs(tmp_path)
+        state.interactive_path(tmp_path).write_text("1\n")
+
+        with (
+            mock.patch("terok_shield.interactive.SubprocessRunner"),
+            mock.patch("terok_shield.interactive.NfqueueHandler.create", return_value=None),
+        ):
+            with pytest.raises(SystemExit, match="1"):
+                run_interactive(tmp_path, "ctr")

--- a/tests/unit/test_interactive.py
+++ b/tests/unit/test_interactive.py
@@ -23,7 +23,15 @@ from terok_shield.interactive import (
 )
 from terok_shield.nfqueue import QueuedPacket
 
-from ..testnet import TEST_IP1, TEST_IP2
+from ..testnet import (
+    DNSMASQ_DOMAIN,
+    DNSMASQ_DOMAIN2,
+    FRESH_DOMAIN,
+    KEPT_DOMAIN,
+    STALE_DOMAIN,
+    TEST_IP1,
+    TEST_IP2,
+)
 
 
 def _make_session(tmp_path: Path, **kwargs) -> InteractiveSession:
@@ -92,10 +100,10 @@ class TestPendingPacket:
     def test_fields(self) -> None:
         """Stores packet, queued_at, domain."""
         pkt = _make_pkt()
-        pp = _PendingPacket(packet=pkt, queued_at=1.0, domain="example.com")
+        pp = _PendingPacket(packet=pkt, queued_at=1.0, domain=DNSMASQ_DOMAIN)
         assert pp.packet is pkt
         assert pp.queued_at == 1.0
-        assert pp.domain == "example.com"
+        assert pp.domain == DNSMASQ_DOMAIN
 
     def test_default_domain(self) -> None:
         """Domain defaults to empty string."""
@@ -133,11 +141,11 @@ class TestHandleQueued:
     ) -> None:
         """Domain is included when IP is in the domain cache."""
         session = _make_session(tmp_path)
-        session._ip_to_domain[TEST_IP1] = "example.com"
+        session._ip_to_domain[TEST_IP1] = DNSMASQ_DOMAIN
         session._handle_queued(_make_pkt())
 
         event = json.loads(capsys.readouterr().out.strip())
-        assert event["domain"] == "example.com"
+        assert event["domain"] == DNSMASQ_DOMAIN
 
 
 # ── InteractiveSession._process_command ────────────────
@@ -305,29 +313,31 @@ class TestRefreshDomainCache:
         """Reply lines in dnsmasq log populate the IP→domain cache."""
         state.ensure_state_dirs(tmp_path)
         log = state.dnsmasq_log_path(tmp_path)
-        log.write_text(f"reply example.com is {TEST_IP1}\nreply other.com is {TEST_IP2}\n")
+        log.write_text(
+            f"reply {DNSMASQ_DOMAIN} is {TEST_IP1}\nreply {DNSMASQ_DOMAIN2} is {TEST_IP2}\n"
+        )
 
         session = _make_session(tmp_path)
         session._refresh_domain_cache()
 
-        assert session._ip_to_domain[TEST_IP1] == "example.com"
-        assert session._ip_to_domain[TEST_IP2] == "other.com"
+        assert session._ip_to_domain[TEST_IP1] == DNSMASQ_DOMAIN
+        assert session._ip_to_domain[TEST_IP2] == DNSMASQ_DOMAIN2
 
     def test_rebuilds_fresh_on_each_call(self, tmp_path: Path) -> None:
         """Cache is rebuilt from scratch, dropping stale entries after log rotation."""
         state.ensure_state_dirs(tmp_path)
         log = state.dnsmasq_log_path(tmp_path)
-        log.write_text(f"reply old.com is {TEST_IP1}\n")
+        log.write_text(f"reply {STALE_DOMAIN} is {TEST_IP1}\n")
 
         session = _make_session(tmp_path)
         session._refresh_domain_cache()
         assert TEST_IP1 in session._ip_to_domain
 
         # Simulate log rotation
-        log.write_text(f"reply new.com is {TEST_IP2}\n")
+        log.write_text(f"reply {FRESH_DOMAIN} is {TEST_IP2}\n")
         session._refresh_domain_cache()
         assert TEST_IP1 not in session._ip_to_domain
-        assert session._ip_to_domain[TEST_IP2] == "new.com"
+        assert session._ip_to_domain[TEST_IP2] == FRESH_DOMAIN
 
     def test_missing_log_no_error(self, tmp_path: Path) -> None:
         """Missing log file doesn't raise."""
@@ -339,16 +349,16 @@ class TestRefreshDomainCache:
         """OSError during read keeps the previous cache intact."""
         state.ensure_state_dirs(tmp_path)
         log = state.dnsmasq_log_path(tmp_path)
-        log.write_text(f"reply kept.com is {TEST_IP1}\n")
+        log.write_text(f"reply {KEPT_DOMAIN} is {TEST_IP1}\n")
 
         session = _make_session(tmp_path)
         session._refresh_domain_cache()
-        assert session._ip_to_domain[TEST_IP1] == "kept.com"
+        assert session._ip_to_domain[TEST_IP1] == KEPT_DOMAIN
 
         # Simulate OSError on next read (e.g. permission denied mid-rotation)
         with mock.patch.object(type(log), "read_text", side_effect=OSError("perm")):
             session._refresh_domain_cache()
-        assert session._ip_to_domain[TEST_IP1] == "kept.com"
+        assert session._ip_to_domain[TEST_IP1] == KEPT_DOMAIN
 
 
 # ── InteractiveSession._apply_verdict ──────────────────

--- a/tests/unit/test_nfqueue.py
+++ b/tests/unit/test_nfqueue.py
@@ -1,0 +1,193 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the NFQUEUE netlink handler."""
+
+from __future__ import annotations
+
+import socket
+import struct
+from unittest import mock
+
+import pytest
+
+from terok_shield.netlink import NFA_HDR, NFGEN_HDR, NLMSG_HDR
+from terok_shield.nfqueue import (
+    _NFNL_SUBSYS_QUEUE,
+    _NFQA_PACKET_HDR,
+    _NFQA_PAYLOAD,
+    _NFQNL_MSG_PACKET,
+    _NFQNL_MSG_VERDICT,
+    _NFQNL_PACKET_HDR,
+    NF_ACCEPT,
+    NF_DROP,
+    NfqueueHandler,
+    QueuedPacket,
+    _build_verdict_msg,
+)
+from terok_shield.nft_constants import NFQUEUE_NUM
+
+from ..testnet import TEST_IP1
+
+# ── QueuedPacket ───────────────────────────────────────
+
+
+class TestQueuedPacket:
+    """QueuedPacket is a frozen dataclass with the expected fields."""
+
+    def test_fields(self) -> None:
+        """QueuedPacket stores packet_id, dest, port, proto."""
+        pkt = QueuedPacket(packet_id=42, dest=TEST_IP1, port=443, proto=6)
+        assert pkt.packet_id == 42
+        assert pkt.dest == TEST_IP1
+        assert pkt.port == 443
+        assert pkt.proto == 6
+
+    def test_frozen(self) -> None:
+        """QueuedPacket is immutable."""
+        pkt = QueuedPacket(packet_id=1, dest=TEST_IP1, port=80, proto=6)
+        with pytest.raises(AttributeError):
+            pkt.port = 8080  # type: ignore[misc]
+
+
+# ── Message building ──────────────────────────────────
+
+
+class TestVerdictMessage:
+    """Verdict messages have the correct structure."""
+
+    def test_verdict_msg_accept(self) -> None:
+        """Accept verdict message is well-formed."""
+        msg = _build_verdict_msg(NFQUEUE_NUM, 42, NF_ACCEPT)
+        # Parse nlmsghdr
+        assert len(msg) >= NLMSG_HDR.size
+        nl_len, nl_type, _flags, _seq, _pid = NLMSG_HDR.unpack_from(msg, 0)
+        assert nl_len == len(msg)
+        subsys = (nl_type >> 8) & 0xFF
+        msg_type = nl_type & 0xFF
+        assert subsys == _NFNL_SUBSYS_QUEUE
+        assert msg_type == _NFQNL_MSG_VERDICT
+
+    def test_verdict_msg_drop(self) -> None:
+        """Drop verdict message is well-formed."""
+        msg = _build_verdict_msg(NFQUEUE_NUM, 99, NF_DROP)
+        assert len(msg) >= NLMSG_HDR.size
+
+
+# ── NfqueueHandler parsing ────────────────────────────
+
+
+def _build_nfqueue_packet(packet_id: int, dest_ip: str, proto: int, dest_port: int) -> bytes:
+    """Build a raw netlink message mimicking a NFQUEUE packet."""
+    # Build packet header attribute: packet_id(4) + hw_protocol(2) + hook(1) + pad(1)
+    pkt_hdr = _NFQNL_PACKET_HDR.pack(packet_id, 0x0800, 0)
+    pkt_hdr_attr = NFA_HDR.pack(NFA_HDR.size + len(pkt_hdr), _NFQA_PACKET_HDR) + pkt_hdr
+    # Pad to 4 bytes
+    while len(pkt_hdr_attr) % 4:
+        pkt_hdr_attr += b"\x00"
+
+    # Build IP packet payload: minimal IPv4 with TCP dest port
+    ip_parts = dest_ip.split(".")
+    dest_bytes = bytes(int(p) for p in ip_parts)
+    src_bytes = b"\x0a\x00\x00\x01"  # 10.0.0.1
+    ip_header = bytearray(20)
+    ip_header[0] = 0x45  # version=4, ihl=5
+    ip_header[2:4] = struct.pack("!H", 40)  # total length
+    ip_header[9] = proto
+    ip_header[12:16] = src_bytes
+    ip_header[16:20] = dest_bytes
+    # TCP header (just dest port)
+    transport = struct.pack("!HH", 12345, dest_port)
+    raw_pkt = bytes(ip_header) + transport
+    payload_attr = NFA_HDR.pack(NFA_HDR.size + len(raw_pkt), _NFQA_PAYLOAD) + raw_pkt
+    while len(payload_attr) % 4:
+        payload_attr += b"\x00"
+
+    # Build nfgen header + attrs
+    nfgen = NFGEN_HDR.pack(2, 0, socket.htons(NFQUEUE_NUM))
+    attrs = pkt_hdr_attr + payload_attr
+    payload = nfgen + attrs
+
+    # Build nlmsghdr
+    msg_type = (_NFNL_SUBSYS_QUEUE << 8) | _NFQNL_MSG_PACKET
+    nlmsg = NLMSG_HDR.pack(NLMSG_HDR.size + len(payload), msg_type, 0, 0, 0) + payload
+    return nlmsg
+
+
+class TestNfqueueHandlerParsing:
+    """NfqueueHandler._parse_messages() extracts QueuedPackets correctly."""
+
+    def test_parse_single_packet(self) -> None:
+        """A single NFQUEUE message is parsed into a QueuedPacket."""
+        data = _build_nfqueue_packet(42, TEST_IP1, 6, 443)
+        sock = mock.MagicMock(spec=socket.socket)
+        handler = NfqueueHandler(sock, NFQUEUE_NUM)
+
+        packets = handler._parse_messages(data)
+
+        assert len(packets) == 1
+        assert packets[0].packet_id == 42
+        assert packets[0].dest == TEST_IP1
+        assert packets[0].port == 443
+        assert packets[0].proto == 6
+
+    def test_parse_empty_data(self) -> None:
+        """Empty data returns no packets."""
+        sock = mock.MagicMock(spec=socket.socket)
+        handler = NfqueueHandler(sock, NFQUEUE_NUM)
+        assert handler._parse_messages(b"") == []
+
+    def test_parse_truncated_data(self) -> None:
+        """Truncated netlink message returns no packets."""
+        sock = mock.MagicMock(spec=socket.socket)
+        handler = NfqueueHandler(sock, NFQUEUE_NUM)
+        assert handler._parse_messages(b"\x01\x02") == []
+
+
+# ── NfqueueHandler verdict ────────────────────────────
+
+
+class TestNfqueueHandlerVerdict:
+    """NfqueueHandler.verdict() sends the correct message."""
+
+    def test_verdict_accept_sends_message(self) -> None:
+        """verdict(accept=True) sends NF_ACCEPT message."""
+        sock = mock.MagicMock(spec=socket.socket)
+        handler = NfqueueHandler(sock, NFQUEUE_NUM)
+        handler.verdict(42, accept=True)
+        sock.send.assert_called_once()
+        msg = sock.send.call_args[0][0]
+        assert len(msg) >= NLMSG_HDR.size
+
+    def test_verdict_drop_sends_message(self) -> None:
+        """verdict(accept=False) sends NF_DROP message."""
+        sock = mock.MagicMock(spec=socket.socket)
+        handler = NfqueueHandler(sock, NFQUEUE_NUM)
+        handler.verdict(99, accept=False)
+        sock.send.assert_called_once()
+
+
+# ── NfqueueHandler.create() failure ───────────────────
+
+
+class TestNfqueueHandlerCreate:
+    """NfqueueHandler.create() degrades gracefully."""
+
+    def test_returns_none_on_oserror(self) -> None:
+        """create() returns None when AF_NETLINK is unavailable."""
+        with mock.patch("socket.socket", side_effect=OSError("no netlink")):
+            assert NfqueueHandler.create() is None
+
+    def test_returns_none_on_bind_error(self) -> None:
+        """create() returns None when NFQUEUE bind is rejected."""
+        mock_sock = mock.MagicMock(spec=socket.socket)
+        # Simulate kernel rejection: NLMSG_ERROR with errno -1
+        ack_payload = struct.pack("=i", -1)
+        ack = NLMSG_HDR.pack(NLMSG_HDR.size + len(ack_payload), 2, 0, 0, 0) + ack_payload
+        mock_sock.recv.return_value = ack
+
+        with mock.patch("socket.socket", return_value=mock_sock):
+            result = NfqueueHandler.create()
+
+        assert result is None
+        mock_sock.close.assert_called()

--- a/tests/unit/test_nfqueue.py
+++ b/tests/unit/test_nfqueue.py
@@ -23,7 +23,11 @@ from terok_shield.nfqueue import (
     NF_DROP,
     NfqueueHandler,
     QueuedPacket,
+    _build_config_cmd,
+    _build_config_params,
     _build_verdict_msg,
+    _check_ack,
+    _extract_packet_id,
 )
 from terok_shield.nft_constants import NFQUEUE_NUM
 
@@ -181,7 +185,6 @@ class TestNfqueueHandlerCreate:
     def test_returns_none_on_bind_error(self) -> None:
         """create() returns None when NFQUEUE bind is rejected."""
         mock_sock = mock.MagicMock(spec=socket.socket)
-        # Simulate kernel rejection: NLMSG_ERROR with errno -1
         ack_payload = struct.pack("=i", -1)
         ack = NLMSG_HDR.pack(NLMSG_HDR.size + len(ack_payload), 2, 0, 0, 0) + ack_payload
         mock_sock.recv.return_value = ack
@@ -191,3 +194,256 @@ class TestNfqueueHandlerCreate:
 
         assert result is None
         mock_sock.close.assert_called()
+
+    def test_returns_none_on_params_error(self) -> None:
+        """create() returns None when copy-mode config is rejected."""
+        mock_sock = mock.MagicMock(spec=socket.socket)
+        ok_ack = NLMSG_HDR.pack(NLMSG_HDR.size + 4, 2, 0, 0, 0) + struct.pack("=i", 0)
+        err_ack = NLMSG_HDR.pack(NLMSG_HDR.size + 4, 2, 0, 0, 0) + struct.pack("=i", -1)
+        mock_sock.recv.side_effect = [ok_ack, err_ack]
+
+        with mock.patch("socket.socket", return_value=mock_sock):
+            result = NfqueueHandler.create()
+
+        assert result is None
+        mock_sock.close.assert_called()
+
+    def test_success_returns_handler(self) -> None:
+        """create() returns NfqueueHandler when handshake succeeds."""
+        mock_sock = mock.MagicMock(spec=socket.socket)
+        ok_ack = NLMSG_HDR.pack(NLMSG_HDR.size + 4, 2, 0, 0, 0) + struct.pack("=i", 0)
+        mock_sock.recv.return_value = ok_ack
+
+        with mock.patch("socket.socket", return_value=mock_sock):
+            handler = NfqueueHandler.create()
+
+        assert handler is not None
+        assert isinstance(handler, NfqueueHandler)
+
+
+# ── NfqueueHandler.poll() ─────────────────────────────
+
+
+class TestNfqueueHandlerPoll:
+    """NfqueueHandler.poll() reads from the socket."""
+
+    def test_poll_returns_packets(self) -> None:
+        """poll() reads data and returns parsed packets."""
+        data = _build_nfqueue_packet(1, TEST_IP1, 6, 80)
+        sock = mock.MagicMock(spec=socket.socket)
+        sock.recv.side_effect = [data, OSError("done")]
+        handler = NfqueueHandler(sock, NFQUEUE_NUM)
+
+        pkts = handler.poll()
+
+        assert len(pkts) == 1
+        assert pkts[0].packet_id == 1
+
+    def test_poll_empty_on_oserror(self) -> None:
+        """poll() returns empty list when socket raises OSError."""
+        sock = mock.MagicMock(spec=socket.socket)
+        sock.recv.side_effect = OSError
+        handler = NfqueueHandler(sock, NFQUEUE_NUM)
+        assert handler.poll() == []
+
+    def test_poll_empty_on_no_data(self) -> None:
+        """poll() returns empty list when socket returns empty bytes."""
+        sock = mock.MagicMock(spec=socket.socket)
+        sock.recv.return_value = b""
+        handler = NfqueueHandler(sock, NFQUEUE_NUM)
+        assert handler.poll() == []
+
+
+# ── NfqueueHandler.fileno / close ──────────────────────
+
+
+class TestNfqueueHandlerLifecycle:
+    """fileno() and close() delegate to the socket."""
+
+    def test_fileno(self) -> None:
+        """fileno() returns the socket fd."""
+        sock = mock.MagicMock(spec=socket.socket)
+        sock.fileno.return_value = 7
+        handler = NfqueueHandler(sock, NFQUEUE_NUM)
+        assert handler.fileno() == 7
+
+    def test_close(self) -> None:
+        """close() closes the socket."""
+        sock = mock.MagicMock(spec=socket.socket)
+        handler = NfqueueHandler(sock, NFQUEUE_NUM)
+        handler.close()
+        sock.close.assert_called_once()
+
+
+# ── Verdict OSError path ───────────────────────────────
+
+
+class TestVerdictOSError:
+    """verdict() handles send failures gracefully."""
+
+    def test_verdict_oserror_logs_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        """OSError during verdict send is logged, not raised."""
+        import logging
+
+        sock = mock.MagicMock(spec=socket.socket)
+        sock.send.side_effect = OSError("send failed")
+        handler = NfqueueHandler(sock, NFQUEUE_NUM)
+
+        with caplog.at_level(logging.WARNING):
+            handler.verdict(42, accept=True)
+
+        assert "Failed to send verdict" in caplog.text
+
+
+# ── Unparseable packet auto-drop ───────────────────────
+
+
+class TestUnparseablePacketAutoDrop:
+    """Unparseable packets with valid packet_id get auto-dropped."""
+
+    def test_unparseable_payload_issues_drop(self) -> None:
+        """Packet with header but no valid IP payload gets NF_DROP."""
+        # Build a message with a valid packet header but garbage payload
+        pkt_hdr = _NFQNL_PACKET_HDR.pack(99, 0x0800, 0)
+        pkt_hdr_attr = NFA_HDR.pack(NFA_HDR.size + len(pkt_hdr), _NFQA_PACKET_HDR) + pkt_hdr
+        while len(pkt_hdr_attr) % 4:
+            pkt_hdr_attr += b"\x00"
+        # Garbage payload (not a valid IP packet)
+        garbage = b"\xff" * 4
+        payload_attr = NFA_HDR.pack(NFA_HDR.size + len(garbage), _NFQA_PAYLOAD) + garbage
+        while len(payload_attr) % 4:
+            payload_attr += b"\x00"
+
+        nfgen = NFGEN_HDR.pack(2, 0, socket.htons(NFQUEUE_NUM))
+        attrs = pkt_hdr_attr + payload_attr
+        payload = nfgen + attrs
+        msg_type = (_NFNL_SUBSYS_QUEUE << 8) | _NFQNL_MSG_PACKET
+        nlmsg = NLMSG_HDR.pack(NLMSG_HDR.size + len(payload), msg_type, 0, 0, 0) + payload
+
+        sock = mock.MagicMock(spec=socket.socket)
+        handler = NfqueueHandler(sock, NFQUEUE_NUM)
+        packets = handler._parse_messages(nlmsg)
+
+        # No parseable packets returned, but verdict was issued
+        assert packets == []
+        sock.send.assert_called_once()  # NF_DROP verdict sent
+
+
+# ── _extract_packet_id ─────────────────────────────────
+
+
+class TestExtractPacketId:
+    """_extract_packet_id extracts just the ID from attrs."""
+
+    def test_valid_header(self) -> None:
+        """Extracts packet_id from a valid packet header."""
+        pkt_hdr = _NFQNL_PACKET_HDR.pack(42, 0x0800, 0)
+        attrs = {_NFQA_PACKET_HDR: pkt_hdr}
+        assert _extract_packet_id(attrs) == 42
+
+    def test_missing_header(self) -> None:
+        """Returns None when packet header is missing."""
+        assert _extract_packet_id({}) is None
+
+    def test_truncated_header(self) -> None:
+        """Returns None when packet header is too short."""
+        assert _extract_packet_id({_NFQA_PACKET_HDR: b"\x00"}) is None
+
+
+# ── _check_ack ─────────────────────────────────────────
+
+
+class TestCheckAck:
+    """_check_ack reads kernel ACK messages."""
+
+    def test_success_ack(self) -> None:
+        """Returns True on errno=0 ACK."""
+        sock = mock.MagicMock(spec=socket.socket)
+        ack = NLMSG_HDR.pack(NLMSG_HDR.size + 4, 2, 0, 0, 0) + struct.pack("=i", 0)
+        sock.recv.return_value = ack
+        assert _check_ack(sock) is True
+
+    def test_error_ack(self) -> None:
+        """Returns False on negative errno ACK."""
+        sock = mock.MagicMock(spec=socket.socket)
+        ack = NLMSG_HDR.pack(NLMSG_HDR.size + 4, 2, 0, 0, 0) + struct.pack("=i", -13)
+        sock.recv.return_value = ack
+        assert _check_ack(sock) is False
+
+    def test_timeout_returns_false(self) -> None:
+        """Returns False on socket timeout."""
+        sock = mock.MagicMock(spec=socket.socket)
+        sock.recv.side_effect = TimeoutError
+        assert _check_ack(sock) is False
+
+    def test_short_ack_treated_as_ok(self) -> None:
+        """Short ACK (no errno field) treated as success."""
+        sock = mock.MagicMock(spec=socket.socket)
+        sock.recv.return_value = b"\x00" * 8  # too short for error field
+        assert _check_ack(sock) is True
+
+
+# ── Message builder coverage ───────────────────────────
+
+
+class TestMessageBuilders:
+    """Cover _build_config_cmd and _build_config_params."""
+
+    def test_config_cmd_well_formed(self) -> None:
+        """Config bind message starts with valid nlmsghdr."""
+        msg = _build_config_cmd(NFQUEUE_NUM, 1)
+        assert len(msg) >= NLMSG_HDR.size
+        nl_len = NLMSG_HDR.unpack_from(msg, 0)[0]
+        assert nl_len == len(msg)
+
+    def test_config_params_well_formed(self) -> None:
+        """Config params message starts with valid nlmsghdr."""
+        msg = _build_config_params(NFQUEUE_NUM, copy_range=256)
+        assert len(msg) >= NLMSG_HDR.size
+        nl_len = NLMSG_HDR.unpack_from(msg, 0)[0]
+        assert nl_len == len(msg)
+
+
+# ── Edge cases for parse_messages ─────────────────────
+
+
+class TestParseMessagesEdgeCases:
+    """Cover parse_messages edge paths not hit by other tests."""
+
+    def test_malformed_nl_len_breaks_loop(self) -> None:
+        """Message with nl_len smaller than NLMSG_HDR.size triggers break."""
+        sock = mock.MagicMock(spec=socket.socket)
+        handler = NfqueueHandler(sock, NFQUEUE_NUM)
+        # nlmsghdr with nl_len = 4 (less than NLMSG_HDR.size=16)
+        bad_msg = NLMSG_HDR.pack(4, 0, 0, 0, 0)
+        assert handler._parse_messages(bad_msg) == []
+
+    def test_nl_len_exceeds_data_breaks_loop(self) -> None:
+        """Message claiming more bytes than available triggers break."""
+        sock = mock.MagicMock(spec=socket.socket)
+        handler = NfqueueHandler(sock, NFQUEUE_NUM)
+        # nl_len says 1000 but data is only 16 bytes
+        bad_msg = NLMSG_HDR.pack(1000, 0, 0, 0, 0)
+        assert handler._parse_messages(bad_msg) == []
+
+
+# ── _attrs_to_packet edge cases ───────────────────────
+
+
+class TestAttrsToPacket:
+    """Cover _attrs_to_packet returning None for missing packet_id."""
+
+    def test_no_packet_header_returns_none(self) -> None:
+        """Missing NFQA_PACKET_HDR → None."""
+        from terok_shield.nfqueue import _attrs_to_packet
+
+        assert _attrs_to_packet({}) is None
+
+    def test_valid_header_no_payload_returns_none(self) -> None:
+        """Packet header present but empty payload → None (no dest IP)."""
+        from terok_shield.nfqueue import _attrs_to_packet
+
+        pkt_hdr = _NFQNL_PACKET_HDR.pack(1, 0x0800, 0)
+        attrs = {_NFQA_PACKET_HDR: pkt_hdr}
+        # No NFQA_PAYLOAD → extract_ip_dest returns empty
+        assert _attrs_to_packet(attrs) is None

--- a/tests/unit/test_nft_interactive.py
+++ b/tests/unit/test_nft_interactive.py
@@ -1,0 +1,210 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for interactive-mode nft ruleset generation (deny sets + NFQUEUE)."""
+
+from __future__ import annotations
+
+import pytest
+
+from terok_shield.nft import (
+    RulesetBuilder,
+    add_deny_elements_dual,
+    bypass_ruleset,
+    delete_deny_elements_dual,
+    hook_ruleset,
+    verify_bypass_ruleset,
+    verify_ruleset,
+)
+from terok_shield.nft_constants import (
+    DENIED_LOG_PREFIX,
+    NFQUEUE_NUM,
+    QUEUED_LOG_PREFIX,
+)
+
+from ..testnet import IPV6_CLOUDFLARE, TEST_IP1
+
+# ── Deny sets in both modes ───────────────────────────
+
+
+class TestDenySetsPresent:
+    """Deny sets are always generated in hook and bypass rulesets."""
+
+    def test_hook_strict_has_deny_sets(self) -> None:
+        """Strict-mode hook ruleset includes deny_v4/deny_v6 set declarations."""
+        rs = hook_ruleset()
+        assert "set deny_v4 {" in rs
+        assert "set deny_v6 {" in rs
+
+    def test_hook_interactive_has_deny_sets(self) -> None:
+        """Interactive-mode hook ruleset includes deny_v4/deny_v6 set declarations."""
+        rs = hook_ruleset(interactive=True)
+        assert "set deny_v4 {" in rs
+        assert "set deny_v6 {" in rs
+
+    def test_bypass_has_deny_sets(self) -> None:
+        """Bypass ruleset includes deny_v4/deny_v6 set declarations."""
+        rs = bypass_ruleset()
+        assert "set deny_v4 {" in rs
+        assert "set deny_v6 {" in rs
+
+    def test_deny_set_match_rules_in_strict(self) -> None:
+        """Strict mode includes deny-set match rules with reject."""
+        rs = hook_ruleset()
+        assert "@deny_v4" in rs
+        assert "@deny_v6" in rs
+        assert DENIED_LOG_PREFIX in rs
+
+    def test_deny_set_match_rules_in_interactive(self) -> None:
+        """Interactive mode includes deny-set match rules with reject."""
+        rs = hook_ruleset(interactive=True)
+        assert "@deny_v4" in rs
+        assert "@deny_v6" in rs
+
+
+# ── Interactive mode specifics ─────────────────────────
+
+
+class TestInteractiveRuleset:
+    """Interactive mode uses NFQUEUE as terminal rule."""
+
+    def test_has_queue_rule(self) -> None:
+        """Interactive ruleset contains queue num directive."""
+        rs = hook_ruleset(interactive=True)
+        assert f"queue num {NFQUEUE_NUM}" in rs
+
+    def test_has_queued_prefix(self) -> None:
+        """Interactive ruleset logs with QUEUED prefix."""
+        rs = hook_ruleset(interactive=True)
+        assert QUEUED_LOG_PREFIX in rs
+
+    def test_custom_nfqueue_num(self) -> None:
+        """Custom NFQUEUE number is honoured."""
+        rs = hook_ruleset(interactive=True, nfqueue_num=42)
+        assert "queue num 42" in rs
+
+    def test_strict_has_no_queue(self) -> None:
+        """Strict mode does not contain queue directive."""
+        rs = hook_ruleset(interactive=False)
+        assert "queue num" not in rs
+        assert QUEUED_LOG_PREFIX not in rs
+
+
+# ── Verify interactive ruleset ────────────────────────
+
+
+class TestVerifyInteractive:
+    """verify_ruleset(interactive=True) checks NFQUEUE-specific invariants."""
+
+    def test_valid_interactive_passes(self) -> None:
+        """A correctly generated interactive ruleset passes verification."""
+        rs = hook_ruleset(interactive=True)
+        assert verify_ruleset(rs, interactive=True) == []
+
+    def test_valid_strict_passes(self) -> None:
+        """A correctly generated strict ruleset passes verification."""
+        rs = hook_ruleset()
+        assert verify_ruleset(rs) == []
+
+    def test_strict_fails_interactive_check(self) -> None:
+        """A strict ruleset fails interactive verification (no queue)."""
+        rs = hook_ruleset()
+        errors = verify_ruleset(rs, interactive=True)
+        assert any("queue" in e for e in errors)
+
+    def test_bypass_has_deny_sets(self) -> None:
+        """Bypass ruleset passes verification including deny sets."""
+        rs = bypass_ruleset()
+        assert verify_bypass_ruleset(rs) == []
+
+    def test_verify_checks_deny_sets(self) -> None:
+        """verify_ruleset checks that deny sets are present."""
+        # A ruleset without deny sets should fail
+        bad = hook_ruleset().replace("deny_v4", "xxx_v4").replace("deny_v6", "xxx_v6")
+        errors = verify_ruleset(bad)
+        assert any("deny_v4" in e for e in errors)
+        assert any("deny_v6" in e for e in errors)
+
+
+# ── Deny set operations ────────────────────────────────
+
+
+class TestDenySetOperations:
+    """add_deny_elements_dual / delete_deny_elements_dual."""
+
+    def test_add_v4(self) -> None:
+        """IPv4 goes to deny_v4."""
+        cmd = add_deny_elements_dual([TEST_IP1])
+        assert "deny_v4" in cmd
+        assert TEST_IP1 in cmd
+
+    def test_add_v6(self) -> None:
+        """IPv6 goes to deny_v6."""
+        cmd = add_deny_elements_dual([IPV6_CLOUDFLARE])
+        assert "deny_v6" in cmd
+        assert IPV6_CLOUDFLARE in cmd
+
+    def test_delete_v4(self) -> None:
+        """delete generates delete element command."""
+        cmd = delete_deny_elements_dual([TEST_IP1])
+        assert "delete element" in cmd
+        assert "deny_v4" in cmd
+
+    def test_empty_input(self) -> None:
+        """Empty input returns empty string."""
+        assert add_deny_elements_dual([]) == ""
+        assert delete_deny_elements_dual([]) == ""
+
+
+# ── RulesetBuilder interactive ────────────────────────
+
+
+class TestRulesetBuilderInteractive:
+    """RulesetBuilder.build_hook(interactive=True) integration."""
+
+    def test_builder_interactive(self) -> None:
+        """Builder passes interactive flag through correctly."""
+        builder = RulesetBuilder()
+        rs = builder.build_hook(interactive=True)
+        assert "queue num" in rs
+        assert QUEUED_LOG_PREFIX in rs
+
+    def test_builder_strict(self) -> None:
+        """Builder strict mode has no queue."""
+        builder = RulesetBuilder()
+        rs = builder.build_hook(interactive=False)
+        assert "queue num" not in rs
+
+    def test_builder_custom_nfqueue(self) -> None:
+        """Builder respects custom nfqueue_num."""
+        builder = RulesetBuilder(nfqueue_num=99)
+        rs = builder.build_hook(interactive=True)
+        assert "queue num 99" in rs
+
+    def test_verify_interactive(self) -> None:
+        """Builder verify_hook passes interactive flag."""
+        builder = RulesetBuilder()
+        rs = builder.build_hook(interactive=True)
+        assert builder.verify_hook(rs, interactive=True) == []
+
+
+# ── Validation ─────────────────────────────────────────
+
+
+class TestNfqueueValidation:
+    """NFQUEUE number validation."""
+
+    def test_invalid_nfqueue_num_bool(self) -> None:
+        """Boolean nfqueue_num is rejected."""
+        with pytest.raises(ValueError, match="integer"):
+            RulesetBuilder(nfqueue_num=True)
+
+    def test_invalid_nfqueue_num_negative(self) -> None:
+        """Negative nfqueue_num is rejected."""
+        with pytest.raises(ValueError, match="range"):
+            RulesetBuilder(nfqueue_num=-1)
+
+    def test_invalid_nfqueue_num_too_large(self) -> None:
+        """nfqueue_num > 65535 is rejected."""
+        with pytest.raises(ValueError, match="range"):
+            RulesetBuilder(nfqueue_num=70000)

--- a/tests/unit/test_nft_interactive.py
+++ b/tests/unit/test_nft_interactive.py
@@ -112,6 +112,28 @@ class TestVerifyInteractive:
         errors = verify_ruleset(rs, interactive=True)
         assert any("queue" in e for e in errors)
 
+    def test_interactive_fails_strict_check(self) -> None:
+        """An interactive ruleset fails strict verification (has queue)."""
+        rs = hook_ruleset(interactive=True)
+        errors = verify_ruleset(rs, interactive=False)
+        assert any("queue" in e.lower() or "strict" in e.lower() for e in errors)
+
+    def test_wrong_queue_num_fails(self) -> None:
+        """Interactive verification rejects mismatched queue number."""
+        rs = hook_ruleset(interactive=True, nfqueue_num=42)
+        errors = verify_ruleset(rs, interactive=True, nfqueue_num=99)
+        assert any("99" in e for e in errors)
+
+    def test_builder_verify_custom_queue(self) -> None:
+        """RulesetBuilder.verify_hook passes its own nfqueue_num."""
+        builder = RulesetBuilder(nfqueue_num=77)
+        rs = builder.build_hook(interactive=True)
+        assert builder.verify_hook(rs, interactive=True) == []
+        # A different builder with nfqueue_num=200 should reject it
+        other = RulesetBuilder(nfqueue_num=200)
+        errors = other.verify_hook(rs, interactive=True)
+        assert any("200" in e for e in errors)
+
     def test_bypass_has_deny_sets(self) -> None:
         """Bypass ruleset passes verification including deny sets."""
         rs = bypass_ruleset()

--- a/tests/unit/test_nft_interactive.py
+++ b/tests/unit/test_nft_interactive.py
@@ -118,21 +118,20 @@ class TestVerifyInteractive:
         errors = verify_ruleset(rs, interactive=False)
         assert any("queue" in e.lower() or "strict" in e.lower() for e in errors)
 
-    def test_wrong_queue_num_fails(self) -> None:
-        """Interactive verification rejects mismatched queue number."""
-        rs = hook_ruleset(interactive=True, nfqueue_num=42)
-        errors = verify_ruleset(rs, interactive=True, nfqueue_num=99)
-        assert any("99" in e for e in errors)
+    def test_nflog_tier_passes_interactive_check(self) -> None:
+        """NFLOG+reject tier passes interactive verification."""
+        rs = hook_ruleset(interactive=True, nfqueue=False)
+        errors = verify_ruleset(rs, interactive=True)
+        assert errors == []
 
-    def test_builder_verify_custom_queue(self) -> None:
-        """RulesetBuilder.verify_hook passes its own nfqueue_num."""
-        builder = RulesetBuilder(nfqueue_num=77)
-        rs = builder.build_hook(interactive=True)
+    def test_builder_nflog_tier(self) -> None:
+        """RulesetBuilder with nfqueue=False generates NFLOG+reject ruleset."""
+        builder = RulesetBuilder()
+        rs = builder.build_hook(interactive=True, nfqueue=False)
+        assert "queue num" not in rs
+        assert "TEROK_SHIELD_QUEUED" in rs
+        assert "admin-prohibited" in rs
         assert builder.verify_hook(rs, interactive=True) == []
-        # A different builder with nfqueue_num=200 should reject it
-        other = RulesetBuilder(nfqueue_num=200)
-        errors = other.verify_hook(rs, interactive=True)
-        assert any("200" in e for e in errors)
 
     def test_bypass_has_deny_sets(self) -> None:
         """Bypass ruleset passes verification including deny sets."""

--- a/tests/unit/test_watch.py
+++ b/tests/unit/test_watch.py
@@ -16,6 +16,13 @@ import pytest
 
 import terok_shield.watch as _watch_mod
 from terok_shield.config import DnsTier
+from terok_shield.netlink import (
+    NFA_HDR,
+    NFGEN_HDR,
+    NLMSG_HDR,
+    extract_ip_dest,
+    parse_nflog_attrs,
+)
 from terok_shield.nft_constants import (
     ALLOWED_LOG_PREFIX,
     BYPASS_LOG_PREFIX,
@@ -25,13 +32,10 @@ from terok_shield.nft_constants import (
 )
 from terok_shield.watch import (
     _DOMAIN_REFRESH_INTERVAL,
-    _NFA_HDR,
-    _NFGEN_HDR,
     _NFNL_SUBSYS_ULOG,
     _NFULA_PAYLOAD,
     _NFULA_PREFIX,
     _NFULNL_MSG_PACKET,
-    _NLMSG_HDR,
     _QUERY_RE,
     AuditLogWatcher,
     DnsLogWatcher,
@@ -39,9 +43,7 @@ from terok_shield.watch import (
     WatchEvent,
     _build_nflog_bind_msg,
     _ensure_log_file,
-    _extract_ip_dest,
     _handle_signal,
-    _parse_nflog_attrs,
     run_watch,
 )
 from tests.testnet import BLOCKED_DOMAIN, BLOCKED_SUBDOMAIN, TEST_DOMAIN, TEST_DOMAIN2
@@ -495,28 +497,28 @@ def _make_nflog_packet(
 
     # NFULA_PREFIX attribute
     prefix_bytes = prefix.encode("ascii") + b"\x00"
-    prefix_attr_len = _NFA_HDR.size + len(prefix_bytes)
-    attrs += _NFA_HDR.pack(prefix_attr_len, _NFULA_PREFIX)
+    prefix_attr_len = NFA_HDR.size + len(prefix_bytes)
+    attrs += NFA_HDR.pack(prefix_attr_len, _NFULA_PREFIX)
     attrs += prefix_bytes
     # Pad to 4-byte alignment
     pad = (4 - (prefix_attr_len % 4)) % 4
     attrs += b"\x00" * pad
 
     # NFULA_PAYLOAD attribute
-    payload_attr_len = _NFA_HDR.size + len(raw_ip)
-    attrs += _NFA_HDR.pack(payload_attr_len, _NFULA_PAYLOAD)
+    payload_attr_len = NFA_HDR.size + len(raw_ip)
+    attrs += NFA_HDR.pack(payload_attr_len, _NFULA_PAYLOAD)
     attrs += raw_ip
     pad = (4 - (payload_attr_len % 4)) % 4
     attrs += b"\x00" * pad
 
     # nfgenmsg header
-    nfgen = _NFGEN_HDR.pack(af_family, 0, socket.htons(NFLOG_GROUP))
+    nfgen = NFGEN_HDR.pack(af_family, 0, socket.htons(NFLOG_GROUP))
 
     # netlink message header
     msg_type = (_NFNL_SUBSYS_ULOG << 8) | _NFULNL_MSG_PACKET
     payload = nfgen + attrs
-    nlmsg = _NLMSG_HDR.pack(
-        _NLMSG_HDR.size + len(payload),
+    nlmsg = NLMSG_HDR.pack(
+        NLMSG_HDR.size + len(payload),
         msg_type,
         0,
         0,
@@ -535,7 +537,7 @@ class TestExtractIpDest:
         ip_header[9] = 6  # TCP
         ip_header[16:20] = socket.inet_aton("198.51.100.1")
         transport = struct.pack("!HH", 54321, 8080)
-        dest, proto, port = _extract_ip_dest(bytes(ip_header) + transport)
+        dest, proto, port = extract_ip_dest(bytes(ip_header) + transport)
         assert dest == "198.51.100.1"
         assert proto == 6
         assert port == 8080
@@ -547,7 +549,7 @@ class TestExtractIpDest:
         ip_header[9] = 17  # UDP
         ip_header[16:20] = socket.inet_aton("203.0.113.1")
         transport = struct.pack("!HH", 12345, 53)
-        dest, proto, port = _extract_ip_dest(bytes(ip_header) + transport)
+        dest, proto, port = extract_ip_dest(bytes(ip_header) + transport)
         assert dest == "203.0.113.1"
         assert proto == 17
         assert port == 53
@@ -561,26 +563,26 @@ class TestExtractIpDest:
         # Destination address at offset 24
         ip6_header[24:40] = socket.inet_pton(socket.AF_INET6, "2001:db8::1")
         transport = struct.pack("!HH", 54321, 443)
-        dest, proto, port = _extract_ip_dest(bytes(ip6_header) + transport)
+        dest, proto, port = extract_ip_dest(bytes(ip6_header) + transport)
         assert dest == "2001:db8::1"
         assert proto == 6
         assert port == 443
 
     def test_too_short_returns_empty(self) -> None:
         """Packet shorter than minimum IP header returns empty tuple."""
-        assert _extract_ip_dest(b"\x45" * 10) == ("", 0, 0)
+        assert extract_ip_dest(b"\x45" * 10) == ("", 0, 0)
 
     def test_unknown_version_returns_empty(self) -> None:
         """Packet with unknown IP version returns empty tuple."""
         pkt = bytearray(20)
         pkt[0] = 0x35  # version=3 — invalid
-        assert _extract_ip_dest(bytes(pkt)) == ("", 0, 0)
+        assert extract_ip_dest(bytes(pkt)) == ("", 0, 0)
 
     def test_malformed_ihl_returns_empty(self) -> None:
         """IPv4 packet with IHL < 5 (20 bytes) is rejected as malformed."""
         pkt = bytearray(20)
         pkt[0] = 0x43  # version=4, IHL=3 (12 bytes — below minimum)
-        assert _extract_ip_dest(bytes(pkt)) == ("", 0, 0)
+        assert extract_ip_dest(bytes(pkt)) == ("", 0, 0)
 
 
 class TestParseNflogAttrs:
@@ -593,30 +595,30 @@ class TestParseNflogAttrs:
 
         attrs_data = b""
         # PREFIX attr
-        attr_len = _NFA_HDR.size + len(prefix)
-        attrs_data += _NFA_HDR.pack(attr_len, _NFULA_PREFIX) + prefix
+        attr_len = NFA_HDR.size + len(prefix)
+        attrs_data += NFA_HDR.pack(attr_len, _NFULA_PREFIX) + prefix
         pad = (4 - (attr_len % 4)) % 4
         attrs_data += b"\x00" * pad
         # PAYLOAD attr
-        attr_len = _NFA_HDR.size + len(payload)
-        attrs_data += _NFA_HDR.pack(attr_len, _NFULA_PAYLOAD) + payload
+        attr_len = NFA_HDR.size + len(payload)
+        attrs_data += NFA_HDR.pack(attr_len, _NFULA_PAYLOAD) + payload
         pad = (4 - (attr_len % 4)) % 4
         attrs_data += b"\x00" * pad
 
-        parsed = _parse_nflog_attrs(attrs_data)
+        parsed = parse_nflog_attrs(attrs_data)
         assert _NFULA_PREFIX in parsed
         assert _NFULA_PAYLOAD in parsed
         assert b"DENIED" in parsed[_NFULA_PREFIX]
 
     def test_empty_data_returns_empty_dict(self) -> None:
         """Empty data returns empty attribute dict."""
-        assert _parse_nflog_attrs(b"") == {}
+        assert parse_nflog_attrs(b"") == {}
 
     def test_truncated_attr_stops_parsing(self) -> None:
         """Attribute with length shorter than header stops parsing."""
         # Attribute claiming 2-byte length (less than 4-byte header)
-        data = _NFA_HDR.pack(2, _NFULA_PREFIX)
-        assert _parse_nflog_attrs(data) == {}
+        data = NFA_HDR.pack(2, _NFULA_PREFIX)
+        assert parse_nflog_attrs(data) == {}
 
 
 class TestBuildNflogBindMsg:
@@ -626,8 +628,8 @@ class TestBuildNflogBindMsg:
         """Bind message has correct netlink header structure."""
         msg = _build_nflog_bind_msg(NFLOG_GROUP)
         # Must be at least nlmsg header size
-        assert len(msg) >= _NLMSG_HDR.size
-        nl_len, nl_type, _flags, _seq, _pid = _NLMSG_HDR.unpack_from(msg, 0)
+        assert len(msg) >= NLMSG_HDR.size
+        nl_len, nl_type, _flags, _seq, _pid = NLMSG_HDR.unpack_from(msg, 0)
         assert nl_len == len(msg)
         # Type should be ULOG subsystem + CONFIG msg
         assert (nl_type >> 8) == _NFNL_SUBSYS_ULOG
@@ -705,15 +707,15 @@ class TestNflogWatcherParsing:
         watcher = self._make_watcher()
         # Build a message with prefix but no payload attribute
         prefix_bytes = b"TEROK_SHIELD_DENIED: \x00"
-        prefix_attr_len = _NFA_HDR.size + len(prefix_bytes)
-        attrs = _NFA_HDR.pack(prefix_attr_len, _NFULA_PREFIX) + prefix_bytes
+        prefix_attr_len = NFA_HDR.size + len(prefix_bytes)
+        attrs = NFA_HDR.pack(prefix_attr_len, _NFULA_PREFIX) + prefix_bytes
         pad = (4 - (prefix_attr_len % 4)) % 4
         attrs += b"\x00" * pad
 
-        nfgen = _NFGEN_HDR.pack(2, 0, socket.htons(NFLOG_GROUP))
+        nfgen = NFGEN_HDR.pack(2, 0, socket.htons(NFLOG_GROUP))
         msg_type = (_NFNL_SUBSYS_ULOG << 8) | _NFULNL_MSG_PACKET
         payload = nfgen + attrs
-        nlmsg = _NLMSG_HDR.pack(_NLMSG_HDR.size + len(payload), msg_type, 0, 0, 0) + payload
+        nlmsg = NLMSG_HDR.pack(NLMSG_HDR.size + len(payload), msg_type, 0, 0, 0) + payload
         events = watcher._parse_messages(nlmsg)
         assert events == []
 
@@ -744,7 +746,7 @@ class TestNflogWatcherParsing:
         """_parse_messages stops when nl_len is smaller than header size."""
         watcher = self._make_watcher()
         # Craft a message with nl_len = 4 (less than NLMSG_HDR.size=16)
-        bad_msg = _NLMSG_HDR.pack(4, 0, 0, 0, 0)
+        bad_msg = NLMSG_HDR.pack(4, 0, 0, 0, 0)
         events = watcher._parse_messages(bad_msg)
         assert events == []
 
@@ -780,7 +782,7 @@ class TestNflogWatcherCreate:
         mock_sock.bind.assert_called_once_with((0, 0))
         mock_sock.setblocking.assert_called_once_with(False)
         mock_sock.send.assert_called_once()
-        assert len(mock_sock.send.call_args[0][0]) >= _NLMSG_HDR.size
+        assert len(mock_sock.send.call_args[0][0]) >= NLMSG_HDR.size
         result.close()
 
     def test_returns_none_on_attribute_error(self) -> None:
@@ -794,7 +796,7 @@ class TestNflogWatcherCreate:
         mock_sock = MagicMock(spec=socket.socket)
         # Build an NLMSG_ERROR ACK with errno -1 (EPERM)
         ack_payload = struct.pack("=i", -1)
-        ack = _NLMSG_HDR.pack(_NLMSG_HDR.size + len(ack_payload), 2, 0, 0, 0) + ack_payload
+        ack = NLMSG_HDR.pack(NLMSG_HDR.size + len(ack_payload), 2, 0, 0, 0) + ack_payload
         mock_sock.recv.return_value = ack
         with patch("terok_shield.watch.socket.socket", return_value=mock_sock):
             result = NflogWatcher.create(_CONTAINER)
@@ -805,7 +807,7 @@ class TestNflogWatcherCreate:
         """create() succeeds when the kernel ACK has error code 0."""
         mock_sock = MagicMock(spec=socket.socket)
         ack_payload = struct.pack("=i", 0)
-        ack = _NLMSG_HDR.pack(_NLMSG_HDR.size + len(ack_payload), 2, 0, 0, 0) + ack_payload
+        ack = NLMSG_HDR.pack(NLMSG_HDR.size + len(ack_payload), 2, 0, 0, 0) + ack_payload
         mock_sock.recv.return_value = ack
         with patch("terok_shield.watch.socket.socket", return_value=mock_sock):
             result = NflogWatcher.create(_CONTAINER)

--- a/tests/unit/test_watch.py
+++ b/tests/unit/test_watch.py
@@ -29,6 +29,7 @@ from terok_shield.nft_constants import (
     DENIED_LOG_PREFIX,
     NFLOG_GROUP,
     PRIVATE_LOG_PREFIX,
+    QUEUED_LOG_PREFIX,
 )
 from terok_shield.watch import (
     _DOMAIN_REFRESH_INTERVAL,
@@ -682,6 +683,15 @@ class TestNflogWatcherParsing:
         assert events[0].action == "bypass_connection"
         assert events[0].port == 53
         assert events[0].proto == 17
+
+    def test_queued_packet(self) -> None:
+        """NFLOG message with QUEUED prefix yields queued_connection event."""
+        watcher = self._make_watcher()
+        data = _make_nflog_packet(f"{QUEUED_LOG_PREFIX}: ", "198.51.100.5", 6, 443)
+        events = watcher._parse_messages(data)
+        assert len(events) == 1
+        assert events[0].action == "queued_connection"
+        assert events[0].dest == "198.51.100.5"
 
     def test_unknown_prefix_yields_nflog_action(self) -> None:
         """NFLOG message with unrecognized prefix yields generic nflog action."""


### PR DESCRIPTION
## Summary

- **Deny sets** (`@deny_v4`/`@deny_v6`) added unconditionally to all rulesets — fixes the dnsmasq re-population race in strict mode, and serves as the operator rejection cache in interactive mode
- **Interactive terminal rule**: `hook_ruleset(interactive=True)` swaps the deny-all reject for `queue num N`, routing unknown packets to userspace for operator verdict
- **NFQUEUE handler** (`nfqueue.py`): raw `AF_NETLINK` implementation mirroring the existing `NflogWatcher` pattern — `create/poll/verdict/fileno/close`
- **Interactive verdict loop** (`interactive.py`): bidirectional JSON-lines protocol on stdin/stdout with domain enrichment from dnsmasq log and configurable verdict timeout
- **Shared netlink utilities** (`netlink.py`): extracted `extract_ip_dest` and struct definitions from `watch.py` for reuse by both NFLOG and NFQUEUE handlers

### Config additions
- `interactive: bool` — enable NFQUEUE mode (default: `false`)
- `nfqueue_timeout: int` — seconds before auto-drop (default: `5`, range 1–60)

### NFT chain structure (both modes)
```
allow sets → deny sets → private-range reject → terminal
  strict:      NFLOG DENIED + reject (as before)
  interactive: NFLOG QUEUED + queue num N
```

Closes #83

## Test plan
- [x] 873 unit tests pass (36 new: nft_interactive, nfqueue)
- [x] Lint clean (ruff)
- [x] Module boundaries validated (tach)
- [x] 100% docstring coverage
- [x] REUSE/SPDX compliant
- [x] Bandit SAST: no medium/high findings
- [ ] Integration test with podman+nft: container with `interactive: true`, verify packets queue and verdict protocol works (manual, needs container runtime)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New interactive command for real-time interception and accept/deny verdicts on queued connections; CLI flags added to enable interactive mode.

* **Configuration**
  * New options: interactive (bool) and nfqueue_timeout (seconds, 1–60) with sensible defaults and validation.

* **Behavior**
  * NFQUEUE/NFLOG interactive tiers with queued-log support, domain enrichment, auto-deny on timeout, and persistent allow/deny state synced to rulesets.

* **Chores**
  * Bundle/state version bumped to 4 — rerun pre-start.

* **Tests**
  * Extensive unit tests covering interactive flow, queuing, parsing, ruleset generation/verification, and persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->