### PR TITLE
feat: NFQUEUE interactive tier — kernel queue holds packets pending v…

### DIFF
--- a/src/terok_shield/config.py
+++ b/src/terok_shield/config.py
@@ -113,6 +113,7 @@ class ShieldConfig:
     audit_enabled: bool = True
     profiles_dir: Path | None = None
     interactive: bool = False
+    nfqueue_timeout: int = 5
 
 
 # -- Config-file schema (Pydantic) ------------------------
@@ -145,6 +146,12 @@ class ShieldFileConfig(BaseModel):
         description="TCP ports forwarded to host loopback (via pasta ``-T``)",
     )
     interactive: bool = Field(default=False, description="Enable interactive NFLOG approval mode")
+    nfqueue_timeout: int = Field(
+        default=5,
+        ge=1,
+        le=300,
+        description="Seconds before an NFQUEUE-held packet is auto-dropped (1–300)",
+    )
     audit: AuditFileConfig = Field(
         default_factory=AuditFileConfig, description="Audit logging settings"
     )

--- a/src/terok_shield/interactive.py
+++ b/src/terok_shield/interactive.py
@@ -35,6 +35,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from . import state
+from .nfqueue import NfqueueHandler, QueuedPacket
 from .nft import add_deny_elements_dual, add_elements_dual
 from .run import CommandRunner, SubprocessRunner
 from .state import read_interactive_tier
@@ -372,6 +373,317 @@ class InteractiveSession:
         self._ip_to_domain = mapping
 
 
+# ── NFQUEUE Session ───────────────────────────────────
+
+
+class NfqueueInteractiveSession:
+    """Drive the interactive NFQUEUE verdict loop.
+
+    Creates an :class:`NfqueueHandler`, listens for queued packets,
+    emits pending events as JSON lines on stdout, reads verdict commands
+    from stdin, and issues accept/drop verdicts to the kernel.  Packets
+    are held in the kernel queue until a verdict is issued or the
+    configured timeout expires (auto-drop).
+    """
+
+    def __init__(
+        self,
+        *,
+        runner: CommandRunner,
+        state_dir: Path,
+        container: str,
+        timeout: int = 5,
+    ) -> None:
+        """Initialise the NFQUEUE session.
+
+        Args:
+            runner: Command runner for nft operations.
+            state_dir: Per-container state directory.
+            container: Container name (for nft nsenter).
+            timeout: Seconds before auto-dropping unverdicted packets.
+        """
+        self._runner = runner
+        self._state_dir = state_dir
+        self._container = container
+        self._timeout = timeout
+
+        self._seen_ips: set[str] = set()
+        self._pending_by_ip: dict[str, _PendingPacket] = {}
+        self._ip_to_domain: dict[str, str] = {}
+        self._last_domain_refresh: float = 0.0
+        self._next_id: int = 1
+
+    def run(self) -> None:
+        """Enter the interactive NFQUEUE event loop.
+
+        Creates the NFQUEUE handler, sets stdin to non-blocking, installs
+        signal handlers, and delegates to :meth:`_loop`.
+        """
+        handler = NfqueueHandler.create()
+        if handler is None:
+            print(
+                "Error: could not create NFQUEUE handler (nfnetlink_queue unavailable).",
+                file=sys.stderr,
+            )
+            raise SystemExit(1)
+
+        stdin_fd = sys.stdin.fileno()
+        _set_nonblocking(stdin_fd)
+
+        global _running  # noqa: PLW0603
+        _running = True
+        signal.signal(signal.SIGINT, _handle_signal)
+        signal.signal(signal.SIGTERM, _handle_signal)
+
+        try:
+            self._loop(handler, stdin_fd)
+        finally:
+            handler.close()
+
+    def _loop(self, handler: NfqueueHandler, stdin_fd: int) -> None:
+        """Select-based event loop multiplexing NFQUEUE and stdin.
+
+        Args:
+            handler: The NFQUEUE netlink handler.
+            stdin_fd: File descriptor for stdin (set to non-blocking).
+        """
+        buf = ""
+        while _running:
+            if time.monotonic() - self._last_domain_refresh > _DOMAIN_REFRESH_INTERVAL:
+                self._refresh_domain_cache()
+
+            self._expire_stale_packets(handler)
+
+            try:
+                readable, _, _ = select.select([handler, stdin_fd], [], [], 1.0)
+            except (OSError, ValueError):
+                break
+
+            fds = _readable_fds(readable)
+            if handler.fileno() in fds:
+                self._drain_handler(handler)
+            if stdin_fd in fds:
+                result = self._read_stdin(handler, buf)
+                if result is None:
+                    break
+                buf = result
+
+    def _drain_handler(self, handler: NfqueueHandler) -> None:
+        """Process all pending NFQUEUE packets from the handler.
+
+        Args:
+            handler: The NFQUEUE handler to drain.
+        """
+        for pkt in handler.poll():
+            self._handle_queued_packet(handler, pkt)
+
+    def _handle_queued_packet(self, handler: NfqueueHandler, pkt: QueuedPacket) -> None:
+        """Process a queued NFQUEUE packet.
+
+        Deduplicates by destination IP.  First packet to a given IP emits a
+        pending event; subsequent packets to the same IP are auto-accepted
+        (if previously accepted) or auto-dropped (if previously denied or
+        still pending).
+
+        Args:
+            handler: The NFQUEUE handler for issuing auto-verdicts.
+            pkt: The queued packet from the kernel.
+        """
+        ip = pkt.dest
+        if ip in self._seen_ips and ip not in self._pending_by_ip:
+            # Already verdicted — auto-accept (IP was allowed)
+            handler.verdict(pkt.packet_id, accept=True)
+            return
+        if ip in self._pending_by_ip:
+            # Still pending verdict — drop duplicate
+            handler.verdict(pkt.packet_id, accept=False)
+            return
+
+        self._seen_ips.add(ip)
+        domain = self._ip_to_domain.get(ip, "")
+        event_id = self._next_id
+        self._next_id += 1
+
+        pending = _PendingPacket(
+            dest=ip,
+            port=pkt.port,
+            proto=pkt.proto,
+            queued_at=time.monotonic(),
+            domain=domain,
+            packet_id=pkt.packet_id,
+        )
+        self._pending_by_ip[ip] = pending
+
+        out = {
+            "type": "pending",
+            "id": event_id,
+            "dest": ip,
+            "port": pkt.port,
+            "proto": pkt.proto,
+            "domain": domain,
+        }
+        print(json.dumps(out, separators=(",", ":")), flush=True)
+
+    def _expire_stale_packets(self, handler: NfqueueHandler) -> None:
+        """Drop packets that have been pending longer than the timeout.
+
+        Args:
+            handler: The NFQUEUE handler for issuing drop verdicts.
+        """
+        now = time.monotonic()
+        expired = [ip for ip, p in self._pending_by_ip.items() if now - p.queued_at > self._timeout]
+        for ip in expired:
+            pending = self._pending_by_ip.pop(ip)
+            handler.verdict(pending.packet_id, accept=False)
+            logger.debug("Auto-dropped packet to %s (timeout)", ip)
+
+    def _read_stdin(self, handler: NfqueueHandler, buf: str) -> str | None:
+        """Read available bytes from stdin and process complete lines.
+
+        Returns the updated buffer, or ``None`` on EOF.
+
+        Args:
+            handler: NFQUEUE handler for issuing verdicts.
+            buf: Accumulated partial line from previous reads.
+        """
+        try:
+            data = os.read(sys.stdin.fileno(), 4096)
+        except OSError:
+            return buf
+        if not data:
+            return None
+
+        buf += data.decode("utf-8", errors="replace")
+        while "\n" in buf:
+            line, buf = buf.split("\n", 1)
+            line = line.strip()
+            if line:
+                self._process_command(handler, line)
+        return buf
+
+    def _process_command(self, handler: NfqueueHandler, line: str) -> None:
+        """Parse and execute a single JSON command from stdin.
+
+        Args:
+            handler: NFQUEUE handler for issuing verdicts.
+            line: A single JSON line from the controlling process.
+        """
+        try:
+            cmd = json.loads(line)
+        except json.JSONDecodeError:
+            logger.warning("Invalid JSON on stdin: %s", line)
+            return
+
+        if not isinstance(cmd, dict):
+            return
+        if cmd.get("type") != "verdict":
+            return
+
+        verdict_id = cmd.get("id")
+        if isinstance(verdict_id, bool) or not isinstance(verdict_id, int):
+            return
+
+        action = cmd.get("action")
+        if action not in ("accept", "deny"):
+            return
+
+        pending = next((p for p in self._pending_by_ip.values() if p.packet_id == verdict_id), None)
+        if pending is None:
+            # Try by sequential id (packet_id may have been reassigned)
+            pending = next(
+                (p for i, p in enumerate(self._pending_by_ip.values(), 1) if i == verdict_id),
+                None,
+            )
+        if pending is None:
+            logger.warning("No pending packet with id %d", verdict_id)
+            return
+
+        accept = action == "accept"
+        handler.verdict(pending.packet_id, accept=accept)
+        ok = self._apply_verdict(pending, accept=accept)
+
+        if ok:
+            self._pending_by_ip.pop(pending.dest, None)
+
+        out = {
+            "type": "verdict_applied",
+            "id": verdict_id,
+            "dest": pending.dest,
+            "action": action,
+            "ok": ok,
+        }
+        print(json.dumps(out, separators=(",", ":")), flush=True)
+
+    def _apply_verdict(self, pending: _PendingPacket, *, accept: bool) -> bool:
+        """Apply verdict to nft ruleset and persist to state files.
+
+        Args:
+            pending: The pending packet to verdict.
+            accept: True for accept, False for deny.
+
+        Returns:
+            True if the verdict was successfully applied.
+        """
+        ip = pending.dest
+        if accept:
+            permanent = self._is_dnsmasq_tier()
+            nft_cmd = add_elements_dual([ip], permanent=permanent)
+        else:
+            nft_cmd = add_deny_elements_dual([ip])
+
+        if nft_cmd and not self._nft_apply(nft_cmd):
+            return False
+
+        if accept:
+            _append_unique(state.live_allowed_path(self._state_dir), ip)
+        else:
+            _append_unique(state.deny_path(self._state_dir), ip)
+        return True
+
+    def _nft_apply(self, nft_cmd: str) -> bool:
+        """Apply nft commands via nsenter into the container's network namespace.
+
+        Args:
+            nft_cmd: One or more nft commands (newline-separated).
+
+        Returns:
+            True if all commands succeeded.
+        """
+        for line in nft_cmd.strip().splitlines():
+            parts = line.strip().split()
+            if not parts:
+                continue
+            try:
+                self._runner.nft_via_nsenter(self._container, *parts)
+            except Exception:
+                logger.exception("nft command failed: %s", line)
+                return False
+        return True
+
+    def _is_dnsmasq_tier(self) -> bool:
+        """Return True when the container uses the dnsmasq DNS tier."""
+        tier_path = state.dns_tier_path(self._state_dir)
+        try:
+            return tier_path.is_file() and tier_path.read_text().strip() == "dnsmasq"
+        except OSError:
+            return False
+
+    def _refresh_domain_cache(self) -> None:
+        """Reload the IP-to-domain mapping from the dnsmasq query log."""
+        self._last_domain_refresh = time.monotonic()
+        log_path = state.dnsmasq_log_path(self._state_dir)
+        try:
+            text = log_path.read_text()
+        except OSError:
+            return
+
+        mapping: dict[str, str] = {}
+        for m in _REPLY_RE.finditer(text):
+            domain, ip = m.group(1), m.group(2)
+            mapping[ip] = domain.lower().rstrip(".")
+        self._ip_to_domain = mapping
+
+
 # ── Helpers ────────────────────────────────────────────
 
 
