### PR TITLE
refactor: reinforce audit boundaries and streamline facade subsystems

### DIFF
--- a/src/terok_shield/__init__.py
+++ b/src/terok_shield/__init__.py
@@ -10,14 +10,21 @@ The primary entry point is the ``Shield`` facade class:
     >>> from terok_shield import Shield, ShieldConfig
     >>> shield = Shield(ShieldConfig(state_dir=Path("/tmp/my-container")))
     >>> shield.pre_start("my-container", ["dev-standard"])
+
+Core and support layer modules are imported lazily — ``from terok_shield
+import ShieldConfig`` does not pull in nft, dnsmasq, or subprocess
+helpers.  Heavy imports are deferred until ``Shield`` is instantiated.
 """
 
+import importlib as _importlib
 import logging
 from collections.abc import Iterator
 from dataclasses import dataclass, field
 from importlib.metadata import PackageNotFoundError, version as _meta_version
 from pathlib import Path
+from typing import TYPE_CHECKING
 
+# ── Eager: common layer (zero-cost, pure data) ─────────
 from .common.config import (
     AuditFileConfig,
     DnsTier,
@@ -37,20 +44,43 @@ from .common.podman_info import (
     system_hooks_dir,
 )
 from .common.util import is_ip as _is_ip
-from .core import dnsmasq, state
-from .core.dns import DnsResolver
-from .core.mode_hook import setup_global_hooks
-from .core.nft import RulesetBuilder
-from .core.run import (
-    CommandRunner,
-    DigNotFoundError,
-    ExecError,
-    NftNotFoundError,
-    ShieldNeedsSetup,
-    SubprocessRunner,
-)
-from .lib.audit import AuditLogger
-from .lib.profiles import ProfileLoader
+
+if TYPE_CHECKING:
+    from .core.dns import DnsResolver
+    from .core.nft import RulesetBuilder
+    from .core.run import CommandRunner
+    from .lib.audit import AuditLogger
+    from .lib.profiles import ProfileLoader
+
+# ── Lazy: core + support layer ──────────────────────────
+# Re-exported names from __all__ that are deferred until first access.
+# Keeps ``from terok_shield import ShieldConfig`` lightweight.
+
+_LAZY_IMPORTS: dict[str, tuple[str, str]] = {
+    "AuditLogger": ("terok_shield.lib.audit", "AuditLogger"),
+    "CommandRunner": ("terok_shield.core.run", "CommandRunner"),
+    "DigNotFoundError": ("terok_shield.core.run", "DigNotFoundError"),
+    "DnsResolver": ("terok_shield.core.dns", "DnsResolver"),
+    "ExecError": ("terok_shield.core.run", "ExecError"),
+    "NftNotFoundError": ("terok_shield.core.run", "NftNotFoundError"),
+    "ProfileLoader": ("terok_shield.lib.profiles", "ProfileLoader"),
+    "RulesetBuilder": ("terok_shield.core.nft", "RulesetBuilder"),
+    "ShieldNeedsSetup": ("terok_shield.core.run", "ShieldNeedsSetup"),
+    "SubprocessRunner": ("terok_shield.core.run", "SubprocessRunner"),
+    "setup_global_hooks": ("terok_shield.core.hook_install", "setup_global_hooks"),
+}
+
+
+def __getattr__(name: str) -> object:
+    """Lazy import for re-exported core/support layer names."""
+    if name in _LAZY_IMPORTS:
+        mod_path, attr = _LAZY_IMPORTS[name]
+        mod = _importlib.import_module(mod_path)
+        value = getattr(mod, attr)
+        globals()[name] = value  # cache for subsequent access
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 logger = logging.getLogger(__name__)
 
@@ -129,11 +159,11 @@ class Shield:
         self,
         config: ShieldConfig,
         *,
-        runner: CommandRunner | None = None,
-        audit: AuditLogger | None = None,
-        dns: DnsResolver | None = None,
-        profiles: ProfileLoader | None = None,
-        ruleset: RulesetBuilder | None = None,
+        runner: "CommandRunner | None" = None,
+        audit: "AuditLogger | None" = None,
+        dns: "DnsResolver | None" = None,
+        profiles: "ProfileLoader | None" = None,
+        ruleset: "RulesetBuilder | None" = None,
     ) -> None:
         """Create the shield facade.
 