@@ -455,27 +767,26 @@ def _nsenter_reexec(state_dir: Path, container: str) -> None:
 
 
 def run_interactive(state_dir: Path, container: str) -> None:
-    """Start the interactive NFLOG handler for a container.
+    """Start the interactive handler for a container.
 
-    The NFLOG netlink socket must be inside the container's network
-    namespace to receive packets logged by nft rules.  On first
-    invocation, re-execs via ``podman unshare nsenter`` into the
-    container's netns.  The re-exec sets ``_TEROK_SHIELD_NFLOG_NSENTER``
-    so the second invocation runs the handler directly.
+    Reads the persisted interactive tier (``nflog`` or ``nfqueue``) and
+    dispatches to the appropriate session class.  Both tiers require
+    the handler to run inside the container's network namespace — on
+    first invocation, re-execs via ``podman unshare nsenter``.
 
     Args:
         state_dir: Per-container state directory (may be relative).
         container: Container name.
 
     Raises:
-        SystemExit: If the interactive tier is not configured or NFLOG
-            watcher creation fails.
+        SystemExit: If the interactive tier is not configured or handler
+            creation fails.
     """
     state_dir = state_dir.resolve()
     tier = read_interactive_tier(state_dir)
-    if tier != "nflog":
+    if tier not in ("nflog", "nfqueue"):
         print(
-            f"Error: interactive tier not configured (got {tier!r}, expected 'nflog').",
+            f"Error: interactive tier not configured (got {tier!r}, expected 'nflog' or 'nfqueue').",
             file=sys.stderr,
         )
         raise SystemExit(1)
@@ -485,7 +796,12 @@ def run_interactive(state_dir: Path, container: str) -> None:
         return
 
     runner = SubprocessRunner()
-    session = InteractiveSession(runner=runner, state_dir=state_dir, container=container)
+    if tier == "nfqueue":
+        session: InteractiveSession | NfqueueInteractiveSession = NfqueueInteractiveSession(
+            runner=runner, state_dir=state_dir, container=container
+        )
+    else:
+        session = InteractiveSession(runner=runner, state_dir=state_dir, container=container)
     session.run()
 
 

--- a/src/terok_shield/mode_hook.py
+++ b/src/terok_shield/mode_hook.py
@@ -105,6 +105,31 @@ def _split_domains_ips(entries: list[str]) -> tuple[list[str], list[str]]:
     return domains, raw_ips
 
 
+def _nfqueue_kernel_support() -> bool:
+    """Check if the kernel has NFQUEUE support (module loaded or built-in).
+
+    Reads ``/proc/modules`` for ``nfnetlink_queue`` and falls back to
+    ``modules.builtin`` for statically compiled kernels.  Pure read-only,
+    no root required.
+    """
+    try:
+        modules = Path("/proc/modules").read_text()
+        if "nfnetlink_queue" in modules:
+            return True
+    except OSError:
+        pass
+
+    # Check built-in modules for statically compiled kernels
+    import platform
+
+    release = platform.release()
+    builtin = Path(f"/lib/modules/{release}/modules.builtin")
+    try:
+        return "nfnetlink_queue" in builtin.read_text()
+    except OSError:
+        return False
+
+
 def _is_dnsmasq_tier(state_dir: Path) -> bool:
     """Return True when the container's DNS tier is dnsmasq (or unknown).
 
@@ -313,9 +338,20 @@ class HookMode:
         state.upstream_dns_path(sd).write_text(f"{upstream_dns}\n")
         state.dns_tier_path(sd).write_text(f"{tier.value}\n")
 
+        # Detect interactive tier: nfqueue if kernel supports it, else nflog
+        interactive = self._config.interactive
+        use_nfqueue = False
+        if interactive:
+            use_nfqueue = _nfqueue_kernel_support()
+            tier_name = "nfqueue" if use_nfqueue else "nflog"
+            state.interactive_path(sd).write_text(f"{tier_name}\n")
+            if not use_nfqueue:
+                logger.info("nfnetlink_queue unavailable — using NFLOG interactive tier")
+        else:
+            state.interactive_path(sd).unlink(missing_ok=True)
+
         # Pre-generate complete nft ruleset (gateway sets start empty; hook populates them)
         set_timeout = NFT_SET_TIMEOUT_DNSMASQ if tier == DnsTier.DNSMASQ else ""
-        interactive = self._config.interactive
         ruleset_builder = RulesetBuilder(
             dns=upstream_dns,
             loopback_ports=self._config.loopback_ports,
@@ -323,17 +359,11 @@ class HookMode:
         )
         ips = state.read_effective_ips(sd)
         denied_ips = list(state.read_denied_ips(sd))
-        ruleset = ruleset_builder.build_hook(interactive=interactive)
+        ruleset = ruleset_builder.build_hook(interactive=interactive, nfqueue=use_nfqueue)
         ruleset += ruleset_builder.add_elements_dual(ips)
         if denied_ips:
             ruleset += add_deny_elements_dual(denied_ips)
         state.ruleset_path(sd).write_text(ruleset)
-
-        # Persist interactive mode flag for shield_up() and the verdict handler
-        if interactive:
-            state.interactive_path(sd).write_text("nflog\n")
-        else:
-            state.interactive_path(sd).unlink(missing_ok=True)
 
         # Pre-generate dnsmasq config if using dnsmasq tier; otherwise scrub
         # stale artifacts so hook_entrypoint.py does not launch dnsmasq when
@@ -728,10 +758,12 @@ class HookMode:
     def shield_up(self, container: str) -> None:
         """Restore normal deny-all mode for a running container."""
         sd = self._config.state_dir.resolve()
-        interactive = state.interactive_path(sd).is_file()
+        tier = state.read_interactive_tier(sd)
+        interactive = tier is not None
+        use_nfqueue = tier == "nfqueue"
 
         ruleset = self._container_ruleset(container)
-        rs = ruleset.build_hook(interactive=interactive)
+        rs = ruleset.build_hook(interactive=interactive, nfqueue=use_nfqueue)
         current = self.shield_state(container)
         if current == ShieldState.INACTIVE:
             stdin = rs
@@ -772,7 +804,7 @@ class HookMode:
                     )
 
         output = self._runner.nft_via_nsenter(container, "list", "ruleset")
-        errors = ruleset.verify_hook(output, interactive=interactive)
+        errors = ruleset.verify_hook(output, interactive=interactive, nfqueue=use_nfqueue)
         if errors:
             raise RuntimeError(f"Ruleset verification failed: {'; '.join(errors)}")
 
@@ -788,10 +820,12 @@ class HookMode:
         if not self._ruleset.verify_bypass(output, allow_all=True):
             return ShieldState.DOWN_ALL
 
-        # Check both strict and interactive hook rulesets
+        # Check strict, interactive-nflog, and interactive-nfqueue hook rulesets
         if not self._ruleset.verify_hook(output):
             return ShieldState.UP
         if not self._ruleset.verify_hook(output, interactive=True):
+            return ShieldState.UP
+        if not self._ruleset.verify_hook(output, interactive=True, nfqueue=True):
             return ShieldState.UP
 
         return ShieldState.ERROR

--- a/src/terok_shield/netlink.py
+++ b/src/terok_shield/netlink.py
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared netlink struct definitions and IP packet parsing.
+
+Provides the low-level netlink message structs (``NLMSG_HDR``, ``NFGEN_HDR``,
+``NFA_HDR``) and packet-parsing helpers (``parse_nflog_attrs``,
+``extract_ip_dest``) used by both the NFLOG watcher and the NFQUEUE handler.
+
+Constants are stable kernel ABI from ``linux/netfilter/nfnetlink_log.h`` and
+``linux/netlink.h`` — unchanged since kernel 2.6.14 (2005).
+"""
+
+import socket
+import struct
+
+# IP protocol numbers
+IPPROTO_TCP = 6
+IPPROTO_UDP = 17
+
+# Netlink message header: length(4) + type(2) + flags(2) + seq(4) + pid(4)
+NLMSG_HDR = struct.Struct("=IHHII")
+# nfgenmsg: family(1) + version(1) + res_id(2)
+NFGEN_HDR = struct.Struct("=BBH")
+# nflog/nfqueue TLV attribute header: length(2) + type(2)
+NFA_HDR = struct.Struct("=HH")
+
+# Netlink message flags
+NLM_F_REQUEST = 1
+NLM_F_ACK = 4
+
+# AF_INET is 2 on all Linux platforms
+AF_INET = 2
+
+
+def parse_nflog_attrs(data: bytes) -> dict[int, bytes]:
+    """Parse TLV attributes from an NFLOG/NFQUEUE packet message.
+
+    Returns a dict mapping attribute type to raw attribute value bytes.
+    """
+    attrs: dict[int, bytes] = {}
+    offset = 0
+    while offset + NFA_HDR.size <= len(data):
+        nfa_len, nfa_type = NFA_HDR.unpack_from(data, offset)
+        if nfa_len < NFA_HDR.size:
+            break
+        # Mask out the nested/byteorder flags from the type field
+        nfa_type &= 0x7FFF
+        value = data[offset + NFA_HDR.size : offset + nfa_len]
+        attrs[nfa_type] = value
+        # Attributes are 4-byte aligned
+        offset += (nfa_len + 3) & ~3
+    return attrs
+
+
+def extract_ip_dest(payload: bytes) -> tuple[str, int, int]:
+    """Extract destination IP, protocol, and port from a raw IP packet.
+
+    Handles both IPv4 and IPv6 headers (NFLOG/NFQUEUE in inet tables
+    delivers the IP header).  Returns ``("", 0, 0)`` if the packet
+    cannot be parsed.
+    """
+    if len(payload) < 20:
+        return ("", 0, 0)
+    version = (payload[0] >> 4) & 0xF
+    if version != 4:
+        # IPv6 parsing: 40-byte header, dest at offset 24
+        if version == 6 and len(payload) >= 40:
+            dest_bytes = payload[24:40]
+            dest = socket.inet_ntop(socket.AF_INET6, dest_bytes)
+            proto = payload[6]  # Next Header
+            port = 0
+            if proto in (IPPROTO_TCP, IPPROTO_UDP) and len(payload) >= 44:
+                port = struct.unpack_from("!H", payload, 42)[0]  # dest port
+            return (dest, proto, port)
+        return ("", 0, 0)
+    ihl = (payload[0] & 0xF) * 4
+    if ihl < 20:
+        return ("", 0, 0)
+    proto = payload[9]
+    dest = socket.inet_ntop(socket.AF_INET, payload[16:20])
+    port = 0
+    if proto in (IPPROTO_TCP, IPPROTO_UDP) and len(payload) >= ihl + 4:
+        port = struct.unpack_from("!H", payload, ihl + 2)[0]  # dest port
+    return (dest, proto, port)

--- a/src/terok_shield/nfqueue.py
+++ b/src/terok_shield/nfqueue.py
@@ -1,0 +1,269 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Raw AF_NETLINK NFQUEUE handler for interactive packet queuing.
+
+Provides a pure-Python NFQUEUE subscriber that binds to a kernel queue,
+receives queued packets, and issues accept/drop verdicts — all via raw
+netlink without external C libraries.
+
+Used by the NFQUEUE interactive tier when the ``nfnetlink_queue`` kernel
+module is available.  Falls back to the NFLOG tier otherwise.
+"""
+
+from __future__ import annotations
+
+import logging
+import socket
+import struct
+from dataclasses import dataclass
+
+from .netlink import (
+    NFA_HDR,
+    NFGEN_HDR,
+    NLM_F_ACK,
+    NLM_F_REQUEST,
+    NLMSG_HDR,
+    extract_ip_dest,
+    parse_nflog_attrs,
+)
+from .nft_constants import NFQUEUE_NUM
+
+logger = logging.getLogger(__name__)
+
+# ── Netlink constants (linux/netfilter/nfnetlink_queue.h) ─
+
+_NETLINK_NETFILTER = 12
+
+NF_ACCEPT = 1
+NF_DROP = 0
+
+_NFNL_SUBSYS_QUEUE = 3
+_NFQNL_MSG_PACKET = 0
+_NFQNL_MSG_VERDICT = 1
+_NFQNL_MSG_CONFIG = 2
+
+_NFQNL_CFG_CMD_BIND = 1
+_NFQA_CFG_CMD = 1
+_NFQA_CFG_PARAMS = 5
+_NFQA_PACKET_HDR = 1
+_NFQA_VERDICT_HDR = 3
+_NFQA_PAYLOAD = 10
+
+_NFQNL_COPY_PACKET = 2
+_NFQNL_PACKET_HDR = struct.Struct("!IHB")  # packet_id, hw_protocol, hook
+_NFQNL_CFG_CMD_STRUCT = struct.Struct("!BxH")  # command, padding, pf
+
+
+@dataclass(frozen=True)
+class QueuedPacket:
+    """A packet queued by NFQUEUE awaiting a verdict."""
+
+    packet_id: int
+    dest: str
+    port: int
+    proto: int
+
+
+# ── NfqueueHandler ────────────────────────────────────
+
+
+class NfqueueHandler:
+    """Raw AF_NETLINK NFQUEUE subscriber.
+
+    Binds to a kernel NFQUEUE group, receives queued packets via
+    ``poll()``, and issues verdicts via ``verdict()``.  The socket
+    is non-blocking after the initial blocking handshake.
+
+    Use :meth:`create` to construct; it handles the bind handshake
+    and returns ``None`` if NFQUEUE is unavailable.
+    """
+
+    def __init__(self, sock: socket.socket, queue_num: int) -> None:
+        """Wrap an already-bound NFQUEUE netlink socket.
+
+        Use :meth:`create` instead of calling this directly.
+        """
+        self._sock = sock
+        self._queue_num = queue_num
+
+    @classmethod
+    def create(cls, queue_num: int = NFQUEUE_NUM) -> NfqueueHandler | None:
+        """Create and bind an NFQUEUE handler, or return ``None`` on failure.
+
+        Binds to the specified queue number, sets copy mode to full packet,
+        and configures a reasonable copy range for IP header extraction.
+
+        Args:
+            queue_num: NFQUEUE group number to bind to.
+        """
+        sock: socket.socket | None = None
+        try:
+            sock = socket.socket(socket.AF_NETLINK, socket.SOCK_RAW, _NETLINK_NETFILTER)
+            sock.bind((0, 0))
+
+            # Handshake in blocking mode so ACKs are reliably received
+            sock.settimeout(2.0)
+            sock.send(_build_config_cmd(queue_num, _NFQNL_CFG_CMD_BIND))
+            if not _check_ack(sock):
+                sock.close()
+                return None
+            sock.send(_build_config_params(queue_num, copy_range=256))
+            if not _check_ack(sock):
+                sock.close()
+                return None
+
+            # Switch to non-blocking for the poll() loop
+            sock.setblocking(False)
+            return cls(sock, queue_num)
+        except (OSError, AttributeError):
+            logger.debug("NFQUEUE socket unavailable — interactive mode disabled")
+            if sock is not None:
+                sock.close()
+            return None
+
+    def fileno(self) -> int:
+        """Return the file descriptor for ``select.select()`` multiplexing."""
+        return self._sock.fileno()
+
+    def close(self) -> None:
+        """Close the netlink socket."""
+        self._sock.close()
+
+    def poll(self) -> list[QueuedPacket]:
+        """Read available NFQUEUE messages and return parsed packets."""
+        try:
+            data = self._sock.recv(65536)
+        except OSError:
+            return []
+        return self._parse_messages(data) if data else []
+
+    def verdict(self, packet_id: int, *, accept: bool) -> None:
+        """Issue a verdict for a queued packet.
+
+        Args:
+            packet_id: Kernel-assigned packet identifier.
+            accept: ``True`` for NF_ACCEPT, ``False`` for NF_DROP.
+        """
+        msg = _build_verdict_msg(self._queue_num, packet_id, NF_ACCEPT if accept else NF_DROP)
+        try:
+            self._sock.send(msg)
+        except OSError:
+            logger.warning("Failed to send verdict for packet %d", packet_id)
+
+    def _parse_messages(self, data: bytes) -> list[QueuedPacket]:
+        """Parse one or more netlink messages from raw *data*."""
+        packets: list[QueuedPacket] = []
+        offset = 0
+        while offset + NLMSG_HDR.size <= len(data):
+            nl_len, nl_type, _flags, _seq, _pid = NLMSG_HDR.unpack_from(data, offset)
+            if nl_len < NLMSG_HDR.size or offset + nl_len > len(data):
+                break
+            pkt = self._handle_one_message(data, offset, nl_len, nl_type)
+            if pkt:
+                packets.append(pkt)
+            offset += (nl_len + 3) & ~3
+        return packets
+
+    def _handle_one_message(
+        self, data: bytes, offset: int, nl_len: int, nl_type: int
+    ) -> QueuedPacket | None:
+        """Parse a single netlink message, auto-dropping unparseable packets."""
+        subsys = (nl_type >> 8) & 0xFF
+        msg = nl_type & 0xFF
+        if subsys != _NFNL_SUBSYS_QUEUE or msg != _NFQNL_MSG_PACKET:
+            return None
+        attr_offset = NLMSG_HDR.size + NFGEN_HDR.size
+        if offset + attr_offset >= offset + nl_len:
+            return None
+        attrs = parse_nflog_attrs(data[offset + attr_offset : offset + nl_len])
+        pkt = _attrs_to_packet(attrs)
+        if pkt:
+            return pkt
+        # Unparseable payload but we have a packet_id — must still issue
+        # a verdict or the packet stays stuck in the kernel queue.
+        pid = _extract_packet_id(attrs)
+        if pid is not None:
+            self.verdict(pid, accept=False)
+        return None
+
+
+# ── Packet parsing ────────────────────────────────────
+
+
+def _extract_packet_id(attrs: dict[int, bytes]) -> int | None:
+    """Extract just the packet_id from NFQUEUE attributes, or ``None``."""
+    pkt_hdr = attrs.get(_NFQA_PACKET_HDR)
+    if not pkt_hdr or len(pkt_hdr) < _NFQNL_PACKET_HDR.size:
+        return None
+    return _NFQNL_PACKET_HDR.unpack_from(pkt_hdr)[0]
+
+
+def _attrs_to_packet(attrs: dict[int, bytes]) -> QueuedPacket | None:
+    """Convert parsed NFQUEUE attributes into a :class:`QueuedPacket`."""
+    packet_id = _extract_packet_id(attrs)
+    if packet_id is None:
+        return None
+    payload = attrs.get(_NFQA_PAYLOAD, b"")
+    dest, proto, port = extract_ip_dest(payload)
+    if not dest:
+        return None
+    return QueuedPacket(packet_id=packet_id, dest=dest, port=port, proto=proto)
+
+
+# ── Message builders ──────────────────────────────────
+
+
+def _build_config_cmd(queue_num: int, command: int) -> bytes:
+    """Build an NFQUEUE config command message (bind/unbind)."""
+    cmd_attr = _NFQNL_CFG_CMD_STRUCT.pack(command, socket.AF_INET)
+    nfa = NFA_HDR.pack(NFA_HDR.size + len(cmd_attr), _NFQA_CFG_CMD) + cmd_attr
+    nfgen = NFGEN_HDR.pack(2, 0, socket.htons(queue_num))
+    payload = nfgen + nfa
+    msg_type = (_NFNL_SUBSYS_QUEUE << 8) | _NFQNL_MSG_CONFIG
+    return (
+        NLMSG_HDR.pack(NLMSG_HDR.size + len(payload), msg_type, NLM_F_REQUEST | NLM_F_ACK, 0, 0)
+        + payload
+    )
+
+
+def _build_config_params(queue_num: int, *, copy_range: int = 256) -> bytes:
+    """Build an NFQUEUE config params message (copy mode + range)."""
+    params = struct.pack("!IB3x", copy_range, _NFQNL_COPY_PACKET)
+    nfa = NFA_HDR.pack(NFA_HDR.size + len(params), _NFQA_CFG_PARAMS) + params
+    nfgen = NFGEN_HDR.pack(2, 0, socket.htons(queue_num))
+    payload = nfgen + nfa
+    msg_type = (_NFNL_SUBSYS_QUEUE << 8) | _NFQNL_MSG_CONFIG
+    return (
+        NLMSG_HDR.pack(NLMSG_HDR.size + len(payload), msg_type, NLM_F_REQUEST | NLM_F_ACK, 0, 0)
+        + payload
+    )
+
+
+def _build_verdict_msg(queue_num: int, packet_id: int, verdict: int) -> bytes:
+    """Build an NFQUEUE verdict message."""
+    nfgen = NFGEN_HDR.pack(2, 0, socket.htons(queue_num))
+    msg_type = (_NFNL_SUBSYS_QUEUE << 8) | _NFQNL_MSG_VERDICT
+    verdict_payload = struct.pack("!II", verdict, packet_id)
+    attr = NFA_HDR.pack(NFA_HDR.size + len(verdict_payload), _NFQA_VERDICT_HDR) + verdict_payload
+    payload = nfgen + attr
+    return NLMSG_HDR.pack(NLMSG_HDR.size + len(payload), msg_type, NLM_F_REQUEST, 0, 0) + payload
+
+
+def _check_ack(sock: socket.socket) -> bool:
+    """Read and check an NLMSG_ERROR ACK from the kernel.
+
+    Returns ``True`` if the ACK indicates success (error code 0),
+    ``False`` otherwise.
+    """
+    try:
+        ack = sock.recv(4096)
+        if len(ack) >= NLMSG_HDR.size + 4:
+            err = struct.unpack_from("=i", ack, NLMSG_HDR.size)[0]
+            if err < 0:
+                logger.debug("NFQUEUE config rejected (errno %d)", -err)
+                return False
+        return True
+    except OSError:
+        logger.debug("NFQUEUE ACK not received")
+        return False