@@ -145,6 +175,13 @@ class Shield:
             profiles: Profile loader (default: from config.profiles_dir).
             ruleset: Ruleset builder (default: from config loopback_ports).
         """
+        from .core import state
+        from .core.dns import DnsResolver
+        from .core.nft import RulesetBuilder
+        from .core.run import SubprocessRunner
+        from .lib.audit import AuditLogger
+        from .lib.profiles import ProfileLoader
+
         self.config = config
         self.runner = runner or SubprocessRunner()
         self.audit = audit or AuditLogger(
@@ -180,6 +217,8 @@ class Shield:
         :class:`EnvironmentCheck` with detected issues and setup hints.
         Does not raise — the caller decides how to handle issues.
         """
+        from .core import dnsmasq, state
+
         output = self.runner.run(["podman", "info", "-f", "json"], check=False)
         info = parse_podman_info(output)
         issues: list[str] = []
@@ -262,6 +301,8 @@ class Shield:
 
     def allow(self, container: str, target: str) -> list[str]:
         """Live-allow a domain or IP for a running container."""
+        from .core.run import ExecError
+
         is_domain = not _is_ip(target)
         ips = [target] if not is_domain else self.dns.resolve_domains([target])
         allowed: list[str] = []
@@ -280,6 +321,8 @@ class Shield:
 
     def deny(self, container: str, target: str) -> list[str]:
         """Live-deny a domain or IP for a running container."""
+        from .core.run import ExecError
+
         is_domain = not _is_ip(target)
         ips = [target] if not is_domain else self.dns.resolve_domains([target])
         denied: list[str] = []
@@ -329,6 +372,8 @@ class Shield:
         force: bool = False,
     ) -> list[str]:
         """Resolve DNS profiles and cache the results."""
+        from .core import state
+
         if profiles is None:
             profiles = list(self.config.default_profiles)
         entries = self.profiles.compose_profiles(profiles)

--- a/src/terok_shield/cli/interactive.py
+++ b/src/terok_shield/cli/interactive.py
@@ -21,8 +21,6 @@ persisted to ``live.allowed``; denied IPs are added to the deny sets and
 persisted to ``deny.list``.
 """
 
-from __future__ import annotations
-
 import json
 import logging
 import os

--- a/src/terok_shield/cli/main.py
+++ b/src/terok_shield/cli/main.py
@@ -470,7 +470,7 @@ def _cmd_setup(*, root: bool, user: bool) -> None:
         ensure_containers_conf_hooks_dir,
         system_hooks_dir,
     )
-    from ..core.mode_hook import setup_global_hooks
+    from ..core.hook_install import setup_global_hooks
 
     sys_dir = system_hooks_dir()
     usr_dir = USER_HOOKS_DIR.expanduser()

--- a/src/terok_shield/cli/registry.py
+++ b/src/terok_shield/cli/registry.py
@@ -12,15 +12,12 @@ Handler functions accept ``(shield, container?, **kwargs)`` and print to
 stdout, making them reusable across different CLI frontends.
 """
 
-from __future__ import annotations
-
 import json
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
-if TYPE_CHECKING:
-    from .. import EnvironmentCheck, Shield
+from .. import EnvironmentCheck, Shield
 
 
 @dataclass(frozen=True)

--- a/src/terok_shield/cli/watch.py
+++ b/src/terok_shield/cli/watch.py
@@ -9,8 +9,6 @@ event loop.  The library-level watcher classes live in
 :mod:`terok_shield.lib.watchers`.
 """
 
-from __future__ import annotations
-
 import select
 import signal
 import sys

--- a/src/terok_shield/common/podman_info.py
+++ b/src/terok_shield/common/podman_info.py
@@ -9,8 +9,6 @@ podman capabilities, version, and hooks directory configuration.
 This module is stateless — callers cache the result.
 """
 
-from __future__ import annotations
-
 import json
 import os
 import tomllib

--- a/src/terok_shield/core/dnsmasq.py
+++ b/src/terok_shield/core/dnsmasq.py
@@ -11,8 +11,6 @@ static pre-start resolution cannot.
 This module is the single owner of dnsmasq config format and CLI args.
 """
 
-from __future__ import annotations
-
 import ipaddress
 import logging
 import os

--- a/src/terok_shield/core/hook_install.py
+++ b/src/terok_shield/core/hook_install.py
@@ -13,7 +13,6 @@ global installation (called by the ``setup`` CLI command).
 """
 
 import json