--- a/src/terok_shield/nft.py
+++ b/src/terok_shield/nft.py
@@ -21,6 +21,7 @@ from .nft_constants import (
     BYPASS_LOG_PREFIX,
     DENIED_LOG_PREFIX,
     NFLOG_GROUP,
+    NFQUEUE_NUM,
     NFT_TABLE,
     PASTA_DNS,
     PASTA_HOST_LOOPBACK_MAP,
@@ -145,7 +146,7 @@ def _deny_set_rules() -> str:
 
 
 def _interactive_reject_rule() -> str:
-    """Generate the NFLOG+reject terminal rule for interactive mode.
+    """Generate the NFLOG+reject terminal rule for interactive NFLOG mode.
 
     Rejects unmatched packets immediately but logs them with the QUEUED prefix
     so the interactive handler can detect them via NFLOG.
@@ -154,6 +155,15 @@ def _interactive_reject_rule() -> str:
         f'        log group {NFLOG_GROUP} prefix "{QUEUED_LOG_PREFIX}: " '
         f"counter reject with icmpx admin-prohibited"
     )
+
+
+def _nfqueue_rule() -> str:
+    """Generate the NFQUEUE terminal rule for interactive NFQUEUE mode.
+
+    Queues unmatched packets to the kernel NFQUEUE where the interactive
+    handler holds them until a verdict (accept/drop) is issued.
+    """
+    return f"        counter queue num {NFQUEUE_NUM}"
 
 
 def _loopback_port_rules(ports: tuple[int, ...]) -> str:
@@ -229,13 +239,14 @@ class RulesetBuilder:
         self._loopback_ports = loopback_ports
         self._set_timeout = set_timeout
 
-    def build_hook(self, *, interactive: bool = False) -> str:
+    def build_hook(self, *, interactive: bool = False, nfqueue: bool = False) -> str:
         """Generate the hook-mode (deny-all) nftables ruleset."""
         return hook_ruleset(
             dns=self._dns,
             loopback_ports=self._loopback_ports,
             set_timeout=self._set_timeout,
             interactive=interactive,
+            nfqueue=nfqueue,
         )
 
     def build_bypass(self, *, allow_all: bool = False) -> str:
@@ -247,9 +258,11 @@ class RulesetBuilder:
             set_timeout=self._set_timeout,
         )
 
-    def verify_hook(self, nft_output: str, *, interactive: bool = False) -> list[str]:
+    def verify_hook(
+        self, nft_output: str, *, interactive: bool = False, nfqueue: bool = False
+    ) -> list[str]:
         """Check applied hook ruleset invariants.  Returns errors (empty = OK)."""
-        return verify_ruleset(nft_output, interactive=interactive)
+        return verify_ruleset(nft_output, interactive=interactive, nfqueue=nfqueue)
 
     def verify_bypass(self, nft_output: str, *, allow_all: bool = False) -> list[str]:
         """Check applied bypass ruleset invariants.  Returns errors (empty = OK)."""
@@ -288,6 +301,7 @@ def hook_ruleset(
     set_timeout: str = "",
     *,
     interactive: bool = False,
+    nfqueue: bool = False,
 ) -> str:
     """Generate a per-container nftables ruleset for hook mode.
 
@@ -308,7 +322,10 @@ def hook_ruleset(
         loopback_ports: TCP ports to allow on the loopback interface.
         set_timeout: nft set element timeout (e.g. ``30m``).
         interactive: When True, replaces the terminal deny-all rule with an
-            NFLOG+reject rule using the QUEUED prefix for interactive handling.
+            interactive terminal rule (NFLOG+reject or NFQUEUE).
+        nfqueue: When True (and *interactive* is True), uses an NFQUEUE
+            terminal rule instead of NFLOG+reject.  Requires kernel
+            ``nfnetlink_queue`` support.
     """
     dns = safe_ip(dns)
     if set_timeout:
@@ -328,7 +345,10 @@ def hook_ruleset(
     set_v6 = _set_declaration("allow_v6", "ipv6_addr", set_timeout)
     set_deny_v4 = _set_declaration("deny_v4", "ipv4_addr")
     set_deny_v6 = _set_declaration("deny_v6", "ipv6_addr")
-    terminal_rule = _interactive_reject_rule() if interactive else _audit_deny_rule()
+    if interactive:
+        terminal_rule = _nfqueue_rule() if nfqueue else _interactive_reject_rule()
+    else:
+        terminal_rule = _audit_deny_rule()
     return textwrap.dedent(f"""\
         table {NFT_TABLE} {{
             {set_v4}
@@ -577,18 +597,21 @@ def _verify_private_blocks(nft_output: str) -> list[str]:
     return errors
 
 
-def verify_ruleset(nft_output: str, *, interactive: bool = False) -> list[str]:
+def verify_ruleset(
+    nft_output: str, *, interactive: bool = False, nfqueue: bool = False
+) -> list[str]:
     """Check applied ruleset invariants.  Returns errors (empty = OK).
 
     Verifies:
     - Default policy is drop
     - Both output and input chains exist
-    - Reject type is present
+    - Reject type is present (unless nfqueue — packets are queued, not rejected)
     - Dual-stack allow sets are declared
     - Dual-stack deny sets are declared
     - All private ranges are present (RFC 1918 + RFC 4193/4291)
-    - Interactive mode: queued nflog prefix present
-    - Non-interactive mode: deny nflog prefix present
+    - Interactive NFLOG: queued nflog prefix present
+    - Interactive NFQUEUE: ``queue num`` present
+    - Non-interactive: deny nflog prefix present
     """
     errors: list[str] = []
     if "policy drop" not in nft_output:
@@ -596,7 +619,9 @@ def verify_ruleset(nft_output: str, *, interactive: bool = False) -> list[str]:
     for chain in ("output", "input"):
         if f"chain {chain}" not in nft_output:
             errors.append(f"{chain} chain missing")
-    if "admin-prohibited" not in nft_output:
+    # NFQUEUE mode queues packets instead of rejecting — admin-prohibited is
+    # still present from private-range rules, but not the terminal rule.
+    if not (interactive and nfqueue) and "admin-prohibited" not in nft_output:
         errors.append("reject type missing")
     if "allow_v4" not in nft_output:
         errors.append("allow_v4 set missing")
@@ -607,7 +632,10 @@ def verify_ruleset(nft_output: str, *, interactive: bool = False) -> list[str]:
     if "deny_v6" not in nft_output:
         errors.append("deny_v6 set missing")
     if interactive:
-        if QUEUED_LOG_PREFIX not in nft_output:
+        if nfqueue:
+            if f"queue num {NFQUEUE_NUM}" not in nft_output:
+                errors.append("nfqueue terminal rule missing")
+        elif QUEUED_LOG_PREFIX not in nft_output:
             errors.append("queued nflog prefix missing")
     else:
         # Verify the terminal deny-all rule specifically — not just the prefix

--- a/src/terok_shield/nft_constants.py
+++ b/src/terok_shield/nft_constants.py
@@ -59,3 +59,6 @@ PRIVATE_LOG_PREFIX = "TEROK_SHIELD_PRIVATE"
 ALLOWED_LOG_PREFIX = "TEROK_SHIELD_ALLOWED"
 BYPASS_LOG_PREFIX = "TEROK_SHIELD_BYPASS"
 QUEUED_LOG_PREFIX = "TEROK_SHIELD_QUEUED"
+
+# ── NFQUEUE ────────────────────────────────────────────
+NFQUEUE_NUM = 200  # nfqueue group number for interactive packet queuing

--- a/src/terok_shield/state.py
+++ b/src/terok_shield/state.py
@@ -127,14 +127,18 @@ def interactive_path(state_dir: Path) -> Path:
 def read_interactive_tier(state_dir: Path) -> str | None:
     """Read the interactive tier from the state bundle.
 
-    Returns ``"nflog"`` (or whatever tier string is stored) if the file
-    exists and contains a non-empty value, otherwise ``None``.
+    Returns ``"nflog"``, ``"nfqueue"``, or ``None``.  Legacy value
+    ``"1"`` (from early interactive marker files) is treated as ``"nflog"``
+    for backward compatibility.
     """
     path = interactive_path(state_dir)
     if not path.is_file():
         return None
     value = path.read_text().strip()
-    return value or None
+    if not value:
+        return None
+    # Legacy: "1" was the original boolean marker before tier-aware values
+    return "nflog" if value == "1" else value
 
 
 def live_domains_path(state_dir: Path) -> Path:

--- a/src/terok_shield/watch.py
+++ b/src/terok_shield/watch.py
@@ -32,6 +32,7 @@ from pathlib import Path
 
 from . import dnsmasq, state
 from .config import DnsTier
+from .netlink import NFA_HDR, NFGEN_HDR, NLMSG_HDR, extract_ip_dest, parse_nflog_attrs
 from .nft_constants import NFLOG_GROUP
 
 logger = logging.getLogger(__name__)
@@ -222,8 +223,7 @@ class AuditLogWatcher:
 
 # ── NFLOG watcher ──────────────────────────────────────
 
-# Linux netlink / nflog constants (from linux/netfilter/nfnetlink.h and
-# linux/netfilter/nfnetlink_log.h).
+# NFLOG-specific constants (from linux/netfilter/nfnetlink_log.h).
 _NETLINK_NETFILTER = 12
 _NFNL_SUBSYS_ULOG = 4
 _NFULNL_MSG_CONFIG = 1
@@ -231,31 +231,14 @@ _NFULNL_MSG_PACKET = 0
 
 # nflog config commands
 _NFULNL_CFG_CMD_BIND = 1
-_NFULNL_CFG_CMD_UNBIND = 0
 
 # nflog attribute types (TLV in the packet payload)
 _NFULA_PACKET_HDR = 1
 _NFULA_PREFIX = 10  # NFULA_PREFIX (nfnetlink_log.h)
 _NFULA_PAYLOAD = 9
 
-# IP protocol numbers
-_IPPROTO_TCP = 6
-_IPPROTO_UDP = 17
-
-# Netlink message header: length(4) + type(2) + flags(2) + seq(4) + pid(4)
-_NLMSG_HDR = struct.Struct("=IHHII")
-# nfgenmsg: family(1) + version(1) + res_id(2)
-_NFGEN_HDR = struct.Struct("=BBH")
-# nflog config command: command(1) + pad(1) + pf(2)
+# nflog config command struct: command(1) + pad(1) + pf(2)
 _NFULNL_CFG_CMD = struct.Struct("=BBH")
-# nflog TLV attribute header: length(2) + type(2)
-_NFA_HDR = struct.Struct("=HH")
-
-_NLM_F_REQUEST = 1
-_NLM_F_ACK = 4
-
-# AF_INET is 2 on all Linux platforms
-_AF_INET = 2
 
 
 def _build_nflog_bind_msg(group: int) -> bytes:
@@ -264,75 +247,24 @@ def _build_nflog_bind_msg(group: int) -> bytes:
     Constructs the raw NFULNL_MSG_CONFIG message with CMD_BIND
     for the specified NFLOG group number.
     """
+    from .netlink import AF_INET, NLM_F_ACK, NLM_F_REQUEST
+
     msg_type = (_NFNL_SUBSYS_ULOG << 8) | _NFULNL_MSG_CONFIG
-    nfgen = _NFGEN_HDR.pack(_AF_INET, 0, socket.htons(group))
-    # Config command attribute: NFULA_CFG_CMD
-    cmd_payload = _NFULNL_CFG_CMD.pack(_NFULNL_CFG_CMD_BIND, 0, socket.htons(_AF_INET))
-    # Attribute TLV: type=1 (NFULA_CFG_CMD), length=header+payload
-    attr = _NFA_HDR.pack(_NFA_HDR.size + len(cmd_payload), 1) + cmd_payload
+    nfgen = NFGEN_HDR.pack(AF_INET, 0, socket.htons(group))
+    cmd_payload = _NFULNL_CFG_CMD.pack(_NFULNL_CFG_CMD_BIND, 0, socket.htons(AF_INET))
+    attr = NFA_HDR.pack(NFA_HDR.size + len(cmd_payload), 1) + cmd_payload
     payload = nfgen + attr
     nlmsg = (
-        _NLMSG_HDR.pack(
-            _NLMSG_HDR.size + len(payload),
+        NLMSG_HDR.pack(
+            NLMSG_HDR.size + len(payload),
             msg_type,
-            _NLM_F_REQUEST | _NLM_F_ACK,
+            NLM_F_REQUEST | NLM_F_ACK,
             0,
             0,
         )
         + payload
     )
     return nlmsg
-
-
-def _parse_nflog_attrs(data: bytes) -> dict[int, bytes]:
-    """Parse TLV attributes from an NFLOG packet message.
-
-    Returns a dict mapping attribute type to raw attribute value bytes.
-    """
-    attrs: dict[int, bytes] = {}
-    offset = 0
-    while offset + _NFA_HDR.size <= len(data):
-        nfa_len, nfa_type = _NFA_HDR.unpack_from(data, offset)
-        if nfa_len < _NFA_HDR.size:
-            break
-        # Mask out the nested/byteorder flags from the type field
-        nfa_type &= 0x7FFF
-        value = data[offset + _NFA_HDR.size : offset + nfa_len]
-        attrs[nfa_type] = value
-        # Attributes are 4-byte aligned
-        offset += (nfa_len + 3) & ~3
-    return attrs
-
-
-def _extract_ip_dest(payload: bytes) -> tuple[str, int, int]:
-    """Extract destination IP, protocol, and port from a raw IP packet.
-
-    Handles IPv4 only (NFLOG in inet tables delivers the IP header).
-    Returns ``("", 0, 0)`` if the packet cannot be parsed.
-    """
-    if len(payload) < 20:
-        return ("", 0, 0)
-    version = (payload[0] >> 4) & 0xF
-    if version != 4:
-        # IPv6 parsing: 40-byte header, dest at offset 24
-        if version == 6 and len(payload) >= 40:
-            dest_bytes = payload[24:40]
-            dest = socket.inet_ntop(socket.AF_INET6, dest_bytes)
-            proto = payload[6]  # Next Header
-            port = 0
-            if proto in (_IPPROTO_TCP, _IPPROTO_UDP) and len(payload) >= 44:
-                port = struct.unpack_from("!H", payload, 42)[0]  # dest port
-            return (dest, proto, port)
-        return ("", 0, 0)
-    ihl = (payload[0] & 0xF) * 4
-    if ihl < 20:
-        return ("", 0, 0)
-    proto = payload[9]
-    dest = socket.inet_ntop(socket.AF_INET, payload[16:20])
-    port = 0
-    if proto in (_IPPROTO_TCP, _IPPROTO_UDP) and len(payload) >= ihl + 4:
-        port = struct.unpack_from("!H", payload, ihl + 2)[0]  # dest port
-    return (dest, proto, port)
 
 
 class NflogWatcher:
@@ -375,8 +307,8 @@ class NflogWatcher:
             sock.settimeout(2.0)
             sock.send(_build_nflog_bind_msg(group))
             ack = sock.recv(4096)
-            if len(ack) >= _NLMSG_HDR.size + 4:
-                err = struct.unpack_from("=i", ack, _NLMSG_HDR.size)[0]
+            if len(ack) >= NLMSG_HDR.size + 4:
+                err = struct.unpack_from("=i", ack, NLMSG_HDR.size)[0]
                 if err < 0:
                     sock.close()
                     logger.debug("NFLOG bind rejected (errno %d) — skipping", -err)
@@ -418,18 +350,18 @@ class NflogWatcher:
         """Parse one or more netlink messages from raw *data*."""
         events: list[WatchEvent] = []
         offset = 0
-        while offset + _NLMSG_HDR.size <= len(data):
-            nl_len, nl_type, _flags, _seq, _pid = _NLMSG_HDR.unpack_from(data, offset)
-            if nl_len < _NLMSG_HDR.size or offset + nl_len > len(data):
+        while offset + NLMSG_HDR.size <= len(data):
+            nl_len, nl_type, _flags, _seq, _pid = NLMSG_HDR.unpack_from(data, offset)
+            if nl_len < NLMSG_HDR.size or offset + nl_len > len(data):
                 break
             # Check this is an NFLOG packet message
             subsys = (nl_type >> 8) & 0xFF
             msg = nl_type & 0xFF
             if subsys == _NFNL_SUBSYS_ULOG and msg == _NFULNL_MSG_PACKET:
                 # Skip nlmsg header + nfgenmsg (4 bytes)
-                attr_offset = _NLMSG_HDR.size + _NFGEN_HDR.size
+                attr_offset = NLMSG_HDR.size + NFGEN_HDR.size
                 if offset + attr_offset < offset + nl_len:
-                    attrs = _parse_nflog_attrs(data[offset + attr_offset : offset + nl_len])
+                    attrs = parse_nflog_attrs(data[offset + attr_offset : offset + nl_len])
                     event = self._attr_to_event(attrs)
                     if event:
                         events.append(event)
@@ -457,7 +389,7 @@ class NflogWatcher:
             action = "nflog"
 
         payload = attrs.get(_NFULA_PAYLOAD, b"")
-        dest, proto, port = _extract_ip_dest(payload)
+        dest, proto, port = extract_ip_dest(payload)
         if not dest:
             return None
 

--- a/tach.toml
+++ b/tach.toml
@@ -30,6 +30,19 @@ depends_on = [
     "terok_shield.nft_constants",
 ]
 
+# Shared netlink struct definitions — no dependencies
+[[modules]]
+path = "terok_shield.netlink"
+depends_on = []
+
+# NFQUEUE handler — depends on netlink + nft_constants
+[[modules]]
+path = "terok_shield.nfqueue"
+depends_on = [
+    "terok_shield.netlink",
+    "terok_shield.nft_constants",
+]
+
 # Per-container state bundle layout — zero dependencies
 [[modules]]
 path = "terok_shield.state"
@@ -95,6 +108,7 @@ path = "terok_shield.watch"
 depends_on = [
     "terok_shield.config",
     "terok_shield.dnsmasq",
+    "terok_shield.netlink",
     "terok_shield.nft_constants",
     "terok_shield.state",
 ]
@@ -113,11 +127,12 @@ depends_on = [
     "terok_shield.util",
 ]
 
-# Interactive verdict loop — NFLOG-based operator approval
+# Interactive verdict loop — NFLOG + NFQUEUE operator approval
 [[modules]]
 path = "terok_shield.interactive"
 depends_on = [
     "terok_shield.nft",
+    "terok_shield.nfqueue",
     "terok_shield.run",
     "terok_shield.state",
     "terok_shield.watch",

--- a/tests/unit/test_api_surface.py
+++ b/tests/unit/test_api_surface.py
@@ -91,6 +91,7 @@ class TestAPISurface:
             "audit_enabled",
             "profiles_dir",
             "interactive",
+            "nfqueue_timeout",
         ]
 
         cfg = make_config()

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -227,3 +227,27 @@ class TestShieldFileConfigAuditValidation:
         """audit.enabled must be a boolean."""
         with pytest.raises(ValidationError):
             ShieldFileConfig(audit={"enabled": "yes-please"})  # type: ignore[arg-type]
+
+
+class TestShieldFileConfigNfqueueTimeout:
+    """nfqueue_timeout validation and defaults."""
+
+    def test_default_value(self) -> None:
+        """nfqueue_timeout defaults to 5 seconds."""
+        cfg = ShieldFileConfig()
+        assert cfg.nfqueue_timeout == 5
+
+    def test_valid_range(self) -> None:
+        """Values within 1–300 are accepted."""
+        assert ShieldFileConfig(nfqueue_timeout=1).nfqueue_timeout == 1
+        assert ShieldFileConfig(nfqueue_timeout=300).nfqueue_timeout == 300
+
+    def test_zero_rejected(self) -> None:
+        """Timeout of 0 is rejected (minimum is 1)."""
+        with pytest.raises(ValidationError):
+            ShieldFileConfig(nfqueue_timeout=0)
+
+    def test_too_high_rejected(self) -> None:
+        """Timeout above 300 is rejected."""
+        with pytest.raises(ValidationError):
+            ShieldFileConfig(nfqueue_timeout=301)

--- a/tests/unit/test_hook_mode_class.py
+++ b/tests/unit/test_hook_mode_class.py
@@ -1262,7 +1262,30 @@ def test_shield_up_interactive_uses_interactive_ruleset(
 
     harness.mode.shield_up("test-ctr")
 
-    harness.ruleset.build_hook.assert_called_with(interactive=True)
+    harness.ruleset.build_hook.assert_called_with(interactive=True, nfqueue=False)
+
+
+def test_shield_up_nfqueue_tier_passes_nfqueue_flag(
+    make_hook_mode: HookModeHarnessFactory,
+    make_config: ConfigFactory,
+) -> None:
+    """shield_up() passes nfqueue=True when the interactive tier is nfqueue."""
+    config = make_config()
+    harness = make_hook_mode(config=config)
+    harness.mode._container_ruleset = lambda _c: harness.ruleset
+    harness.runner.nft_via_nsenter.return_value = ""
+    harness.ruleset.build_hook.return_value = "hook ruleset"
+    harness.ruleset.verify_hook.return_value = []
+    harness.ruleset.add_elements_dual.return_value = ""
+    harness.ruleset.verify_bypass.return_value = ["not bypass"]
+
+    state.interactive_path(config.state_dir).write_text("nfqueue\n")
+    harness.mode.shield_up("test-ctr")
+
+    harness.ruleset.build_hook.assert_called_with(interactive=True, nfqueue=True)
+    harness.ruleset.verify_hook.assert_called_with(
+        harness.runner.nft_via_nsenter.return_value, interactive=True, nfqueue=True
+    )
 
 
 def test_shield_up_repopulates_deny_sets(

--- a/tests/unit/test_interactive.py
+++ b/tests/unit/test_interactive.py
@@ -527,6 +527,26 @@ class TestRunInteractive:
         mock_session_cls.assert_called_once()
         mock_session_cls.return_value.run.assert_called_once()
 
+    def test_dispatches_nfqueue_inside_netns(self, tmp_path: Path) -> None:
+        """run_interactive dispatches to NfqueueInteractiveSession for nfqueue tier."""
+        state.interactive_path(tmp_path).write_text("nfqueue\n")
+        with (
+            mock.patch.dict("os.environ", {_NSENTER_ENV: "1"}),
+            mock.patch("terok_shield.interactive.SubprocessRunner") as mock_runner_cls,
+            mock.patch("terok_shield.interactive.NfqueueInteractiveSession") as mock_session_cls,
+        ):
+            run_interactive(tmp_path, _CONTAINER)
+        mock_runner_cls.assert_called_once()
+        mock_session_cls.assert_called_once()
+        mock_session_cls.return_value.run.assert_called_once()
+
+    def test_nsenter_reexec_for_nfqueue(self, tmp_path: Path) -> None:
+        """run_interactive calls nsenter reexec for nfqueue tier too."""
+        state.interactive_path(tmp_path).write_text("nfqueue\n")
+        with mock.patch("terok_shield.interactive._nsenter_reexec") as mock_reexec:
+            run_interactive(tmp_path, _CONTAINER)
+        mock_reexec.assert_called_once_with(tmp_path, _CONTAINER)
+
 
 # ── __main__ block ───────────────────────────────────────
 
@@ -566,7 +586,7 @@ class TestMainBlock:
         # run_interactive will fail (no interactive tier), but the __main__
         # block dispatched correctly — exit code 1, not 2.
         assert result.returncode == 1
-        assert "nflog" in result.stderr
+        assert "interactive tier" in result.stderr.lower() or "nflog" in result.stderr
 
 
 # ── _nsenter_reexec ──────────────────────────────────────

--- a/tests/unit/test_netlink.py
+++ b/tests/unit/test_netlink.py
@@ -1,0 +1,176 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the shared netlink module (netlink.py)."""
+
+from __future__ import annotations
+
+import socket
+import struct
+
+from terok_shield.netlink import (
+    AF_INET,
+    IPPROTO_TCP,
+    IPPROTO_UDP,
+    NFA_HDR,
+    NFGEN_HDR,
+    NLM_F_ACK,
+    NLM_F_REQUEST,
+    NLMSG_HDR,
+    extract_ip_dest,
+    parse_nflog_attrs,
+)
+
+from ..testnet import TEST_IP1
+
+# ── Struct sizes ────────────────────────────────────────
+
+
+class TestStructSizes:
+    """Verify netlink struct sizes match kernel ABI."""
+
+    def test_nlmsg_hdr_size(self) -> None:
+        """NLMSG_HDR is 16 bytes (4+2+2+4+4)."""
+        assert NLMSG_HDR.size == 16
+
+    def test_nfgen_hdr_size(self) -> None:
+        """NFGEN_HDR is 4 bytes (1+1+2)."""
+        assert NFGEN_HDR.size == 4
+
+    def test_nfa_hdr_size(self) -> None:
+        """NFA_HDR is 4 bytes (2+2)."""
+        assert NFA_HDR.size == 4
+
+
+# ── Constants ───────────────────────────────────────────
+
+
+class TestConstants:
+    """Verify netlink constants match expected kernel values."""
+
+    def test_af_inet(self) -> None:
+        """AF_INET is 2 on all Linux platforms."""
+        assert AF_INET == 2
+
+    def test_nlm_flags(self) -> None:
+        """NLM_F_REQUEST and NLM_F_ACK match kernel definitions."""
+        assert NLM_F_REQUEST == 1
+        assert NLM_F_ACK == 4
+
+    def test_ip_protocol_numbers(self) -> None:
+        """IP protocol numbers match IANA assignments."""
+        assert IPPROTO_TCP == 6
+        assert IPPROTO_UDP == 17
+
+
+# ── parse_nflog_attrs ──────────────────────────────────
+
+
+class TestParseNflogAttrs:
+    """Tests for TLV attribute parsing."""
+
+    def test_empty_data(self) -> None:
+        """Empty data returns empty dict."""
+        assert parse_nflog_attrs(b"") == {}
+
+    def test_single_attr(self) -> None:
+        """Single TLV attribute is correctly parsed."""
+        value = b"HELLO"
+        attr = NFA_HDR.pack(NFA_HDR.size + len(value), 10) + value
+        result = parse_nflog_attrs(attr)
+        assert result[10] == value
+
+    def test_multiple_attrs(self) -> None:
+        """Multiple TLV attributes are correctly parsed with 4-byte alignment."""
+        val1 = b"AB"
+        val2 = b"CDEF"
+        attr1 = NFA_HDR.pack(NFA_HDR.size + len(val1), 1) + val1
+        # Pad attr1 to 4 bytes
+        attr1 += b"\x00" * (4 - len(attr1) % 4) if len(attr1) % 4 else b""
+        attr2 = NFA_HDR.pack(NFA_HDR.size + len(val2), 2) + val2
+        result = parse_nflog_attrs(attr1 + attr2)
+        assert result[1] == val1
+        assert result[2] == val2
+
+    def test_short_attr_stops(self) -> None:
+        """Attribute with nfa_len < NFA_HDR.size stops parsing."""
+        data = NFA_HDR.pack(2, 1)  # nfa_len=2 < NFA_HDR.size=4
+        assert parse_nflog_attrs(data) == {}
+
+    def test_masks_nested_flag(self) -> None:
+        """Type field is masked to strip nested/byteorder flags (0x7FFF)."""
+        value = b"X"
+        attr_type = 0x8001  # nested flag set + type 1
+        attr = NFA_HDR.pack(NFA_HDR.size + len(value), attr_type) + value
+        result = parse_nflog_attrs(attr)
+        assert 1 in result
+
+
+# ── extract_ip_dest ────────────────────────────────────
+
+
+class TestExtractIpDest:
+    """Tests for IP packet destination extraction."""
+
+    def test_ipv4_tcp(self) -> None:
+        """Extracts dest IP, protocol, and port from IPv4 TCP packet."""
+        ip_header = bytearray(20)
+        ip_header[0] = 0x45  # version=4, IHL=5
+        ip_header[9] = IPPROTO_TCP
+        ip_header[16:20] = socket.inet_aton(TEST_IP1)
+        transport = struct.pack("!HH", 12345, 443)
+        dest, proto, port = extract_ip_dest(bytes(ip_header) + transport)
+        assert dest == TEST_IP1
+        assert proto == IPPROTO_TCP
+        assert port == 443
+
+    def test_ipv4_udp(self) -> None:
+        """Extracts dest port from IPv4 UDP packet."""
+        ip_header = bytearray(20)
+        ip_header[0] = 0x45
+        ip_header[9] = IPPROTO_UDP
+        ip_header[16:20] = socket.inet_aton(TEST_IP1)
+        transport = struct.pack("!HH", 12345, 53)
+        dest, proto, port = extract_ip_dest(bytes(ip_header) + transport)
+        assert dest == TEST_IP1
+        assert proto == IPPROTO_UDP
+        assert port == 53
+
+    def test_ipv6_tcp(self) -> None:
+        """Extracts dest IP and port from IPv6 TCP packet."""
+        ip6_header = bytearray(40)
+        ip6_header[0] = 0x60  # version=6
+        ip6_header[6] = IPPROTO_TCP  # Next Header
+        ip6_header[24:40] = socket.inet_pton(socket.AF_INET6, "2001:db8::1")
+        transport = struct.pack("!HH", 12345, 8080)
+        dest, proto, port = extract_ip_dest(bytes(ip6_header) + transport)
+        assert dest == "2001:db8::1"
+        assert proto == IPPROTO_TCP
+        assert port == 8080
+
+    def test_too_short(self) -> None:
+        """Returns empty tuple for packets shorter than 20 bytes."""
+        assert extract_ip_dest(b"\x45" * 10) == ("", 0, 0)
+
+    def test_bad_ihl(self) -> None:
+        """Returns empty tuple for IPv4 with IHL < 5 (20 bytes)."""
+        pkt = bytearray(20)
+        pkt[0] = 0x41  # version=4, IHL=1 (invalid)
+        assert extract_ip_dest(bytes(pkt)) == ("", 0, 0)
+
+    def test_unknown_version(self) -> None:
+        """Returns empty tuple for non-IPv4/IPv6 packets."""
+        pkt = bytearray(20)
+        pkt[0] = 0x30  # version=3
+        assert extract_ip_dest(bytes(pkt)) == ("", 0, 0)
+
+    def test_non_tcp_udp_no_port(self) -> None:
+        """Non-TCP/UDP protocol returns port=0."""
+        ip_header = bytearray(20)
+        ip_header[0] = 0x45
+        ip_header[9] = 1  # ICMP
+        ip_header[16:20] = socket.inet_aton(TEST_IP1)
+        dest, proto, port = extract_ip_dest(bytes(ip_header))
+        assert dest == TEST_IP1
+        assert proto == 1
+        assert port == 0

--- a/tests/unit/test_nfqueue.py
+++ b/tests/unit/test_nfqueue.py
@@ -1,0 +1,383 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the NFQUEUE handler (nfqueue.py)."""
+
+from __future__ import annotations
+
+import socket
+import struct
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from terok_shield.netlink import NFA_HDR, NFGEN_HDR, NLM_F_ACK, NLM_F_REQUEST, NLMSG_HDR
+from terok_shield.nfqueue import (
+    _NFNL_SUBSYS_QUEUE,
+    _NFQA_PACKET_HDR,
+    _NFQA_PAYLOAD,
+    _NFQNL_CFG_CMD_BIND,
+    _NFQNL_MSG_CONFIG,
+    _NFQNL_MSG_PACKET,
+    _NFQNL_MSG_VERDICT,
+    _NFQNL_PACKET_HDR,
+    NF_ACCEPT,
+    NF_DROP,
+    NfqueueHandler,
+    QueuedPacket,
+    _attrs_to_packet,
+    _build_config_cmd,
+    _build_config_params,
+    _build_verdict_msg,
+    _check_ack,
+    _extract_packet_id,
+)
+from terok_shield.nft_constants import NFQUEUE_NUM
+
+from ..testnet import TEST_IP1
+
+# ── QueuedPacket ─────────────────────────────────────────
+
+
+class TestQueuedPacket:
+    """Tests for the QueuedPacket frozen dataclass."""
+
+    def test_fields(self) -> None:
+        """QueuedPacket stores all required fields."""
+        pkt = QueuedPacket(packet_id=42, dest=TEST_IP1, port=443, proto=6)
+        assert pkt.packet_id == 42
+        assert pkt.dest == TEST_IP1
+        assert pkt.port == 443
+        assert pkt.proto == 6
+
+    def test_frozen(self) -> None:
+        """QueuedPacket is frozen (immutable)."""
+        pkt = QueuedPacket(packet_id=1, dest=TEST_IP1, port=80, proto=6)
+        with pytest.raises(AttributeError):
+            pkt.packet_id = 2  # type: ignore[misc]
+
+
+# ── _extract_packet_id ──────────────────────────────────
+
+
+class TestExtractPacketId:
+    """Tests for _extract_packet_id from NFQUEUE attributes."""
+
+    def test_extracts_id(self) -> None:
+        """Extracts packet_id from a valid NFQA_PACKET_HDR attribute."""
+        hdr = _NFQNL_PACKET_HDR.pack(123, 0x0800, 3)
+        attrs = {_NFQA_PACKET_HDR: hdr}
+        assert _extract_packet_id(attrs) == 123
+
+    def test_returns_none_on_missing_hdr(self) -> None:
+        """Returns None when NFQA_PACKET_HDR is absent."""
+        assert _extract_packet_id({}) is None
+
+    def test_returns_none_on_short_hdr(self) -> None:
+        """Returns None when NFQA_PACKET_HDR payload is too short."""
+        assert _extract_packet_id({_NFQA_PACKET_HDR: b"\x00"}) is None
+
+
+# ── _attrs_to_packet ────────────────────────────────────
+
+
+class TestAttrsToPacket:
+    """Tests for _attrs_to_packet conversion."""
+
+    def test_valid_ipv4_tcp(self) -> None:
+        """Converts valid NFQUEUE attributes with IPv4 TCP payload to QueuedPacket."""
+        hdr = _NFQNL_PACKET_HDR.pack(7, 0x0800, 3)
+        # Minimal IPv4 header: version=4, IHL=5, proto=TCP(6), dest=192.0.2.1
+        ip_header = bytearray(20)
+        ip_header[0] = 0x45  # version=4, IHL=5
+        ip_header[9] = 6  # TCP
+        ip_header[16:20] = socket.inet_aton(TEST_IP1)
+        # TCP header: src_port=12345, dst_port=443
+        transport = struct.pack("!HH", 12345, 443)
+        attrs = {
+            _NFQA_PACKET_HDR: hdr,
+            _NFQA_PAYLOAD: bytes(ip_header) + transport,
+        }
+        pkt = _attrs_to_packet(attrs)
+        assert pkt is not None
+        assert pkt.packet_id == 7
+        assert pkt.dest == TEST_IP1
+        assert pkt.port == 443
+        assert pkt.proto == 6
+
+    def test_returns_none_without_packet_hdr(self) -> None:
+        """Returns None when NFQA_PACKET_HDR is missing."""
+        assert _attrs_to_packet({_NFQA_PAYLOAD: b"\x45" * 40}) is None
+
+    def test_returns_none_on_empty_payload(self) -> None:
+        """Returns None when payload is too short to parse."""
+        hdr = _NFQNL_PACKET_HDR.pack(1, 0x0800, 3)
+        assert _attrs_to_packet({_NFQA_PACKET_HDR: hdr}) is None
+
+
+# ── Message builders ────────────────────────────────────
+
+
+class TestMessageBuilders:
+    """Tests for NFQUEUE netlink message construction."""
+
+    def test_config_cmd_structure(self) -> None:
+        """_build_config_cmd produces a valid netlink message with correct type."""
+        msg = _build_config_cmd(NFQUEUE_NUM, _NFQNL_CFG_CMD_BIND)
+        assert len(msg) >= NLMSG_HDR.size
+        nl_len, nl_type, flags, _seq, _pid = NLMSG_HDR.unpack_from(msg, 0)
+        assert nl_len == len(msg)
+        assert nl_type == (_NFNL_SUBSYS_QUEUE << 8) | _NFQNL_MSG_CONFIG
+        assert flags & NLM_F_REQUEST
+        assert flags & NLM_F_ACK
+
+    def test_config_params_structure(self) -> None:
+        """_build_config_params produces a valid netlink message."""
+        msg = _build_config_params(NFQUEUE_NUM, copy_range=256)
+        assert len(msg) >= NLMSG_HDR.size
+        nl_len, nl_type, flags, _seq, _pid = NLMSG_HDR.unpack_from(msg, 0)
+        assert nl_len == len(msg)
+        assert nl_type == (_NFNL_SUBSYS_QUEUE << 8) | _NFQNL_MSG_CONFIG
+
+    def test_verdict_msg_structure(self) -> None:
+        """_build_verdict_msg produces a valid netlink message with correct type."""
+        msg = _build_verdict_msg(NFQUEUE_NUM, 42, NF_ACCEPT)
+        assert len(msg) >= NLMSG_HDR.size
+        nl_len, nl_type, flags, _seq, _pid = NLMSG_HDR.unpack_from(msg, 0)
+        assert nl_len == len(msg)
+        assert nl_type == (_NFNL_SUBSYS_QUEUE << 8) | _NFQNL_MSG_VERDICT
+        assert flags & NLM_F_REQUEST
+
+    def test_verdict_msg_contains_packet_id_and_verdict(self) -> None:
+        """Verdict message payload contains the verdict code and packet ID."""
+        msg = _build_verdict_msg(NFQUEUE_NUM, 99, NF_DROP)
+        # After NLMSG_HDR + NFGEN_HDR + NFA_HDR, the payload has verdict(4) + packet_id(4)
+        verdict_offset = NLMSG_HDR.size + NFGEN_HDR.size + NFA_HDR.size
+        verdict_val, pkt_id = struct.unpack_from("!II", msg, verdict_offset)
+        assert verdict_val == NF_DROP
+        assert pkt_id == 99
+
+
+# ── _check_ack ──────────────────────────────────────────
+
+
+class TestCheckAck:
+    """Tests for _check_ack netlink ACK verification."""
+
+    def test_success_ack(self) -> None:
+        """_check_ack returns True on error code 0 (success)."""
+        ack_payload = struct.pack("=i", 0)
+        ack = NLMSG_HDR.pack(NLMSG_HDR.size + len(ack_payload), 2, 0, 0, 0) + ack_payload
+        sock = MagicMock()
+        sock.recv.return_value = ack
+        assert _check_ack(sock) is True
+
+    def test_error_ack(self) -> None:
+        """_check_ack returns False on negative error code."""
+        ack_payload = struct.pack("=i", -1)
+        ack = NLMSG_HDR.pack(NLMSG_HDR.size + len(ack_payload), 2, 0, 0, 0) + ack_payload
+        sock = MagicMock()
+        sock.recv.return_value = ack
+        assert _check_ack(sock) is False
+
+    def test_oserror_returns_false(self) -> None:
+        """_check_ack returns False when recv raises OSError."""
+        sock = MagicMock()
+        sock.recv.side_effect = OSError("broken")
+        assert _check_ack(sock) is False
+
+    def test_short_ack_returns_true(self) -> None:
+        """_check_ack returns True when ACK is too short to parse (benign)."""
+        sock = MagicMock()
+        sock.recv.return_value = b"\x00" * 4
+        assert _check_ack(sock) is True
+
+
+# ── NfqueueHandler ──────────────────────────────────────
+
+
+class TestNfqueueHandler:
+    """Tests for the NfqueueHandler class."""
+
+    def test_create_returns_none_on_oserror(self) -> None:
+        """create() returns None when socket creation fails."""
+        with patch("terok_shield.nfqueue.socket.socket", side_effect=OSError("no netlink")):
+            assert NfqueueHandler.create() is None
+
+    def test_create_returns_none_on_bind_ack_failure(self) -> None:
+        """create() returns None when bind ACK indicates failure."""
+        mock_sock = MagicMock()
+        # Bind ACK with negative error code
+        ack_payload = struct.pack("=i", -1)
+        ack = NLMSG_HDR.pack(NLMSG_HDR.size + len(ack_payload), 2, 0, 0, 0) + ack_payload
+        mock_sock.recv.return_value = ack
+        with patch("terok_shield.nfqueue.socket.socket", return_value=mock_sock):
+            handler = NfqueueHandler.create()
+        assert handler is None
+        mock_sock.close.assert_called()
+
+    def test_create_returns_handler_on_success(self) -> None:
+        """create() returns an NfqueueHandler on successful handshake."""
+        mock_sock = MagicMock()
+        # Success ACK (error code 0)
+        ack_payload = struct.pack("=i", 0)
+        ack = NLMSG_HDR.pack(NLMSG_HDR.size + len(ack_payload), 2, 0, 0, 0) + ack_payload
+        mock_sock.recv.return_value = ack
+        with patch("terok_shield.nfqueue.socket.socket", return_value=mock_sock):
+            handler = NfqueueHandler.create()
+        assert handler is not None
+        mock_sock.setblocking.assert_called_with(False)
+
+    def test_fileno_delegates(self) -> None:
+        """fileno() returns the socket's file descriptor."""
+        mock_sock = MagicMock()
+        mock_sock.fileno.return_value = 42
+        handler = NfqueueHandler(mock_sock, NFQUEUE_NUM)
+        assert handler.fileno() == 42
+
+    def test_close_delegates(self) -> None:
+        """close() closes the underlying socket."""
+        mock_sock = MagicMock()
+        handler = NfqueueHandler(mock_sock, NFQUEUE_NUM)
+        handler.close()
+        mock_sock.close.assert_called_once()
+
+    def test_poll_returns_empty_on_oserror(self) -> None:
+        """poll() returns empty list when recv raises OSError."""
+        mock_sock = MagicMock()
+        mock_sock.recv.side_effect = OSError("would block")
+        handler = NfqueueHandler(mock_sock, NFQUEUE_NUM)
+        assert handler.poll() == []
+
+    def test_poll_returns_empty_on_empty_data(self) -> None:
+        """poll() returns empty list on empty recv data."""
+        mock_sock = MagicMock()
+        mock_sock.recv.return_value = b""
+        handler = NfqueueHandler(mock_sock, NFQUEUE_NUM)
+        assert handler.poll() == []
+
+    def test_verdict_sends_message(self) -> None:
+        """verdict() sends a verdict message to the socket."""
+        mock_sock = MagicMock()
+        handler = NfqueueHandler(mock_sock, NFQUEUE_NUM)
+        handler.verdict(42, accept=True)
+        mock_sock.send.assert_called_once()
+        msg = mock_sock.send.call_args[0][0]
+        assert len(msg) >= NLMSG_HDR.size
+
+    def test_verdict_accept_uses_nf_accept(self) -> None:
+        """verdict(accept=True) uses NF_ACCEPT code in the message."""
+        mock_sock = MagicMock()
+        handler = NfqueueHandler(mock_sock, NFQUEUE_NUM)
+        handler.verdict(7, accept=True)
+        msg = mock_sock.send.call_args[0][0]
+        verdict_offset = NLMSG_HDR.size + NFGEN_HDR.size + NFA_HDR.size
+        verdict_val, _ = struct.unpack_from("!II", msg, verdict_offset)
+        assert verdict_val == NF_ACCEPT
+
+    def test_verdict_drop_uses_nf_drop(self) -> None:
+        """verdict(accept=False) uses NF_DROP code in the message."""
+        mock_sock = MagicMock()
+        handler = NfqueueHandler(mock_sock, NFQUEUE_NUM)
+        handler.verdict(7, accept=False)
+        msg = mock_sock.send.call_args[0][0]
+        verdict_offset = NLMSG_HDR.size + NFGEN_HDR.size + NFA_HDR.size
+        verdict_val, _ = struct.unpack_from("!II", msg, verdict_offset)
+        assert verdict_val == NF_DROP
+
+    def test_verdict_oserror_logged(self, caplog: pytest.LogCaptureFixture) -> None:
+        """verdict() logs a warning on OSError."""
+        mock_sock = MagicMock()
+        mock_sock.send.side_effect = OSError("broken")
+        handler = NfqueueHandler(mock_sock, NFQUEUE_NUM)
+        handler.verdict(1, accept=True)
+        assert "Failed to send verdict" in caplog.text
+
+
+# ── _parse_messages / _handle_one_message ──────────────
+
+
+class TestParseMessages:
+    """Tests for message parsing in NfqueueHandler."""
+
+    @staticmethod
+    def _build_nfqueue_msg(packet_id: int, dest_ip: str, port: int = 443) -> bytes:
+        """Build a minimal NFQUEUE packet message for testing."""
+        # NFQA_PACKET_HDR attribute
+        pkt_hdr = _NFQNL_PACKET_HDR.pack(packet_id, 0x0800, 3)
+        attr1 = NFA_HDR.pack(NFA_HDR.size + len(pkt_hdr), _NFQA_PACKET_HDR) + pkt_hdr
+        # Pad to 4 bytes
+        while len(attr1) % 4:
+            attr1 += b"\x00"
+
+        # NFQA_PAYLOAD attribute: IPv4 TCP packet
+        ip_header = bytearray(20)
+        ip_header[0] = 0x45  # version=4, IHL=5
+        ip_header[9] = 6  # TCP
+        ip_header[16:20] = socket.inet_aton(dest_ip)
+        transport = struct.pack("!HH", 12345, port)
+        payload = bytes(ip_header) + transport
+        attr2 = NFA_HDR.pack(NFA_HDR.size + len(payload), _NFQA_PAYLOAD) + payload
+
+        # nfgenmsg + attributes
+        nfgen = NFGEN_HDR.pack(2, 0, socket.htons(NFQUEUE_NUM))
+        body = nfgen + attr1 + attr2
+
+        # netlink header
+        msg_type = (_NFNL_SUBSYS_QUEUE << 8) | _NFQNL_MSG_PACKET
+        return NLMSG_HDR.pack(NLMSG_HDR.size + len(body), msg_type, 0, 0, 0) + body
+
+    def test_parse_valid_packet(self) -> None:
+        """_parse_messages extracts a QueuedPacket from a valid NFQUEUE message."""
+        mock_sock = MagicMock()
+        handler = NfqueueHandler(mock_sock, NFQUEUE_NUM)
+        data = self._build_nfqueue_msg(42, TEST_IP1, 443)
+        packets = handler._parse_messages(data)
+        assert len(packets) == 1
+        assert packets[0].packet_id == 42
+        assert packets[0].dest == TEST_IP1
+        assert packets[0].port == 443
+
+    def test_ignores_non_queue_messages(self) -> None:
+        """_parse_messages ignores messages with wrong subsystem."""
+        mock_sock = MagicMock()
+        handler = NfqueueHandler(mock_sock, NFQUEUE_NUM)
+        # Build a message with wrong subsystem (ulog instead of queue)
+        nfgen = NFGEN_HDR.pack(2, 0, 0)
+        body = nfgen
+        msg_type = (4 << 8) | 0  # ULOG subsystem
+        data = NLMSG_HDR.pack(NLMSG_HDR.size + len(body), msg_type, 0, 0, 0) + body
+        assert handler._parse_messages(data) == []
+
+    def test_handle_one_message_drops_unparseable(self) -> None:
+        """_handle_one_message issues a drop verdict for unparseable packets."""
+        mock_sock = MagicMock()
+        handler = NfqueueHandler(mock_sock, NFQUEUE_NUM)
+
+        # Build a message with a packet_hdr but no payload (unparseable)
+        pkt_hdr = _NFQNL_PACKET_HDR.pack(99, 0x0800, 3)
+        attr = NFA_HDR.pack(NFA_HDR.size + len(pkt_hdr), _NFQA_PACKET_HDR) + pkt_hdr
+        nfgen = NFGEN_HDR.pack(2, 0, socket.htons(NFQUEUE_NUM))
+        body = nfgen + attr
+        msg_type = (_NFNL_SUBSYS_QUEUE << 8) | _NFQNL_MSG_PACKET
+        data = NLMSG_HDR.pack(NLMSG_HDR.size + len(body), msg_type, 0, 0, 0) + body
+
+        result = handler._handle_one_message(data, 0, len(data), msg_type)
+        assert result is None
+        # Should have issued a drop verdict for packet 99
+        mock_sock.send.assert_called_once()
+
+    def test_short_message_ignored(self) -> None:
+        """_parse_messages handles truncated data gracefully."""
+        mock_sock = MagicMock()
+        handler = NfqueueHandler(mock_sock, NFQUEUE_NUM)
+        # Too short for even a netlink header
+        assert handler._parse_messages(b"\x00" * 4) == []
+
+    def test_bad_length_stops_parsing(self) -> None:
+        """_parse_messages stops when nl_len would read past data boundary."""
+        mock_sock = MagicMock()
+        handler = NfqueueHandler(mock_sock, NFQUEUE_NUM)
+        # nl_len claims 1000 bytes but data is only 16
+        data = NLMSG_HDR.pack(1000, 0, 0, 0, 0)
+        assert handler._parse_messages(data) == []

--- a/tests/unit/test_nft.py
+++ b/tests/unit/test_nft.py
@@ -286,6 +286,47 @@ def test_verify_ruleset_interactive_mode_cross_validates() -> None:
     assert any("queued nflog prefix" in e for e in errors)
 
 
+# ── NFQUEUE mode ──────────────────────────────────────────
+
+
+def test_hook_ruleset_nfqueue_contains_queue_num() -> None:
+    """NFQUEUE interactive mode uses 'queue num' terminal rule."""
+    ruleset = hook_ruleset(interactive=True, nfqueue=True)
+    assert "queue num 200" in ruleset
+
+
+def test_hook_ruleset_nfqueue_no_queued_log_prefix() -> None:
+    """NFQUEUE mode does not use the NFLOG reject terminal rule."""
+    ruleset = hook_ruleset(interactive=True, nfqueue=True)
+    assert _QUEUED_LOG_PREFIX not in ruleset
+
+
+def test_hook_ruleset_nfqueue_still_has_private_ranges() -> None:
+    """NFQUEUE mode still has private-range reject rules."""
+    ruleset = hook_ruleset(interactive=True, nfqueue=True)
+    assert _ADMIN_PROHIBITED in ruleset  # from private-range rules
+
+
+def test_verify_ruleset_accepts_nfqueue() -> None:
+    """verify_ruleset(nfqueue=True) accepts the NFQUEUE hook ruleset."""
+    assert (
+        verify_ruleset(hook_ruleset(interactive=True, nfqueue=True), interactive=True, nfqueue=True)
+        == []
+    )
+
+
+def test_verify_ruleset_nfqueue_rejects_nflog() -> None:
+    """verify_ruleset(nfqueue=True) rejects the NFLOG interactive ruleset."""
+    errors = verify_ruleset(hook_ruleset(interactive=True), interactive=True, nfqueue=True)
+    assert any("nfqueue terminal rule" in e for e in errors)
+
+
+def test_verify_ruleset_nflog_rejects_nfqueue() -> None:
+    """verify_ruleset(interactive=True) rejects the NFQUEUE ruleset (missing QUEUED prefix)."""
+    errors = verify_ruleset(hook_ruleset(interactive=True, nfqueue=True), interactive=True)
+    assert any("queued nflog prefix" in e for e in errors)
+
+
 def test_verify_ruleset_checks_deny_sets() -> None:
     """verify_ruleset() requires deny_v4 and deny_v6 sets in both modes."""
     minimal = (

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -20,12 +20,14 @@ from terok_shield.state import (
     hook_entrypoint,
     hook_json_path,
     hooks_dir,
+    interactive_path,
     live_allowed_path,
     live_domains_path,
     profile_allowed_path,
     profile_domains_path,
     read_denied_ips,
     read_effective_ips,
+    read_interactive_tier,
 )
 
 from ..testfs import FAKE_STATE_DIR
@@ -205,3 +207,26 @@ def test_hook_entrypoint_path_strings_match_state_functions() -> None:
             f"state.{fn.__name__}() returns that filename. "
             "Update hook_entrypoint.py to match."
         )
+
+
+# ── read_interactive_tier ──────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("content", "expected"),
+    [
+        pytest.param("nflog\n", "nflog", id="nflog"),
+        pytest.param("nfqueue\n", "nfqueue", id="nfqueue"),
+        pytest.param("1\n", "nflog", id="legacy-1-to-nflog"),
+        pytest.param("\n", None, id="empty"),
+    ],
+)
+def test_read_interactive_tier(tmp_path: Path, content: str, expected: str | None) -> None:
+    """read_interactive_tier returns the correct tier string with backward compat."""
+    interactive_path(tmp_path).write_text(content)
+    assert read_interactive_tier(tmp_path) == expected
+
+
+def test_read_interactive_tier_missing_file(tmp_path: Path) -> None:
+    """read_interactive_tier returns None when the interactive file is absent."""
+    assert read_interactive_tier(tmp_path) is None

--- a/tests/unit/test_watch.py
+++ b/tests/unit/test_watch.py
@@ -16,6 +16,13 @@ import pytest
 
 import terok_shield.watch as _watch_mod
 from terok_shield.config import DnsTier
+from terok_shield.netlink import (
+    NFA_HDR as _NFA_HDR,
+    NFGEN_HDR as _NFGEN_HDR,
+    NLMSG_HDR as _NLMSG_HDR,
+    extract_ip_dest as _extract_ip_dest,
+    parse_nflog_attrs as _parse_nflog_attrs,
+)
 from terok_shield.nft_constants import (
     ALLOWED_LOG_PREFIX,
     BYPASS_LOG_PREFIX,
@@ -26,13 +33,10 @@ from terok_shield.nft_constants import (
 )
 from terok_shield.watch import (
     _DOMAIN_REFRESH_INTERVAL,
-    _NFA_HDR,
-    _NFGEN_HDR,
     _NFNL_SUBSYS_ULOG,
     _NFULA_PAYLOAD,
     _NFULA_PREFIX,
     _NFULNL_MSG_PACKET,
-    _NLMSG_HDR,
     _QUERY_RE,
     AuditLogWatcher,
     DnsLogWatcher,
@@ -40,9 +44,7 @@ from terok_shield.watch import (
     WatchEvent,
     _build_nflog_bind_msg,
     _ensure_log_file,
-    _extract_ip_dest,
     _handle_signal,
-    _parse_nflog_attrs,
     run_watch,
 )
 from tests.testnet import BLOCKED_DOMAIN, BLOCKED_SUBDOMAIN, TEST_DOMAIN, TEST_DOMAIN2


### PR DESCRIPTION
…erdict

Add a second interactive tier that uses the kernel NFQUEUE mechanism to hold outbound packets until an operator verdict is issued, complementing the existing NFLOG+reject tier.  Auto-detected at pre_start() time via /proc/modules probe; falls back to NFLOG when nfnetlink_queue is absent.

Core additions:
- netlink.py: extract shared netlink structs from watch.py for reuse
- nfqueue.py: pure-Python AF_NETLINK NFQUEUE handler (bind, poll, verdict)
- NfqueueInteractiveSession: event loop with timeout auto-drop, dedup, JSON-lines protocol identical to the NFLOG session
- _nfqueue_rule(): nft terminal rule using `queue num 200`
- _nfqueue_kernel_support(): read-only probe for module availability
- nfqueue_timeout config field (1–300s, default 5)
- Backward-compat: legacy "1" interactive marker reads as "nflog"