-import stat
 from pathlib import Path
 
 from ..common.config import ANNOTATION_KEY
@@ -60,7 +59,7 @@ def _write_hook_files(
             the JSONs need to reference the final install location.
     """
     hook_entrypoint.write_text(_generate_entrypoint())
-    hook_entrypoint.chmod(hook_entrypoint.stat().st_mode | stat.S_IEXEC)
+    hook_entrypoint.chmod(0o755)
     ref_path = str(json_entrypoint_path or hook_entrypoint)
     for stage_name in ("createRuntime", "poststop"):
         hook_json = _generate_hook_json(ref_path, stage_name)

--- a/src/terok_shield/core/hook_install.py
+++ b/src/terok_shield/core/hook_install.py
@@ -119,10 +119,5 @@ def install_hooks(*, hook_entrypoint: Path, hooks_dir: Path) -> None:
         hooks_dir: Directory for hook JSON files.
     """
     hook_entrypoint.parent.mkdir(parents=True, exist_ok=True)
-    hook_entrypoint.write_text(_generate_entrypoint())
-    hook_entrypoint.chmod(hook_entrypoint.stat().st_mode | stat.S_IEXEC)
-
     hooks_dir.mkdir(parents=True, exist_ok=True)
-    for stage_name in ("createRuntime", "poststop"):
-        hook_json = _generate_hook_json(str(hook_entrypoint), stage_name)
-        (hooks_dir / f"terok-shield-{stage_name}.json").write_text(hook_json)
+    _write_hook_files(hook_entrypoint, hooks_dir)

--- a/src/terok_shield/core/hook_install.py
+++ b/src/terok_shield/core/hook_install.py
@@ -1,0 +1,128 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""OCI hook file generation and installation.
+
+Generates the hook entrypoint script (read from ``resources/hook_entrypoint.py``)
+and the OCI hook JSON descriptors, then writes them to per-container or
+global hooks directories.  Pure file I/O — no runtime container interaction.
+
+Provides ``install_hooks()`` for per-container setup (called by
+``HookMode.pre_start()``) and ``setup_global_hooks()`` for one-time
+global installation (called by the ``setup`` CLI command).
+"""
+
+import json
+import stat
+from pathlib import Path
+
+from ..common.config import ANNOTATION_KEY
+
+
+def _generate_entrypoint() -> str:
+    """Return the self-contained OCI hook entrypoint script.
+
+    The script uses ``#!/usr/bin/env python3`` so it resolves Python at
+    execution time — no virtualenv path is baked in at setup time.
+    Works for all install methods: pip, pipx, Poetry, system package.
+    """
+    return (Path(__file__).parent.parent / "resources" / "hook_entrypoint.py").read_text()
+
+
+def _generate_hook_json(entrypoint: str, stage: str) -> str:
+    """Generate an OCI hook JSON descriptor for a given stage.
+
+    Args:
+        entrypoint: Absolute path to the hook entrypoint script.
+        stage: OCI hook stage (``createRuntime`` or ``poststop``).
+    """
+    hook = {
+        "version": "1.0.0",
+        "hook": {"path": entrypoint, "args": ["terok-shield-hook", stage]},
+        "when": {"annotations": {ANNOTATION_KEY: ".*"}},
+        "stages": [stage],
+    }
+    return json.dumps(hook, indent=2) + "\n"
+
+
+def _write_hook_files(
+    hook_entrypoint: Path,
+    hooks_dir: Path,
+    json_entrypoint_path: Path | None = None,
+) -> None:
+    """Write entrypoint script and hook JSON files.
+
+    Args:
+        hook_entrypoint: Where to write the entrypoint script.
+        hooks_dir: Where to write the hook JSON files.
+        json_entrypoint_path: Path to embed in hook JSONs (defaults to
+            *hook_entrypoint*).  Used when writing to a temp dir but
+            the JSONs need to reference the final install location.
+    """
+    hook_entrypoint.write_text(_generate_entrypoint())
+    hook_entrypoint.chmod(hook_entrypoint.stat().st_mode | stat.S_IEXEC)
+    ref_path = str(json_entrypoint_path or hook_entrypoint)
+    for stage_name in ("createRuntime", "poststop"):
+        hook_json = _generate_hook_json(ref_path, stage_name)
+        (hooks_dir / f"terok-shield-{stage_name}.json").write_text(hook_json)
+
+
+def setup_global_hooks(target_dir: Path, *, use_sudo: bool = False) -> None:
+    """Install OCI hooks in a global directory for restart persistence.
+
+    Writes the entrypoint script and hook JSON files directly into
+    *target_dir*.  When *use_sudo* is True, writes to a temp directory
+    first and copies via ``sudo cp``.
+
+    Args:
+        target_dir: Global hooks directory to install into.
+        use_sudo: Use ``sudo`` for writing to the target directory.
+    """
+    import subprocess
+    import tempfile
+
+    entrypoint_name = "terok-shield-hook"
+
+    if use_sudo:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            # Generate JSONs referencing the FINAL entrypoint path
+            final_entrypoint = target_dir / entrypoint_name
+            _write_hook_files(tmp_path / entrypoint_name, tmp_path, final_entrypoint)
+            subprocess.run(
+                ["sudo", "mkdir", "-p", str(target_dir)],
+                check=True,  # noqa: S603, S607
+            )
+            files = [str(tmp_path / entrypoint_name)]
+            for stage in ("createRuntime", "poststop"):
+                files.append(str(tmp_path / f"terok-shield-{stage}.json"))
+            subprocess.run(
+                ["sudo", "cp", *files, str(target_dir) + "/"],
+                check=True,  # noqa: S603, S607
+            )
+            subprocess.run(
+                ["sudo", "chmod", "+x", str(final_entrypoint)],  # noqa: S603, S607
+                check=True,
+            )
+    else:
+        target_dir.mkdir(parents=True, exist_ok=True)
+        _write_hook_files(target_dir / entrypoint_name, target_dir)
+
+
+def install_hooks(*, hook_entrypoint: Path, hooks_dir: Path) -> None:
+    """Install OCI hook entrypoint and hook JSON files.
+
+    Installs hooks for the ``createRuntime`` and ``poststop`` stages.
+
+    Args:
+        hook_entrypoint: Path for the entrypoint script.
+        hooks_dir: Directory for hook JSON files.
+    """
+    hook_entrypoint.parent.mkdir(parents=True, exist_ok=True)
+    hook_entrypoint.write_text(_generate_entrypoint())
+    hook_entrypoint.chmod(hook_entrypoint.stat().st_mode | stat.S_IEXEC)
+
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+    for stage_name in ("createRuntime", "poststop"):
+        hook_json = _generate_hook_json(str(hook_entrypoint), stage_name)
+        (hooks_dir / f"terok-shield-{stage_name}.json").write_text(hook_json)

--- a/src/terok_shield/core/mode_hook.py
+++ b/src/terok_shield/core/mode_hook.py
@@ -6,19 +6,15 @@
 Uses OCI hooks to apply per-container nftables rules inside each
 container's network namespace.  No root required -- only podman and nft.
 The stdlib-only ``hook_entrypoint.py`` applies the pre-generated ruleset at
-container creation; this module handles setup, DNS pre-resolution, and live
-allow/deny.
+container creation; this module handles DNS pre-resolution, live
+allow/deny, and shield lifecycle (up/down/state).
 
-Provides ``HookMode`` (Strategy pattern, implements ``ShieldModeBackend``)
-and ``install_hooks()`` for OCI hook file installation.
+Provides ``HookMode`` (Strategy pattern, implements ``ShieldModeBackend``).
+Hook file installation lives in :mod:`hook_install`.
 """
 
-from __future__ import annotations
-
-import json
 import logging
 import os
-import stat
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -46,6 +42,7 @@ from ..common.podman_info import (
 )
 from ..common.util import is_ip as _is_ip, is_ipv4
 from . import dnsmasq, state
+from .hook_install import install_hooks
 from .nft import (
     NFT_TABLE,
     RulesetBuilder,
@@ -122,115 +119,6 @@ def _is_dnsmasq_tier(state_dir: Path) -> bool:
     return tier_path.read_text().strip() == DnsTier.DNSMASQ.value
 
 
-def _generate_entrypoint() -> str:
-    """Return the self-contained OCI hook entrypoint script.
-
-    The script uses ``#!/usr/bin/env python3`` so it resolves Python at
-    execution time — no virtualenv path is baked in at setup time.
-    Works for all install methods: pip, pipx, Poetry, system package.
-    """
-    return (Path(__file__).parent.parent / "resources" / "hook_entrypoint.py").read_text()
-
-
-def _generate_hook_json(entrypoint: str, stage: str) -> str:
-    """Generate an OCI hook JSON descriptor for a given stage.
-
-    Args:
-        entrypoint: Absolute path to the hook entrypoint script.
-        stage: OCI hook stage (``createRuntime`` or ``poststop``).
-    """
-    hook = {
-        "version": "1.0.0",
-        "hook": {"path": entrypoint, "args": ["terok-shield-hook", stage]},
-        "when": {"annotations": {ANNOTATION_KEY: ".*"}},
-        "stages": [stage],
-    }
-    return json.dumps(hook, indent=2) + "\n"
-
-
-def setup_global_hooks(target_dir: Path, *, use_sudo: bool = False) -> None:
-    """Install OCI hooks in a global directory for restart persistence.
-
-    Writes the entrypoint script and hook JSON files directly into
-    *target_dir*.  When *use_sudo* is True, writes to a temp directory
-    first and copies via ``sudo cp``.
-
-    Args:
-        target_dir: Global hooks directory to install into.
-        use_sudo: Use ``sudo`` for writing to the target directory.
-    """
-    import subprocess
-    import tempfile
-
-    entrypoint_name = "terok-shield-hook"
-
-    if use_sudo:
-        with tempfile.TemporaryDirectory() as tmp:
-            tmp_path = Path(tmp)
-            # Generate JSONs referencing the FINAL entrypoint path
-            final_entrypoint = target_dir / entrypoint_name
-            _write_hook_files(tmp_path / entrypoint_name, tmp_path, final_entrypoint)
-            subprocess.run(
-                ["sudo", "mkdir", "-p", str(target_dir)],
-                check=True,  # noqa: S603, S607
-            )
-            files = [str(tmp_path / entrypoint_name)]
-            for stage in ("createRuntime", "poststop"):
-                files.append(str(tmp_path / f"terok-shield-{stage}.json"))
-            subprocess.run(
-                ["sudo", "cp", *files, str(target_dir) + "/"],
-                check=True,  # noqa: S603, S607
-            )
-            subprocess.run(
-                ["sudo", "chmod", "+x", str(final_entrypoint)],  # noqa: S603, S607
-                check=True,
-            )
-    else:
-        target_dir.mkdir(parents=True, exist_ok=True)
-        _write_hook_files(target_dir / entrypoint_name, target_dir)
-
-
-def _write_hook_files(
-    hook_entrypoint: Path,
-    hooks_dir: Path,
-    json_entrypoint_path: Path | None = None,
-) -> None:
-    """Write entrypoint script and hook JSON files.
-
-    Args:
-        hook_entrypoint: Where to write the entrypoint script.
-        hooks_dir: Where to write the hook JSON files.
-        json_entrypoint_path: Path to embed in hook JSONs (defaults to
-            *hook_entrypoint*).  Used when writing to a temp dir but
-            the JSONs need to reference the final install location.
-    """
-    hook_entrypoint.write_text(_generate_entrypoint())
-    hook_entrypoint.chmod(hook_entrypoint.stat().st_mode | stat.S_IEXEC)
-    ref_path = str(json_entrypoint_path or hook_entrypoint)
-    for stage_name in ("createRuntime", "poststop"):
-        hook_json = _generate_hook_json(ref_path, stage_name)
-        (hooks_dir / f"terok-shield-{stage_name}.json").write_text(hook_json)
-
-
-def install_hooks(*, hook_entrypoint: Path, hooks_dir: Path) -> None:
-    """Install OCI hook entrypoint and hook JSON files.
-
-    Installs hooks for the ``createRuntime`` and ``poststop`` stages.
-
-    Args:
-        hook_entrypoint: Path for the entrypoint script.
-        hooks_dir: Directory for hook JSON files.
-    """
-    hook_entrypoint.parent.mkdir(parents=True, exist_ok=True)
-    hook_entrypoint.write_text(_generate_entrypoint())
-    hook_entrypoint.chmod(hook_entrypoint.stat().st_mode | stat.S_IEXEC)
-
-    hooks_dir.mkdir(parents=True, exist_ok=True)
-    for stage_name in ("createRuntime", "poststop"):
-        hook_json = _generate_hook_json(str(hook_entrypoint), stage_name)
-        (hooks_dir / f"terok-shield-{stage_name}.json").write_text(hook_json)
-
-
 # ── HookMode (Strategy) ─────────────────────────────────
 
 
@@ -248,10 +136,10 @@ class HookMode:
         self,
         *,
         config: ShieldConfig,
-        runner: CommandRunner,
-        audit: AuditLogger,
-        dns: DnsResolver,
-        profiles: ProfileLoader,
+        runner: "CommandRunner",
+        audit: "AuditLogger",
+        dns: "DnsResolver",
+        profiles: "ProfileLoader",
         ruleset: RulesetBuilder,
     ) -> None:
         """Create a hook mode backend with all collaborators.

--- a/src/terok_shield/core/run.py
+++ b/src/terok_shield/core/run.py
@@ -7,8 +7,6 @@ Provides ``CommandRunner`` (Protocol) and ``SubprocessRunner``
 (default implementation).  Every external command goes through here.
 """
 
-from __future__ import annotations
-
 import ipaddress as _ipaddress
 import shutil
 import subprocess

--- a/src/terok_shield/lib/watchers.py
+++ b/src/terok_shield/lib/watchers.py
@@ -14,8 +14,6 @@ Multiplexes three event sources into a single JSON-lines stream:
    degradation when netlink is unavailable.
 """
 
-from __future__ import annotations
-
 import json
 import logging
 import os
@@ -392,7 +390,7 @@ class NflogWatcher:
         self._container = container
 
     @classmethod
-    def create(cls, container: str, group: int = NFLOG_GROUP) -> NflogWatcher | None:
+    def create(cls, container: str, group: int = NFLOG_GROUP) -> "NflogWatcher | None":
         """Create and bind an NFLOG watcher, or return ``None`` on failure.
 
         Failure is expected in environments without ``AF_NETLINK`` support,

--- a/src/terok_shield/resources/shield_probe.py
+++ b/src/terok_shield/resources/shield_probe.py
@@ -24,8 +24,6 @@ Exit codes:
 Output is a single JSON object on stdout.
 """
 
-from __future__ import annotations
-
 import json
 import select
 import socket

--- a/tach.toml
+++ b/tach.toml
@@ -105,17 +105,32 @@ depends_on = [
     "terok_shield.core.state",
 ]
 
+# Hook file generation and installation — no same-layer deps
+[[modules]]
+path = "terok_shield.core.hook_install"
+layer = "core"
+depends_on = []
+
 # Hook mode — OCI hooks, per-container netns
 [[modules]]
 path = "terok_shield.core.mode_hook"
 layer = "core"
 depends_on = [
     "terok_shield.core.dnsmasq",
+    "terok_shield.core.hook_install",
     "terok_shield.core.nft",
     "terok_shield.core.nft_constants",
     "terok_shield.core.run",
     "terok_shield.core.state",
 ]
+
+# ── Resources ─────────────────────────────────────────────
+# resources/hook_entrypoint.py is NOT a tach module.  It is read as a
+# plain file by hook_install._generate_entrypoint() and installed
+# verbatim as an OCI hook script.  It has zero terok_shield imports
+# (stdlib-only, enforced by test_hook_entrypoint_isolation.py).
+# Tests import it as a Python module for white-box testing, but tests/
+# are excluded from tach.
 
 # ── Support ────────────────────────────────────────────────
 # Non-security-critical library modules.

--- a/tests/integration/setup/test_environment.py
+++ b/tests/integration/setup/test_environment.py
@@ -18,7 +18,7 @@ from terok_shield.common.podman_info import (
     has_global_hooks,
     parse_podman_info,
 )
-from terok_shield.core.mode_hook import setup_global_hooks
+from terok_shield.core.hook_install import setup_global_hooks
 from terok_shield.core.run import ShieldNeedsSetup
 
 from ..conftest import hooks_present, nft_missing, podman_missing

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -972,7 +972,7 @@ def test_build_config_uses_resolved_state_root_when_not_overridden(
 class TestSetupCommand:
     """Tests for the setup CLI command."""
 
-    @mock.patch("terok_shield.core.mode_hook.setup_global_hooks")
+    @mock.patch("terok_shield.core.hook_install.setup_global_hooks")
     @mock.patch("terok_shield.common.podman_info.ensure_containers_conf_hooks_dir")
     def test_setup_user(
         self,
@@ -986,7 +986,7 @@ class TestSetupCommand:
         mock_ensure.assert_called_once()
         assert "Done" in capsys.readouterr().out
 
-    @mock.patch("terok_shield.core.mode_hook.setup_global_hooks")
+    @mock.patch("terok_shield.core.hook_install.setup_global_hooks")
     def test_setup_root(
         self,
         mock_setup: mock.Mock,
@@ -1070,7 +1070,7 @@ def test_version_flag_podman_missing(
 class TestSetupInteractive:
     """Tests for interactive setup mode."""
 
-    @mock.patch("terok_shield.core.mode_hook.setup_global_hooks")
+    @mock.patch("terok_shield.core.hook_install.setup_global_hooks")
     @mock.patch("builtins.input", return_value="u")
     def test_interactive_user_choice(
         self,
@@ -1097,7 +1097,7 @@ class TestSetupInteractive:
         main(["setup"])
         assert "Cancelled" in capsys.readouterr().out
 
-    @mock.patch("terok_shield.core.mode_hook.setup_global_hooks")
+    @mock.patch("terok_shield.core.hook_install.setup_global_hooks")
     @mock.patch("builtins.input", return_value="r")
     def test_interactive_root_choice(
         self,

--- a/tests/unit/test_hook_entrypoint_isolation.py
+++ b/tests/unit/test_hook_entrypoint_isolation.py
@@ -45,11 +45,15 @@ class TestHookEntrypointImportIsolation:
                     assert top in stdlib, (
                         f"hook_entrypoint.py imports non-stdlib module: {alias.name}"
                     )
-            elif isinstance(node, ast.ImportFrom) and node.module:
+            elif isinstance(node, ast.ImportFrom):
                 if node.level > 0:
+                    rel = "." * node.level + (node.module or "")
                     raise AssertionError(
-                        f"hook_entrypoint.py has relative import: .{node.module} "
+                        f"hook_entrypoint.py has relative import: {rel} "
                         "(must be stdlib-only, no terok_shield imports)"
                     )
-                top = node.module.split(".")[0]
-                assert top in stdlib, f"hook_entrypoint.py imports non-stdlib module: {node.module}"
+                if node.module:
+                    top = node.module.split(".")[0]
+                    assert top in stdlib, (
+                        f"hook_entrypoint.py imports non-stdlib module: {node.module}"
+                    )

--- a/tests/unit/test_hook_entrypoint_isolation.py
+++ b/tests/unit/test_hook_entrypoint_isolation.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""AST-based tests for hook_entrypoint.py import isolation.
+
+This file stays intentionally small and explicit because it guards the
+import boundary of the OCI hook script.  hook_entrypoint.py runs as a
+standalone OCI hook inside the container runtime's namespace — it must
+use only stdlib modules and no terok_shield imports.  We avoid
+abstraction here so the allowed dependency surface can be reviewed
+line by line.
+"""
+
+import ast
+from pathlib import Path
+
+
+class TestHookEntrypointImportIsolation:
+    """hook_entrypoint.py is stdlib-only -- no third-party or terok_shield imports."""
+
+    def test_hook_entrypoint_has_only_stdlib_imports(self) -> None:
+        """Verify hook_entrypoint.py imports only stdlib modules."""
+        # Keep the source path inline here so auditors can review the exact
+        # security-boundary file target without indirection.
+        source = (
+            Path(__file__).parents[2] / "src" / "terok_shield" / "resources" / "hook_entrypoint.py"
+        ).read_text()
+        tree = ast.parse(source)
+        stdlib = {
+            "ipaddress",
+            "json",
+            "os",
+            "pathlib",
+            "pwd",
+            "shutil",
+            "socket",
+            "struct",
+            "subprocess",
+            "sys",
+        }
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    top = alias.name.split(".")[0]
+                    assert top in stdlib, (
+                        f"hook_entrypoint.py imports non-stdlib module: {alias.name}"
+                    )
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                if node.level > 0:
+                    raise AssertionError(
+                        f"hook_entrypoint.py has relative import: .{node.module} "
+                        "(must be stdlib-only, no terok_shield imports)"
+                    )
+                top = node.module.split(".")[0]
+                assert top in stdlib, f"hook_entrypoint.py imports non-stdlib module: {node.module}"

--- a/tests/unit/test_hook_mode_class.py
+++ b/tests/unit/test_hook_mode_class.py
@@ -18,7 +18,8 @@ from terok_shield.common.config import (
     ShieldState,
 )
 from terok_shield.core import state
-from terok_shield.core.mode_hook import HookMode, install_hooks
+from terok_shield.core.hook_install import install_hooks
+from terok_shield.core.mode_hook import HookMode
 from terok_shield.core.nft import bypass_ruleset, hook_ruleset
 from terok_shield.core.nft_constants import PASTA_HOST_LOOPBACK_MAP
 from terok_shield.core.run import ExecError
@@ -564,7 +565,7 @@ def test_install_hooks_creates_entrypoint_and_hook_jsons(tmp_path: Path) -> None
 
 def test_generate_entrypoint_is_stdlib_only(tmp_path: Path) -> None:
     """The entrypoint script uses /usr/bin/env python3 and has no terok_shield imports."""
-    from terok_shield.core.mode_hook import _generate_entrypoint
+    from terok_shield.core.hook_install import _generate_entrypoint
 
     content = _generate_entrypoint()
     assert content.splitlines()[0] == "#!/usr/bin/env python3"
@@ -598,7 +599,7 @@ def test_pre_start_writes_ruleset_nft(
 
 def test_setup_global_hooks_non_sudo(tmp_path: Path) -> None:
     """setup_global_hooks() installs hooks without sudo."""
-    from terok_shield.core.mode_hook import setup_global_hooks
+    from terok_shield.core.hook_install import setup_global_hooks
 
     target = tmp_path / "hooks.d"
     setup_global_hooks(target)
@@ -615,7 +616,7 @@ def test_setup_global_hooks_sudo_uses_subprocess(tmp_path: Path) -> None:
     """setup_global_hooks(use_sudo=True) calls sudo subprocess."""
     from unittest import mock
 
-    from terok_shield.core.mode_hook import setup_global_hooks
+    from terok_shield.core.hook_install import setup_global_hooks
 
     target = tmp_path / "system-hooks"
     with mock.patch("subprocess.run") as mock_run:


### PR DESCRIPTION
## Summary

- **Extract `core/hook_install.py`** from `mode_hook.py` — separates hook file generation (pure I/O) from the HookMode strategy class (786 → 665 lines)
- **AST import isolation test** for `hook_entrypoint.py` — enforces stdlib-only imports, matching the existing `nft.py` security boundary guard
- **Document `resources/` exclusion** in `tach.toml` — explains why hook_entrypoint.py sits outside the layer system
- **Lazy facade imports** in `__init__.py` — `from terok_shield import ShieldConfig` only loads the common layer; core/support modules deferred via `__getattr__`
- **Remove `from __future__ import annotations`** from all 9 source files — unnecessary on Python 3.12+; TYPE_CHECKING types converted to string annotations where cross-layer constraints apply

## Test plan

- [x] `make check` passes (lint, 990 unit tests, tach, docstrings, REUSE, security)
- [x] Lazy imports verified: `from terok_shield import ShieldConfig` loads only common layer modules
- [x] Lazy re-exports verified: `from terok_shield import SubprocessRunner` resolves correctly via `__getattr__`
- [x] No `from __future__ import annotations` remaining in `src/`
- [ ] Integration tests (needs podman — run manually on test machine)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reduced startup overhead via lazy loading and separated hook-installation into its own component.

* **New Features**
  * Improved hook installation with explicit global install flow, including optional elevated (sudo) handling.

* **Chores**
  * CLI setup flow preserved while wiring for hook installation was reorganized.

* **Tests**
  * Added a test ensuring the hook entrypoint only depends on the standard library.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->