### PR TITLE
feat: D-Bus event bridge for interactive shield sessions

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -46,7 +46,7 @@ jobs:
           key: venv-${{ runner.os }}-py${{ steps.setup-python.outputs.python-version }}-test-${{ hashFiles('**/pyproject.toml', '**/poetry.lock') }}
 
       - name: Install dependencies
-        run: poetry install --with test --no-interaction
+        run: poetry install --with test --with dbus --no-interaction
 
       - name: Run unit tests
         run: make test-unit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
           key: venv-${{ runner.os }}-py${{ steps.setup-python.outputs.python-version }}-test-${{ hashFiles('**/pyproject.toml', '**/poetry.lock') }}
 
       - name: Install dependencies
-        run: poetry install --with test --no-interaction
+        run: poetry install --with test --with dbus --no-interaction
 
       - name: Run host-only integration tests
         run: make test-integration-host

--- a/poetry.lock
+++ b/poetry.lock
@@ -1813,22 +1813,21 @@ tomli-w = ">=1.0,<2.0"
 
 [[package]]
 name = "terok-dbus"
-version = "0.1.0"
+version = "0.2.0"
 description = "D-Bus desktop notification package for terok"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["dbus"]
-files = []
-develop = false
+files = [
+    {file = "terok_dbus-0.2.0-py3-none-any.whl", hash = "sha256:119f4c500239cd37f835b87bc1c862b38502bedd2ae1a058dcbe60e3f6e7cd40"},
+]
 
 [package.dependencies]
 dbus-fast = ">=2.0,<5.0"
 
 [package.source]
-type = "git"
-url = "https://github.com/terok-ai/terok-dbus.git"
-reference = "master"
-resolved_reference = "4801d77d118014cf860b78c936ec2cde7acd7fc7"
+type = "url"
+url = "https://github.com/terok-ai/terok-dbus/releases/download/v0.2.0/terok_dbus-0.2.0-py3-none-any.whl"
 
 [[package]]
 name = "tomli"
@@ -2066,4 +2065,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "9c9f3f96291bb7a7bf452ae35c4d4b10a3f77cf6efbf36884b30be474db2881e"
+content-hash = "b93e5950300133d880ed77675b92c50a01cf5b440301c15fdb477c5afaa5a8d9"

--- a/poetry.lock
+++ b/poetry.lock
@@ -500,6 +500,53 @@ files = [
 toml = ["tomli ; python_full_version <= \"3.11.0a6\""]
 
 [[package]]
+name = "dbus-fast"
+version = "4.0.4"
+description = "A faster version of dbus-next"
+optional = false
+python-versions = ">=3.10"
+groups = ["dbus"]
+files = [
+    {file = "dbus_fast-4.0.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:cc3955d9b86717a2b126700842012e30df3c3b263707154047e9b06e91d7b48d"},
+    {file = "dbus_fast-4.0.4-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d1dc97206c3f7fbf45e2fc12a2a3fdf0f080325a342a140edece4bf33f0bfd23"},
+    {file = "dbus_fast-4.0.4-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:864e032aabfae051db27e1b63055a0f6460d0121d36ddcbe97b903149fa932f6"},
+    {file = "dbus_fast-4.0.4-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:6738fa2a98652caf29e3368e6532f3faead007739f464d047c2cc46ec5b56f6c"},
+    {file = "dbus_fast-4.0.4-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:ed82af97d3ceee7ba31a169b5b8b9341e05ebf45fdf93f02d2fee0b74ef56190"},
+    {file = "dbus_fast-4.0.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:54c67a84a9f633a745c5bf6a37fece3c13f4057b4ecb23a2e83600423cd78057"},
+    {file = "dbus_fast-4.0.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cf5109bbc98c8427f3cc22030de55e57a7288550bc0701a493905bbad3b3dc93"},
+    {file = "dbus_fast-4.0.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:baca8ffed5a5b18cce9c1f17820cc699512bc97ac0743b8b88c61159aa0c961a"},
+    {file = "dbus_fast-4.0.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:cb570c6c8dac1ee2ca02621c0d410ec78d1a96535deee8a34e3028f475be7675"},
+    {file = "dbus_fast-4.0.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1a2ee216e0ddd7b4db397bb31ff71741f6c7fc9618d9ca201e0096d9523b4f33"},
+    {file = "dbus_fast-4.0.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:139b462190f7421e55fec421108f824425a559b3d9a5e0b15421e68275735bad"},
+    {file = "dbus_fast-4.0.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:00a3db08cf1d98bbedfb73467b774fd49adcf83935b8a92f6c552ce78d93491f"},
+    {file = "dbus_fast-4.0.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74183b4ef4cc79a9cd1a46e006c19d00ce9abc7d99d36e6adcd094f414446d38"},
+    {file = "dbus_fast-4.0.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:003f042b1299ebac900d6ee30e8ab2a29988937f56792894da7b5d39a26b1f5f"},
+    {file = "dbus_fast-4.0.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:87be8a41330481c3d3a5e30af10ec713e4f08fe0d6c36f5a401eaef7b5526417"},
+    {file = "dbus_fast-4.0.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:728bc8a02302c6677a42da2b037580755b29c8fccd5c0866acc529053b2d374d"},
+    {file = "dbus_fast-4.0.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1fe60ce3a97e265a3ad117b7f40fc8c08357781b1a2ed3e853f29f9e35d24af7"},
+    {file = "dbus_fast-4.0.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:982235dabb7e7187df4c2c299d95a6232aebc95c8c906496f630265a10bfdf95"},
+    {file = "dbus_fast-4.0.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:33c0168e0e65ed2d0fa91682773cc893472e3d71a5e085ee082e6484c2d29f4a"},
+    {file = "dbus_fast-4.0.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:069df5d46390299d7fccfc0e704af504a8b75794c2c3bc0246b6db0db1f245b0"},
+    {file = "dbus_fast-4.0.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:3564c8a756903a6edf01ceb4dd4927354f03b40a28f000e2b896f02a784e9301"},
+    {file = "dbus_fast-4.0.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0c3a8c07d672b1656a9c7cbdc9a85f493602f72fce8e7f9d97c5e972fa22a684"},
+    {file = "dbus_fast-4.0.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5512b9901ba600f1efdae2555ea18da2b67a46e5c24e397edb38ecbbde4aa43f"},
+    {file = "dbus_fast-4.0.4-cp314-cp314-manylinux_2_41_x86_64.whl", hash = "sha256:36f86ba826f05c4d238c9198ae962f90a9cd27ffacd3a4a988166b3d06c699ca"},
+    {file = "dbus_fast-4.0.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:df0f88a9c1c9f9365627fbfb3dcae3589a12fdc82594945832cb24d9a62674d1"},
+    {file = "dbus_fast-4.0.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4c6c8722e829b8e750fd6db2906b298d3bcfc32d8cdf766e50ba474ef48bf2af"},
+    {file = "dbus_fast-4.0.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8a515e8de0e5971e64a3f49fad2e536b6d2167a9f489e597baf7c802cfb7eef3"},
+    {file = "dbus_fast-4.0.4-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ad5240c29ec631f9610e03a6bbf4f4c22274e04ea8791e8401542cd6cdbd7b28"},
+    {file = "dbus_fast-4.0.4-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5843c3e543ac1d48cafff67394ada9e568f20d122b44408e378ae43402b785ca"},
+    {file = "dbus_fast-4.0.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7ebb845f2e15ef19f4a99cb879dfbcb1c7028a97d5aaba93b36f65cfd938a022"},
+    {file = "dbus_fast-4.0.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:698fe83128150dd49aaa7deb5493523309f0a9749c3c075730a6981851607455"},
+    {file = "dbus_fast-4.0.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:f815c979322e0f2e0ad0b1bd3adbf7d2840d69ca7f75be1215d8211e8a667fe5"},
+    {file = "dbus_fast-4.0.4-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0827134ae05d0f23349c0505ecc3b54ae8359be7f634b9eb16c8ad2dff9d51bb"},
+    {file = "dbus_fast-4.0.4-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44e605de4e18d0e94690d0ef7270e5f1c396ec30e0aac0ae3cac8886b458965c"},
+    {file = "dbus_fast-4.0.4-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:0c869d1949065d7b3c75d926cd461faa434691b4cf57a10559617821afe30737"},
+    {file = "dbus_fast-4.0.4-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:92b3aaea0e6df4cf83208ae994b08554335166eff726947733b93da748eab641"},
+    {file = "dbus_fast-4.0.4.tar.gz", hash = "sha256:43137f0b73a7adbf7d5c0e9eb9d8d34df9e6e0aeafade2166e641c52dfe0a853"},
+]
+
+[[package]]
 name = "docstr-coverage"
 version = "2.3.2"
 description = "Utility for examining python source files to ensure proper documentation. Lists missing docstrings, and calculates overall docstring coverage percentage rating."
@@ -1765,6 +1812,25 @@ tomli = ">=1.2.2"
 tomli-w = ">=1.0,<2.0"
 
 [[package]]
+name = "terok-dbus"
+version = "0.1.0"
+description = "D-Bus desktop notification package for terok"
+optional = false
+python-versions = ">=3.12,<4.0"
+groups = ["dbus"]
+files = []
+develop = false
+
+[package.dependencies]
+dbus-fast = ">=2.0,<5.0"
+
+[package.source]
+type = "git"
+url = "https://github.com/terok-ai/terok-dbus.git"
+reference = "master"
+resolved_reference = "4801d77d118014cf860b78c936ec2cde7acd7fc7"
+
+[[package]]
 name = "tomli"
 version = "2.4.0"
 description = "A lil' TOML parser"
@@ -2000,4 +2066,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "286927b48094ae7155ad3055c43dba949f63fcd17df12f60df8b3d2721da0a54"
+content-hash = "8125650de0b34f83e5369595085ab8bd44bb2e6d7a8cd82a8ba6eed8b191e4bd"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2066,4 +2066,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "8125650de0b34f83e5369595085ab8bd44bb2e6d7a8cd82a8ba6eed8b191e4bd"
+content-hash = "9c9f3f96291bb7a7bf452ae35c4d4b10a3f77cf6efbf36884b30be474db2881e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.poetry]
 name = "terok-shield"
-version = "0.5.4"
+version = "0.6.0"
 description = "nftables-based egress firewalling for Podman containers"
 readme = "README.md"
 license = "Apache-2.0"
@@ -45,7 +45,7 @@ optional = true
 
 [tool.poetry.group.dbus.dependencies]
 dbus-fast = ">=2.0"
-terok-dbus = {git = "https://github.com/terok-ai/terok-dbus.git", rev = "4801d77"}
+terok-dbus = {url = "https://github.com/terok-ai/terok-dbus/releases/download/v0.2.0/terok_dbus-0.2.0-py3-none-any.whl"}
 
 [tool.poetry.group.docs.dependencies]
 mkdocs = ">=1.5,<2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,13 @@ tach = "^0.34.0"
 pytest = ">=7.0"
 pytest-cov = ">=4.0"
 
+[tool.poetry.group.dbus]
+optional = true
+
+[tool.poetry.group.dbus.dependencies]
+dbus-fast = ">=2.0"
+terok-dbus = {git = "https://github.com/terok-ai/terok-dbus.git", branch = "master"}
+
 [tool.poetry.group.docs.dependencies]
 mkdocs = ">=1.5,<2"
 mkdocs-material = ">=9.0"
@@ -92,6 +99,8 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["E402"]
+# dbus_fast uses D-Bus type signature strings ("s", "q", "b") as annotations
+"src/terok_shield/lib/dbus_bridge.py" = ["F821"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["terok_shield"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ optional = true
 
 [tool.poetry.group.dbus.dependencies]
 dbus-fast = ">=2.0"
-terok-dbus = {git = "https://github.com/terok-ai/terok-dbus.git", branch = "master"}
+terok-dbus = {git = "https://github.com/terok-ai/terok-dbus.git", rev = "4801d77"}
 
 [tool.poetry.group.docs.dependencies]
 mkdocs = ">=1.5,<2"

--- a/src/terok_shield/cli/dbus_bridge.py
+++ b/src/terok_shield/cli/dbus_bridge.py
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""``shield dbus-bridge`` entry point — standalone D-Bus bridge launcher.
+
+Acquires the per-container well-known bus name on the session bus,
+creates a :class:`~terok_shield.lib.dbus_bridge.ShieldBridge`, and
+runs until SIGINT/SIGTERM.  For orchestrated use (e.g. terok TUI),
+import :class:`ShieldBridge` directly and manage the bus externally.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import signal
+import sys
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+async def _run_bridge(state_dir: Path, container: str) -> None:
+    """Connect to the session bus, acquire the bus name, and run the bridge."""
+    from dbus_fast.aio import MessageBus
+
+    from ..lib.dbus_bridge import ShieldBridge, bus_name_for_container
+
+    bus = await MessageBus().connect()
+    bridge = ShieldBridge(state_dir=state_dir, container=container, bus=bus)
+
+    name = bus_name_for_container(bridge.container_id)
+    reply = await bus.request_name(name)
+    from dbus_fast import RequestNameReply
+
+    if reply != RequestNameReply.PRIMARY_OWNER:
+        print(
+            f"Error: could not acquire bus name {name} (another bridge may be running).",
+            file=sys.stderr,
+        )
+        bus.disconnect()
+        raise SystemExit(1)
+
+    stop_event = asyncio.Event()
+
+    def _on_signal() -> None:
+        """Set the stop event on SIGINT/SIGTERM."""
+        stop_event.set()
+
+    loop = asyncio.get_running_loop()
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        loop.add_signal_handler(sig, _on_signal)
+
+    await bridge.start()
+    logger.info("D-Bus bridge active: %s -> %s", container, name)
+
+    try:
+        await stop_event.wait()
+    finally:
+        await bridge.stop()
+        bus.disconnect()
+
+
+def run_dbus_bridge(state_dir: Path, container: str) -> None:
+    """Start the standalone D-Bus bridge for a container.
+
+    Acquires the per-container bus name, spawns the interactive
+    subprocess, and relays events until interrupted.
+
+    Args:
+        state_dir: Per-container state directory.
+        container: Container name.
+
+    Raises:
+        SystemExit: If the bus name cannot be acquired.
+    """
+    try:
+        asyncio.run(_run_bridge(state_dir, container))
+    except KeyboardInterrupt:
+        pass

--- a/src/terok_shield/cli/registry.py
+++ b/src/terok_shield/cli/registry.py
@@ -176,6 +176,13 @@ def _handle_interactive(shield: Shield, container: str, *, raw: bool = False) ->
     run_interactive(shield.config.state_dir, container, raw=raw)
 
 
+def _handle_dbus_bridge(shield: Shield, container: str) -> None:
+    """Start D-Bus event bridge for interactive egress control."""
+    from .dbus_bridge import run_dbus_bridge
+
+    run_dbus_bridge(shield.config.state_dir, container)
+
+
 def _handle_preview(shield: Shield, *, down: bool = False, allow_all: bool = False) -> None:
     """Show ruleset that would be applied."""
     if allow_all and not down:
@@ -297,6 +304,12 @@ COMMANDS: tuple[CommandDef, ...] = (
                 help="Use raw JSON-lines protocol instead of human-friendly CLI",
             ),
         ),
+    ),
+    CommandDef(
+        name="dbus-bridge",
+        help="Start D-Bus event bridge for interactive egress control",
+        handler=_handle_dbus_bridge,
+        needs_container=True,
     ),
     # NOTE: CLI special-cases logs with --container optional for aggregated mode.
     # The terok integration layer always has a per-container Shield, so the

--- a/src/terok_shield/core/mode_hook.py
+++ b/src/terok_shield/core/mode_hook.py
@@ -257,6 +257,10 @@ class HookMode:
             hooks_dir=state.hooks_dir(sd),
         )
 
+        # Persist container ID for D-Bus bridge bus name derivation
+        container_id = self._runner.podman_inspect(container, "{{.Id}}")
+        state.container_id_path(sd).write_text(container_id[:12] + "\n")
+
         # Detect DNS tier and upstream DNS
         tier = self._detect_dns_tier()
         mode = info.network_mode or "pasta"

--- a/src/terok_shield/core/state.py
+++ b/src/terok_shield/core/state.py
@@ -26,6 +26,7 @@ Bundle layout::
     ├── dnsmasq.log                    # dnsmasq query log (for shield watch)
     ├── resolv.conf                    # bind-mounted over /etc/resolv.conf (dnsmasq tier)
     ├── interactive                    # interactive tier marker (e.g. "nflog")
+    ├── container.id                   # podman container ID (short, 12-char hex)
     └── audit.jsonl                    # per-container audit log
 """
 
@@ -198,6 +199,11 @@ def read_effective_ips(state_dir: Path) -> list[str]:
     allowed = read_allowed_ips(state_dir)
     denied = read_denied_ips(state_dir)
     return [ip for ip in allowed if ip not in denied]
+
+
+def container_id_path(state_dir: Path) -> Path:
+    """Return the path to the persisted podman container ID file."""
+    return state_dir / "container.id"
 
 
 def ensure_state_dirs(state_dir: Path) -> None:

--- a/src/terok_shield/lib/dbus_bridge.py
+++ b/src/terok_shield/lib/dbus_bridge.py
@@ -1,0 +1,276 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""D-Bus event bridge for interactive NFLOG sessions.
+
+Translates between :class:`InteractiveSession`'s JSON-lines protocol and
+D-Bus ``org.terok.Shield1`` signals/methods.  Each bridge serves one
+container; MPRIS-style per-container bus names
+(``org.terok.Shield1.Container_<short_id>``) allow unlimited coexistence.
+
+The bridge does **not** own the bus name — the caller (standalone CLI or
+orchestrator) acquires the name and passes the connected bus.  This lets
+a single orchestrator manage multiple bridges on one bus connection.
+
+Requires optional dependencies ``dbus-fast`` and ``terok-dbus``.
+Install via ``poetry install --with dbus``.
+"""
+
+import asyncio
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+
+try:
+    from dbus_fast.aio import MessageBus
+    from dbus_fast.service import ServiceInterface, method, signal
+except ImportError as _exc:
+    raise ImportError(
+        "D-Bus bridge requires dbus-fast and terok-dbus. Install via: poetry install --with dbus"
+    ) from _exc
+
+try:
+    from terok_dbus._interfaces import SHIELD_INTERFACE_NAME, SHIELD_OBJECT_PATH
+except ImportError as _exc:
+    raise ImportError(
+        "D-Bus bridge requires terok-dbus. Install via: poetry install --with dbus"
+    ) from _exc
+
+from ..core.state import container_id_path
+
+logger = logging.getLogger(__name__)
+
+BUS_NAME_PREFIX = "org.terok.Shield1.Container_"
+"""Per-container bus name prefix.  Suffixed with the short container ID."""
+
+_NSENTER_ENV = "_TEROK_SHIELD_NFLOG_NSENTER"
+_RAW_ENV = "_TEROK_SHIELD_NFLOG_RAW"
+
+
+def bus_name_for_container(short_id: str) -> str:
+    """Derive the per-container well-known bus name.
+
+    D-Bus bus name segments must start with ``[A-Za-z_]``, so hex IDs
+    (which may start with a digit) are prefixed with ``Container_``.
+    """
+    return f"{BUS_NAME_PREFIX}{short_id}"
+
+
+class _ShieldInterface(ServiceInterface):
+    """D-Bus ``org.terok.Shield1`` interface exported by the bridge.
+
+    Signals are emitted when the subprocess produces JSON events.
+    The ``Verdict`` method routes operator decisions back to the subprocess.
+    """
+
+    def __init__(self, bridge: "ShieldBridge") -> None:
+        """Initialise with a back-reference to the bridge for verdict routing."""
+        super().__init__(SHIELD_INTERFACE_NAME)
+        self._bridge = bridge
+
+    @signal()
+    def connection_blocked(
+        self,
+        container: "s",
+        dest: "s",
+        port: "q",
+        proto: "q",
+        domain: "s",
+        request_id: "s",
+    ) -> "ssqqss":
+        """Emit when a new outbound connection is blocked."""
+        return [container, dest, port, proto, domain, request_id]
+
+    @signal()
+    def verdict_applied(
+        self,
+        container: "s",
+        dest: "s",
+        request_id: "s",
+        action: "s",
+        ok: "b",
+    ) -> "sssb":
+        """Emit after a verdict has been applied to the nft ruleset."""
+        return [container, dest, request_id, action, ok]
+
+    @method()
+    async def verdict(self, request_id: "s", action: "s") -> "b":
+        """Route an operator verdict to the subprocess stdin."""
+        return await self._bridge.submit_verdict(request_id, action)
+
+
+class ShieldBridge:
+    """D-Bus bridge for one container's interactive NFLOG session.
+
+    Spawns ``InteractiveSession`` (JSON-lines mode) as a subprocess that
+    enters the container's network namespace via nsenter.  Translates
+    JSON-lines events to D-Bus ``Shield1`` signals and routes verdicts
+    from D-Bus method calls back to the subprocess's stdin.
+
+    Args:
+        state_dir: Per-container state directory.
+        container: Container name (used for nsenter and signal payloads).
+        bus: Connected ``MessageBus`` instance (caller-owned).
+    """
+
+    def __init__(self, *, state_dir: Path, container: str, bus: MessageBus) -> None:
+        """Initialise the bridge with state directory, container name, and bus."""
+        self._state_dir = state_dir
+        self._container = container
+        self._bus = bus
+        self._process: asyncio.subprocess.Process | None = None
+        self._read_task: asyncio.Task[None] | None = None
+        self._interface = _ShieldInterface(self)
+        self._container_id: str | None = None
+
+    @property
+    def container_id(self) -> str:
+        """Short container ID read from ``state_dir/container.id``."""
+        if self._container_id is None:
+            id_path = container_id_path(self._state_dir)
+            if not id_path.is_file():
+                raise FileNotFoundError(
+                    f"Container ID not found at {id_path}. "
+                    "Run 'shield prepare' first to persist the container ID."
+                )
+            self._container_id = id_path.read_text().strip()
+        return self._container_id
+
+    @property
+    def bus_name(self) -> str:
+        """Per-container well-known bus name."""
+        return bus_name_for_container(self.container_id)
+
+    async def start(self) -> None:
+        """Spawn the interactive subprocess and begin the event relay loop.
+
+        Exports the Shield1 interface on the bus at
+        ``/org/terok/Shield1``, then reads JSON lines from the subprocess
+        stdout and emits D-Bus signals for each event.
+        """
+        self._bus.export(SHIELD_OBJECT_PATH, self._interface)
+
+        env = {**os.environ, _RAW_ENV: "1"}
+        env.pop(_NSENTER_ENV, None)
+        self._process = await asyncio.create_subprocess_exec(
+            sys.executable,
+            "-m",
+            "terok_shield.cli.interactive",
+            str(self._state_dir),
+            self._container,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=None,
+            env=env,
+        )
+        self._read_task = asyncio.create_task(self._read_loop())
+        logger.info(
+            "Bridge started for %s (bus name: %s, pid: %s)",
+            self._container,
+            self.bus_name,
+            self._process.pid,
+        )
+
+    async def stop(self) -> None:
+        """Terminate the subprocess and clean up resources."""
+        if self._read_task and not self._read_task.done():
+            self._read_task.cancel()
+            try:
+                await self._read_task
+            except asyncio.CancelledError:
+                pass
+        if self._process and self._process.returncode is None:
+            self._process.terminate()
+            try:
+                await asyncio.wait_for(self._process.wait(), timeout=5.0)
+            except TimeoutError:
+                self._process.kill()
+                await self._process.wait()
+        try:
+            self._bus.unexport(SHIELD_OBJECT_PATH, self._interface)
+        except Exception:
+            pass
+        logger.info("Bridge stopped for %s", self._container)
+
+    async def submit_verdict(self, request_id: str, action: str) -> bool:
+        """Write a verdict command to the subprocess stdin.
+
+        Args:
+            request_id: Compound ID ``"{container}:{packet_id}"``.
+            action: ``"accept"`` or ``"deny"``.
+
+        Returns:
+            ``True`` if the verdict was written successfully.
+        """
+        if not self._process or self._process.stdin is None:
+            logger.warning("Cannot submit verdict — subprocess not running")
+            return False
+
+        sep = request_id.rfind(":")
+        if sep < 0:
+            logger.warning("Invalid request_id format: %s", request_id)
+            return False
+        try:
+            packet_id = int(request_id[sep + 1 :])
+        except ValueError:
+            logger.warning("Non-integer packet ID in request_id: %s", request_id)
+            return False
+
+        verdict = {"type": "verdict", "id": packet_id, "action": action}
+        line = json.dumps(verdict, separators=(",", ":")) + "\n"
+        try:
+            self._process.stdin.write(line.encode())
+            await self._process.stdin.drain()
+        except (BrokenPipeError, ConnectionResetError):
+            logger.warning("Subprocess stdin closed while writing verdict")
+            return False
+        return True
+
+    async def _read_loop(self) -> None:
+        """Read JSON lines from the subprocess stdout and emit D-Bus signals."""
+        assert self._process is not None
+        assert self._process.stdout is not None
+        try:
+            async for raw_line in self._process.stdout:
+                line = raw_line.decode().strip()
+                if not line:
+                    continue
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError:
+                    logger.warning("Non-JSON line from subprocess: %s", line)
+                    continue
+                self._dispatch_event(event)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("Read loop error for %s", self._container)
+        finally:
+            logger.debug("Read loop exited for %s", self._container)
+
+    def _dispatch_event(self, event: dict) -> None:
+        """Route a parsed JSON event to the appropriate D-Bus signal."""
+        event_type = event.get("type")
+        if event_type == "pending":
+            request_id = f"{self._container}:{event['id']}"
+            self._interface.connection_blocked(
+                self._container,
+                event.get("dest", ""),
+                event.get("port", 0),
+                event.get("proto", 0),
+                event.get("domain", ""),
+                request_id,
+            )
+        elif event_type == "verdict_applied":
+            request_id = f"{self._container}:{event['id']}"
+            self._interface.verdict_applied(
+                self._container,
+                event.get("dest", ""),
+                request_id,
+                event.get("action", ""),
+                event.get("ok", False),
+            )
+        else:
+            logger.debug("Ignoring unknown event type: %s", event_type)

--- a/src/terok_shield/lib/dbus_bridge.py
+++ b/src/terok_shield/lib/dbus_bridge.py
@@ -189,37 +189,58 @@ class ShieldBridge:
         Runs cleanup to completion even if the caller's task is
         cancelled, then re-raises ``CancelledError``.
         """
-        cancelled = False
-        if self._read_task and not self._read_task.done():
-            self._read_task.cancel()
+        await self._cancel_read_task()
+        cancelled = await self._terminate_process()
+        self._unexport_bus()
+        logger.info("Bridge stopped for %s", self._container)
+        if cancelled:
+            raise asyncio.CancelledError
+
+    async def _cancel_read_task(self) -> None:
+        """Cancel the read-loop task and await its completion."""
+        if not self._read_task or self._read_task.done():
+            return
+        self._read_task.cancel()
+        try:
+            await self._read_task
+        except asyncio.CancelledError:  # NOSONAR(S5754) expected from cancel() above
+            pass
+
+    async def _terminate_process(self) -> bool:
+        """Terminate the subprocess, escalating to kill on timeout.
+
+        Returns ``True`` if a ``CancelledError`` was caught during
+        the wait (external cancellation of ``stop()``).
+        """
+        if not self._process or self._process.returncode is not None:
+            return False
+        try:
+            self._process.terminate()
+        except ProcessLookupError:
+            logger.debug("Subprocess already exited before terminate")
+            return False
+        try:
+            await asyncio.wait_for(self._process.wait(), timeout=5.0)
+        except asyncio.CancelledError:  # NOSONAR(S5754) re-raised by stop() via flag
+            return True
+        except TimeoutError:
             try:
-                await self._read_task
-            except asyncio.CancelledError:  # NOSONAR(S5754) child task we just cancelled
-                pass
-        if self._process and self._process.returncode is None:
-            try:
-                self._process.terminate()
+                self._process.kill()
             except ProcessLookupError:
-                logger.debug("Subprocess already exited before terminate")
+                logger.debug("Subprocess already exited before kill")
             else:
                 try:
-                    await asyncio.wait_for(self._process.wait(), timeout=5.0)
-                except asyncio.CancelledError:  # NOSONAR(S5754) re-raised after cleanup via flag
-                    cancelled = True
-                except TimeoutError:
-                    try:
-                        self._process.kill()
-                    except ProcessLookupError:
-                        logger.debug("Subprocess already exited before kill")
-                    else:
-                        await self._process.wait()
+                    await self._process.wait()
+                except asyncio.CancelledError:  # NOSONAR(S5754) re-raised by stop()
+                    return True
+        return False
+
+    def _unexport_bus(self) -> None:
+        """Remove the Shield1 interface from the bus."""
         try:
             self._bus.unexport(SHIELD_OBJECT_PATH, self._interface)
         except Exception:
             logger.debug("Unexport failed during stop", exc_info=True)
-        logger.info("Bridge stopped for %s", self._container)
-        if cancelled:
-            raise asyncio.CancelledError
 
     async def submit_verdict(self, request_id: str, action: str) -> bool:
         """Write a verdict command to the subprocess stdin.

--- a/src/terok_shield/lib/dbus_bridge.py
+++ b/src/terok_shield/lib/dbus_bridge.py
@@ -150,6 +150,10 @@ class ShieldBridge:
         ``/org/terok/Shield1``, then reads JSON lines from the subprocess
         stdout and emits D-Bus signals for each event.
         """
+        # Preload bus_name (file I/O) before any side effects so a
+        # missing container.id raises before we export or spawn.
+        name = self.bus_name
+
         self._bus.export(SHIELD_OBJECT_PATH, self._interface)
         try:
             env = {**os.environ, _RAW_ENV: "1"}
@@ -175,25 +179,17 @@ class ShieldBridge:
         logger.info(
             "Bridge started for %s (bus name: %s, pid: %s)",
             self._container,
-            self.bus_name,
+            name,
             self._process.pid,
         )
 
     async def stop(self) -> None:
         """Terminate the subprocess and clean up resources.
 
-        Shields cleanup from external cancellation: if ``stop()``
-        itself is cancelled while awaiting child tasks, cleanup runs
-        to completion before the ``CancelledError`` is re-raised.
+        Runs cleanup to completion even if the caller's task is
+        cancelled, then re-raises ``CancelledError``.
         """
-        try:
-            await asyncio.shield(self._stop_inner())
-        except asyncio.CancelledError:
-            await self._stop_inner()
-            raise
-
-    async def _stop_inner(self) -> None:
-        """Run the actual teardown sequence (unshielded)."""
+        cancelled = False
         if self._read_task and not self._read_task.done():
             self._read_task.cancel()
             try:
@@ -201,17 +197,29 @@ class ShieldBridge:
             except asyncio.CancelledError:
                 pass  # expected: we just cancelled it
         if self._process and self._process.returncode is None:
-            self._process.terminate()
             try:
-                await asyncio.wait_for(self._process.wait(), timeout=5.0)
-            except TimeoutError:
-                self._process.kill()
-                await self._process.wait()
+                self._process.terminate()
+            except ProcessLookupError:
+                logger.debug("Subprocess already exited before terminate")
+            else:
+                try:
+                    await asyncio.wait_for(self._process.wait(), timeout=5.0)
+                except asyncio.CancelledError:
+                    cancelled = True
+                except TimeoutError:
+                    try:
+                        self._process.kill()
+                    except ProcessLookupError:
+                        logger.debug("Subprocess already exited before kill")
+                    else:
+                        await self._process.wait()
         try:
             self._bus.unexport(SHIELD_OBJECT_PATH, self._interface)
         except Exception:
             logger.debug("Unexport failed during stop", exc_info=True)
         logger.info("Bridge stopped for %s", self._container)
+        if cancelled:
+            raise asyncio.CancelledError
 
     async def submit_verdict(self, request_id: str, action: str) -> bool:
         """Write a verdict command to the subprocess stdin.

--- a/src/terok_shield/lib/dbus_bridge.py
+++ b/src/terok_shield/lib/dbus_bridge.py
@@ -180,13 +180,26 @@ class ShieldBridge:
         )
 
     async def stop(self) -> None:
-        """Terminate the subprocess and clean up resources."""
+        """Terminate the subprocess and clean up resources.
+
+        Shields cleanup from external cancellation: if ``stop()``
+        itself is cancelled while awaiting child tasks, cleanup runs
+        to completion before the ``CancelledError`` is re-raised.
+        """
+        try:
+            await asyncio.shield(self._stop_inner())
+        except asyncio.CancelledError:
+            await self._stop_inner()
+            raise
+
+    async def _stop_inner(self) -> None:
+        """Run the actual teardown sequence (unshielded)."""
         if self._read_task and not self._read_task.done():
             self._read_task.cancel()
             try:
                 await self._read_task
             except asyncio.CancelledError:
-                pass
+                pass  # expected: we just cancelled it
         if self._process and self._process.returncode is None:
             self._process.terminate()
             try:

--- a/src/terok_shield/lib/dbus_bridge.py
+++ b/src/terok_shield/lib/dbus_bridge.py
@@ -151,20 +151,26 @@ class ShieldBridge:
         stdout and emits D-Bus signals for each event.
         """
         self._bus.export(SHIELD_OBJECT_PATH, self._interface)
-
-        env = {**os.environ, _RAW_ENV: "1"}
-        env.pop(_NSENTER_ENV, None)
-        self._process = await asyncio.create_subprocess_exec(
-            sys.executable,
-            "-m",
-            "terok_shield.cli.interactive",
-            str(self._state_dir),
-            self._container,
-            stdin=asyncio.subprocess.PIPE,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=None,
-            env=env,
-        )
+        try:
+            env = {**os.environ, _RAW_ENV: "1"}
+            env.pop(_NSENTER_ENV, None)
+            self._process = await asyncio.create_subprocess_exec(
+                sys.executable,
+                "-m",
+                "terok_shield.cli.interactive",
+                str(self._state_dir),
+                self._container,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=None,
+                env=env,
+            )
+        except Exception:
+            try:
+                self._bus.unexport(SHIELD_OBJECT_PATH, self._interface)
+            except Exception:
+                logger.debug("Unexport failed during start rollback", exc_info=True)
+            raise
         self._read_task = asyncio.create_task(self._read_loop())
         logger.info(
             "Bridge started for %s (bus name: %s, pid: %s)",
@@ -208,12 +214,23 @@ class ShieldBridge:
             logger.warning("Cannot submit verdict — subprocess not running")
             return False
 
-        sep = request_id.rfind(":")
-        if sep < 0:
+        if action not in ("accept", "deny"):
+            logger.warning("Invalid verdict action: %s", action)
+            return False
+
+        container, sep, packet_raw = request_id.partition(":")
+        if not sep or not container:
             logger.warning("Invalid request_id format: %s", request_id)
             return False
+        if container != self._container:
+            logger.warning(
+                "request_id container mismatch: expected=%s got=%s",
+                self._container,
+                container,
+            )
+            return False
         try:
-            packet_id = int(request_id[sep + 1 :])
+            packet_id = int(packet_raw)
         except ValueError:
             logger.warning("Non-integer packet ID in request_id: %s", request_id)
             return False

--- a/src/terok_shield/lib/dbus_bridge.py
+++ b/src/terok_shield/lib/dbus_bridge.py
@@ -194,8 +194,8 @@ class ShieldBridge:
             self._read_task.cancel()
             try:
                 await self._read_task
-            except asyncio.CancelledError:
-                pass  # expected: we just cancelled it
+            except asyncio.CancelledError:  # NOSONAR(S5754) child task we just cancelled
+                pass
         if self._process and self._process.returncode is None:
             try:
                 self._process.terminate()
@@ -204,7 +204,7 @@ class ShieldBridge:
             else:
                 try:
                     await asyncio.wait_for(self._process.wait(), timeout=5.0)
-                except asyncio.CancelledError:
+                except asyncio.CancelledError:  # NOSONAR(S5754) re-raised after cleanup via flag
                     cancelled = True
                 except TimeoutError:
                     try:

--- a/src/terok_shield/lib/dbus_bridge.py
+++ b/src/terok_shield/lib/dbus_bridge.py
@@ -91,7 +91,7 @@ class _ShieldInterface(ServiceInterface):
         request_id: "s",
         action: "s",
         ok: "b",
-    ) -> "sssb":
+    ) -> "ssssb":
         """Emit after a verdict has been applied to the nft ruleset."""
         return [container, dest, request_id, action, ok]
 
@@ -191,7 +191,7 @@ class ShieldBridge:
         try:
             self._bus.unexport(SHIELD_OBJECT_PATH, self._interface)
         except Exception:
-            pass
+            logger.debug("Unexport failed during stop", exc_info=True)
         logger.info("Bridge stopped for %s", self._container)
 
     async def submit_verdict(self, request_id: str, action: str) -> bool:
@@ -230,8 +230,9 @@ class ShieldBridge:
 
     async def _read_loop(self) -> None:
         """Read JSON lines from the subprocess stdout and emit D-Bus signals."""
-        assert self._process is not None
-        assert self._process.stdout is not None
+        if self._process is None or self._process.stdout is None:
+            logger.error("Read loop called without a running subprocess")
+            return
         try:
             async for raw_line in self._process.stdout:
                 line = raw_line.decode().strip()

--- a/tach.toml
+++ b/tach.toml
@@ -159,6 +159,12 @@ path = "terok_shield.lib.watchers"
 layer = "support"
 depends_on = []
 
+# D-Bus bridge — optional, requires dbus-fast + terok-dbus
+[[modules]]
+path = "terok_shield.lib.dbus_bridge"
+layer = "support"
+depends_on = []
+
 # Package root — public API facade
 [[modules]]
 path = "terok_shield"
@@ -173,5 +179,13 @@ depends_on = [
 
 [[modules]]
 path = "terok_shield.cli"
+layer = "cli"
+depends_on = [
+    "terok_shield.cli.dbus_bridge",
+]
+
+# D-Bus bridge CLI entry point
+[[modules]]
+path = "terok_shield.cli.dbus_bridge"
 layer = "cli"
 depends_on = []

--- a/tests/unit/test_dbus_bridge.py
+++ b/tests/unit/test_dbus_bridge.py
@@ -441,6 +441,21 @@ def test_stop_already_exited_process(tmp_path: Path) -> None:
     proc.terminate.assert_not_called()
 
 
+def test_stop_inner_is_idempotent(tmp_path: Path) -> None:
+    """_stop_inner() can be called twice without error."""
+    bridge = _bridge(tmp_path)
+    proc = _mock_process()
+    bridge._process = proc
+    bridge._read_task = None
+
+    asyncio.run(bridge._stop_inner())
+    # Process already exited after first call
+    proc.returncode = 0
+    asyncio.run(bridge._stop_inner())
+
+    proc.terminate.assert_called_once()
+
+
 def test_start_unexports_on_spawn_failure(tmp_path: Path) -> None:
     """start() rolls back the D-Bus export when subprocess creation fails."""
     bridge = _bridge(tmp_path)

--- a/tests/unit/test_dbus_bridge.py
+++ b/tests/unit/test_dbus_bridge.py
@@ -523,6 +523,22 @@ def test_stop_reraises_cancelled_error(tmp_path: Path) -> None:
     bridge._bus.unexport.assert_called_once()
 
 
+def test_stop_kills_then_cancelled_during_wait(tmp_path: Path) -> None:
+    """stop() re-raises CancelledError that arrives during wait after kill."""
+    bridge = _bridge(tmp_path)
+    proc = _mock_process()
+    # First wait: TimeoutError (triggers kill), second wait: CancelledError
+    proc.wait = mock.AsyncMock(side_effect=[TimeoutError(), asyncio.CancelledError()])
+    bridge._process = proc
+    bridge._read_task = None
+
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(bridge.stop())
+    proc.terminate.assert_called_once()
+    proc.kill.assert_called_once()
+    bridge._bus.unexport.assert_called_once()
+
+
 def test_stop_is_idempotent(tmp_path: Path) -> None:
     """stop() can be called twice without error."""
     bridge = _bridge(tmp_path)

--- a/tests/unit/test_dbus_bridge.py
+++ b/tests/unit/test_dbus_bridge.py
@@ -330,6 +330,50 @@ def test_shield_interface_stores_bridge_reference() -> None:
     assert iface._bridge is bridge
 
 
+def test_connection_blocked_signal_body() -> None:
+    """connection_blocked() returns the argument list for D-Bus serialisation."""
+    bridge = mock.MagicMock()
+    iface = _ShieldInterface(bridge)
+    result = iface.connection_blocked(TEST_IP1, TEST_IP1, 443, 6, TEST_DOMAIN, "myapp:1")
+    assert result == [TEST_IP1, TEST_IP1, 443, 6, TEST_DOMAIN, "myapp:1"]
+
+
+def test_verdict_applied_signal_body() -> None:
+    """verdict_applied() returns the argument list for D-Bus serialisation."""
+    bridge = mock.MagicMock()
+    iface = _ShieldInterface(bridge)
+    result = iface.verdict_applied("myapp", TEST_IP1, "myapp:1", "accept", True)
+    assert result == ["myapp", TEST_IP1, "myapp:1", "accept", True]
+
+
+def test_verdict_method_delegates() -> None:
+    """The verdict method body awaits bridge.submit_verdict."""
+    bridge_mock = mock.MagicMock()
+    bridge_mock.submit_verdict = mock.AsyncMock(return_value=True)
+    iface = _ShieldInterface(bridge_mock)
+    # Call the original unwrapped coroutine to exercise the body
+    # (the @method() decorator intercepts normal calls for D-Bus dispatch).
+    orig_fn = _ShieldInterface.verdict.__wrapped__
+    result = asyncio.run(orig_fn(iface, "myapp:1", "accept"))
+    assert result is True
+    bridge_mock.submit_verdict.assert_awaited_once_with("myapp:1", "accept")
+
+
+# ── Registry handler ──────────────────────────────────────
+
+
+def test_handle_dbus_bridge_delegates(tmp_path: Path) -> None:
+    """_handle_dbus_bridge() delegates to run_dbus_bridge with state_dir and container."""
+    from terok_shield.cli.registry import _handle_dbus_bridge
+
+    shield = mock.MagicMock()
+    shield.config.state_dir = tmp_path
+
+    with mock.patch("terok_shield.cli.dbus_bridge.run_dbus_bridge") as run_mock:
+        _handle_dbus_bridge(shield, "myapp")
+        run_mock.assert_called_once_with(tmp_path, "myapp")
+
+
 # ── start / stop lifecycle ─────────────────────────────────
 
 

--- a/tests/unit/test_dbus_bridge.py
+++ b/tests/unit/test_dbus_bridge.py
@@ -1,0 +1,220 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the D-Bus event bridge (lib/dbus_bridge.py)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+dbus_fast = pytest.importorskip("dbus_fast", reason="dbus-fast not installed")
+
+from terok_shield.core.state import container_id_path
+from terok_shield.lib.dbus_bridge import (
+    BUS_NAME_PREFIX,
+    ShieldBridge,
+    _ShieldInterface,
+    bus_name_for_container,
+)
+
+from ..testnet import TEST_DOMAIN, TEST_IP1
+
+# ── Bus name construction ──────────────────────────────────
+
+
+def test_bus_name_prefix_is_well_formed() -> None:
+    """Bus name prefix follows MPRIS-style convention."""
+    assert BUS_NAME_PREFIX == "org.terok.Shield1.Container_"
+
+
+@pytest.mark.parametrize(
+    ("short_id", "expected"),
+    [
+        pytest.param("abc123def456", "org.terok.Shield1.Container_abc123def456", id="hex-id"),
+        pytest.param("0deadbeef12", "org.terok.Shield1.Container_0deadbeef12", id="starts-digit"),
+    ],
+)
+def test_bus_name_for_container(short_id: str, expected: str) -> None:
+    """bus_name_for_container() prefixes the short ID with Container_."""
+    assert bus_name_for_container(short_id) == expected
+
+
+# ── Container ID reading ───────────────────────────────────
+
+
+def test_container_id_read_from_state_dir(tmp_path: Path) -> None:
+    """ShieldBridge.container_id reads from state_dir/container.id."""
+    container_id_path(tmp_path).write_text("abc123def456\n")
+    bus = mock.MagicMock()
+    bridge = ShieldBridge(state_dir=tmp_path, container="test-ctr", bus=bus)
+    assert bridge.container_id == "abc123def456"
+
+
+def test_container_id_missing_raises(tmp_path: Path) -> None:
+    """ShieldBridge.container_id raises FileNotFoundError if not persisted."""
+    bus = mock.MagicMock()
+    bridge = ShieldBridge(state_dir=tmp_path, container="test-ctr", bus=bus)
+    with pytest.raises(FileNotFoundError, match="Container ID not found"):
+        _ = bridge.container_id
+
+
+def test_bus_name_property(tmp_path: Path) -> None:
+    """ShieldBridge.bus_name derives from the persisted container ID."""
+    container_id_path(tmp_path).write_text("0deadbeef12\n")
+    bus = mock.MagicMock()
+    bridge = ShieldBridge(state_dir=tmp_path, container="test-ctr", bus=bus)
+    assert bridge.bus_name == "org.terok.Shield1.Container_0deadbeef12"
+
+
+# ── Request ID mapping ─────────────────────────────────────
+
+
+def test_submit_verdict_writes_stdin(tmp_path: Path) -> None:
+    """submit_verdict() writes JSON to subprocess stdin."""
+    container_id_path(tmp_path).write_text("aabbccddee12\n")
+    bus = mock.MagicMock()
+    bridge = ShieldBridge(state_dir=tmp_path, container="myapp", bus=bus)
+
+    # Mock subprocess with a writable stdin
+    mock_stdin = mock.MagicMock()
+    mock_stdin.write = mock.MagicMock()
+    mock_stdin.drain = mock.AsyncMock()
+    mock_process = mock.MagicMock()
+    mock_process.stdin = mock_stdin
+    mock_process.returncode = None
+    bridge._process = mock_process
+
+    ok = asyncio.run(bridge.submit_verdict("myapp:42", "accept"))
+
+    assert ok is True
+    written = mock_stdin.write.call_args[0][0]
+    parsed = json.loads(written.decode())
+    assert parsed == {"type": "verdict", "id": 42, "action": "accept"}
+
+
+def test_submit_verdict_invalid_request_id(tmp_path: Path) -> None:
+    """submit_verdict() returns False for malformed request_id."""
+    container_id_path(tmp_path).write_text("aabbccddee12\n")
+    bus = mock.MagicMock()
+    bridge = ShieldBridge(state_dir=tmp_path, container="myapp", bus=bus)
+    bridge._process = mock.MagicMock()
+    bridge._process.stdin = mock.MagicMock()
+
+    assert asyncio.run(bridge.submit_verdict("no-colon", "accept")) is False
+    assert asyncio.run(bridge.submit_verdict("myapp:notanumber", "deny")) is False
+
+
+def test_submit_verdict_no_process(tmp_path: Path) -> None:
+    """submit_verdict() returns False when subprocess is not running."""
+    container_id_path(tmp_path).write_text("aabbccddee12\n")
+    bus = mock.MagicMock()
+    bridge = ShieldBridge(state_dir=tmp_path, container="myapp", bus=bus)
+
+    assert asyncio.run(bridge.submit_verdict("myapp:1", "accept")) is False
+
+
+# ── Event dispatch ─────────────────────────────────────────
+
+
+def test_dispatch_pending_event(tmp_path: Path) -> None:
+    """_dispatch_event() emits connection_blocked signal for 'pending' events."""
+    container_id_path(tmp_path).write_text("aabbccddee12\n")
+    bus = mock.MagicMock()
+    bridge = ShieldBridge(state_dir=tmp_path, container="myapp", bus=bus)
+
+    with mock.patch.object(bridge._interface, "connection_blocked") as sig:
+        bridge._dispatch_event(
+            {
+                "type": "pending",
+                "id": 7,
+                "dest": TEST_IP1,
+                "port": 443,
+                "proto": 6,
+                "domain": TEST_DOMAIN,
+            }
+        )
+        sig.assert_called_once_with("myapp", TEST_IP1, 443, 6, TEST_DOMAIN, "myapp:7")
+
+
+def test_dispatch_verdict_applied_event(tmp_path: Path) -> None:
+    """_dispatch_event() emits verdict_applied signal for 'verdict_applied' events."""
+    container_id_path(tmp_path).write_text("aabbccddee12\n")
+    bus = mock.MagicMock()
+    bridge = ShieldBridge(state_dir=tmp_path, container="myapp", bus=bus)
+
+    with mock.patch.object(bridge._interface, "verdict_applied") as sig:
+        bridge._dispatch_event(
+            {
+                "type": "verdict_applied",
+                "id": 7,
+                "dest": TEST_IP1,
+                "action": "accept",
+                "ok": True,
+            }
+        )
+        sig.assert_called_once_with("myapp", TEST_IP1, "myapp:7", "accept", True)
+
+
+def test_dispatch_unknown_event_type(tmp_path: Path) -> None:
+    """_dispatch_event() silently ignores unknown event types."""
+    container_id_path(tmp_path).write_text("aabbccddee12\n")
+    bus = mock.MagicMock()
+    bridge = ShieldBridge(state_dir=tmp_path, container="myapp", bus=bus)
+
+    # Should not raise
+    bridge._dispatch_event({"type": "unknown_thing", "data": 123})
+
+
+# ── Interface class ────────────────────────────────────────
+
+
+def test_shield_interface_name() -> None:
+    """_ShieldInterface uses the canonical Shield1 interface name."""
+    bridge = mock.MagicMock()
+    iface = _ShieldInterface(bridge)
+    assert iface.name == "org.terok.Shield1"
+
+
+def test_shield_interface_stores_bridge_reference() -> None:
+    """_ShieldInterface keeps a reference to the bridge for verdict routing."""
+    bridge = mock.MagicMock()
+    iface = _ShieldInterface(bridge)
+    assert iface._bridge is bridge
+
+
+# ── Lifecycle ──────────────────────────────────────────────
+
+
+def test_stop_terminates_subprocess(tmp_path: Path) -> None:
+    """stop() terminates the subprocess and unexports the interface."""
+    container_id_path(tmp_path).write_text("aabbccddee12\n")
+    bus = mock.MagicMock()
+    bridge = ShieldBridge(state_dir=tmp_path, container="myapp", bus=bus)
+
+    mock_process = mock.MagicMock()
+    mock_process.returncode = None
+    mock_process.terminate = mock.MagicMock()
+    mock_process.kill = mock.MagicMock()
+    mock_process.wait = mock.AsyncMock(return_value=0)
+    bridge._process = mock_process
+    bridge._read_task = None
+
+    asyncio.run(bridge.stop())
+
+    mock_process.terminate.assert_called_once()
+    bus.unexport.assert_called_once()
+
+
+def test_stop_without_process(tmp_path: Path) -> None:
+    """stop() is safe to call when no subprocess has been started."""
+    container_id_path(tmp_path).write_text("aabbccddee12\n")
+    bus = mock.MagicMock()
+    bridge = ShieldBridge(state_dir=tmp_path, container="myapp", bus=bus)
+
+    # Should not raise
+    asyncio.run(bridge.stop())

--- a/tests/unit/test_dbus_bridge.py
+++ b/tests/unit/test_dbus_bridge.py
@@ -13,6 +13,7 @@ from unittest import mock
 import pytest
 
 dbus_fast = pytest.importorskip("dbus_fast", reason="dbus-fast not installed")
+pytest.importorskip("terok_dbus", reason="terok-dbus not installed")
 
 from terok_shield.core.state import container_id_path
 from terok_shield.lib.dbus_bridge import (
@@ -441,19 +442,70 @@ def test_stop_already_exited_process(tmp_path: Path) -> None:
     proc.terminate.assert_not_called()
 
 
-def test_stop_inner_is_idempotent(tmp_path: Path) -> None:
-    """_stop_inner() can be called twice without error."""
+def test_stop_handles_process_lookup_error_on_terminate(tmp_path: Path) -> None:
+    """stop() handles ProcessLookupError when subprocess exits before terminate."""
+    bridge = _bridge(tmp_path)
+    proc = _mock_process()
+    proc.terminate.side_effect = ProcessLookupError
+    bridge._process = proc
+    bridge._read_task = None
+
+    asyncio.run(bridge.stop())
+    proc.terminate.assert_called_once()
+    proc.kill.assert_not_called()
+
+
+def test_stop_handles_process_lookup_error_on_kill(tmp_path: Path) -> None:
+    """stop() handles ProcessLookupError when subprocess exits before kill."""
+    bridge = _bridge(tmp_path)
+    proc = _mock_process()
+    proc.wait = mock.AsyncMock(side_effect=[TimeoutError(), 0])
+    proc.kill.side_effect = ProcessLookupError
+    bridge._process = proc
+    bridge._read_task = None
+
+    asyncio.run(bridge.stop())
+    proc.terminate.assert_called_once()
+    proc.kill.assert_called_once()
+
+
+def test_stop_reraises_cancelled_error(tmp_path: Path) -> None:
+    """stop() re-raises CancelledError after completing cleanup."""
+    bridge = _bridge(tmp_path)
+    proc = _mock_process()
+    proc.wait = mock.AsyncMock(side_effect=asyncio.CancelledError)
+    bridge._process = proc
+    bridge._read_task = None
+
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(bridge.stop())
+    bridge._bus.unexport.assert_called_once()
+
+
+def test_stop_is_idempotent(tmp_path: Path) -> None:
+    """stop() can be called twice without error."""
     bridge = _bridge(tmp_path)
     proc = _mock_process()
     bridge._process = proc
     bridge._read_task = None
 
-    asyncio.run(bridge._stop_inner())
-    # Process already exited after first call
+    asyncio.run(bridge.stop())
     proc.returncode = 0
-    asyncio.run(bridge._stop_inner())
+    asyncio.run(bridge.stop())
 
     proc.terminate.assert_called_once()
+
+
+def test_start_preloads_bus_name(tmp_path: Path) -> None:
+    """start() reads container_id before any side effects."""
+    bus = mock.MagicMock()
+    # No container.id file — should fail before export
+    bridge = ShieldBridge(state_dir=tmp_path, container="myapp", bus=bus)
+
+    with pytest.raises(FileNotFoundError):
+        asyncio.run(bridge.start())
+
+    bus.export.assert_not_called()
 
 
 def test_start_unexports_on_spawn_failure(tmp_path: Path) -> None:

--- a/tests/unit/test_dbus_bridge.py
+++ b/tests/unit/test_dbus_bridge.py
@@ -154,6 +154,27 @@ def test_submit_verdict_no_process(tmp_path: Path) -> None:
     assert asyncio.run(bridge.submit_verdict("myapp:1", "accept")) is False
 
 
+def test_submit_verdict_wrong_container(tmp_path: Path) -> None:
+    """submit_verdict() returns False when request_id targets a different container."""
+    bridge = _bridge(tmp_path)
+    bridge._process = _mock_process()
+    assert asyncio.run(bridge.submit_verdict("other:1", "accept")) is False
+
+
+def test_submit_verdict_invalid_action(tmp_path: Path) -> None:
+    """submit_verdict() returns False for actions other than accept/deny."""
+    bridge = _bridge(tmp_path)
+    bridge._process = _mock_process()
+    assert asyncio.run(bridge.submit_verdict("myapp:1", "maybe")) is False
+
+
+def test_submit_verdict_empty_container_prefix(tmp_path: Path) -> None:
+    """submit_verdict() returns False when request_id starts with a colon."""
+    bridge = _bridge(tmp_path)
+    bridge._process = _mock_process()
+    assert asyncio.run(bridge.submit_verdict(":1", "accept")) is False
+
+
 def test_submit_verdict_broken_pipe(tmp_path: Path) -> None:
     """submit_verdict() returns False on BrokenPipeError."""
     bridge = _bridge(tmp_path)
@@ -418,3 +439,104 @@ def test_stop_already_exited_process(tmp_path: Path) -> None:
     asyncio.run(bridge.stop())
 
     proc.terminate.assert_not_called()
+
+
+def test_start_unexports_on_spawn_failure(tmp_path: Path) -> None:
+    """start() rolls back the D-Bus export when subprocess creation fails."""
+    bridge = _bridge(tmp_path)
+
+    async def _test():
+        with mock.patch("asyncio.create_subprocess_exec", side_effect=OSError("no such binary")):
+            with pytest.raises(OSError, match="no such binary"):
+                await bridge.start()
+        # Interface was exported then unexported during rollback
+        bridge._bus.export.assert_called_once()
+        bridge._bus.unexport.assert_called_once()
+
+    asyncio.run(_test())
+
+
+def test_start_rollback_tolerates_unexport_failure(tmp_path: Path) -> None:
+    """start() rollback does not mask the original error when unexport also fails."""
+    bridge = _bridge(tmp_path)
+    bridge._bus.unexport.side_effect = RuntimeError("bus gone")
+
+    async def _test():
+        with mock.patch("asyncio.create_subprocess_exec", side_effect=FileNotFoundError("python")):
+            with pytest.raises(FileNotFoundError, match="python"):
+                await bridge.start()
+
+    asyncio.run(_test())
+
+
+# ── CLI entry point ────────────────────────────────────────
+
+
+def test_run_dbus_bridge_keyboard_interrupt(tmp_path: Path) -> None:
+    """run_dbus_bridge() exits cleanly on KeyboardInterrupt."""
+    from terok_shield.cli.dbus_bridge import run_dbus_bridge
+
+    container_id_path(tmp_path).write_text("aabbccddee12\n")
+
+    with mock.patch("terok_shield.cli.dbus_bridge._run_bridge", side_effect=KeyboardInterrupt):
+        # Should not raise
+        run_dbus_bridge(tmp_path, "myapp")
+
+
+def test_run_bridge_rejects_duplicate_bus_name(tmp_path: Path) -> None:
+    """_run_bridge exits with SystemExit(1) when bus name is already taken."""
+    from dbus_fast import RequestNameReply
+
+    from terok_shield.cli.dbus_bridge import _run_bridge
+
+    container_id_path(tmp_path).write_text("aabbccddee12\n")
+
+    mock_bus = mock.AsyncMock()
+    mock_bus.request_name = mock.AsyncMock(return_value=RequestNameReply.IN_QUEUE)
+    mock_bus.disconnect = mock.MagicMock()
+
+    mock_bus_cls = mock.MagicMock()
+    mock_bus_cls.return_value.connect = mock.AsyncMock(return_value=mock_bus)
+
+    async def _test():
+        with mock.patch("dbus_fast.aio.MessageBus", mock_bus_cls):
+            with pytest.raises(SystemExit) as exc_info:
+                await _run_bridge(tmp_path, "myapp")
+            assert exc_info.value.code == 1
+        mock_bus.disconnect.assert_called_once()
+
+    asyncio.run(_test())
+
+
+def test_run_bridge_starts_and_stops_on_signal(tmp_path: Path) -> None:
+    """_run_bridge acquires bus name, starts bridge, stops on SIGTERM."""
+    import signal as _signal
+
+    from dbus_fast import RequestNameReply
+
+    from terok_shield.cli.dbus_bridge import _run_bridge
+
+    container_id_path(tmp_path).write_text("aabbccddee12\n")
+
+    mock_bus = mock.AsyncMock()
+    mock_bus.request_name = mock.AsyncMock(return_value=RequestNameReply.PRIMARY_OWNER)
+    mock_bus.disconnect = mock.MagicMock()
+    mock_bus.export = mock.MagicMock()
+    mock_bus.unexport = mock.MagicMock()
+
+    mock_bus_cls = mock.MagicMock()
+    mock_bus_cls.return_value.connect = mock.AsyncMock(return_value=mock_bus)
+
+    async def _test():
+        with mock.patch("dbus_fast.aio.MessageBus", mock_bus_cls):
+            task = asyncio.create_task(_run_bridge(tmp_path, "myapp"))
+            # Let the bridge start and register signal handlers
+            await asyncio.sleep(0.05)
+            # Send SIGTERM to trigger the stop event
+            _signal.raise_signal(_signal.SIGTERM)
+            await asyncio.wait_for(task, timeout=5.0)
+
+        mock_bus.request_name.assert_awaited_once()
+        mock_bus.disconnect.assert_called()
+
+    asyncio.run(_test())

--- a/tests/unit/test_dbus_bridge.py
+++ b/tests/unit/test_dbus_bridge.py
@@ -345,11 +345,9 @@ def test_start_exports_interface_and_spawns_subprocess(tmp_path: Path) -> None:
             spawn.assert_awaited_once()
             args = spawn.call_args[0]
             assert "terok_shield.cli.interactive" in args
+            await bridge.stop()
 
     asyncio.run(_test())
-    # Cleanup
-    if bridge._read_task and not bridge._read_task.done():
-        asyncio.run(bridge.stop())
 
 
 def test_start_passes_raw_env(tmp_path: Path) -> None:
@@ -362,10 +360,9 @@ def test_start_passes_raw_env(tmp_path: Path) -> None:
             await bridge.start()
             kwargs = spawn.call_args[1]
             assert kwargs["env"]["_TEROK_SHIELD_NFLOG_RAW"] == "1"
+            await bridge.stop()
 
     asyncio.run(_test())
-    if bridge._read_task and not bridge._read_task.done():
-        asyncio.run(bridge.stop())
 
 
 def test_stop_terminates_subprocess(tmp_path: Path) -> None:

--- a/tests/unit/test_dbus_bridge.py
+++ b/tests/unit/test_dbus_bridge.py
@@ -24,6 +24,44 @@ from terok_shield.lib.dbus_bridge import (
 
 from ..testnet import TEST_DOMAIN, TEST_IP1
 
+# ── Helpers ────────────────────────────────────────────────
+
+
+def _bridge(tmp_path: Path, container: str = "myapp") -> ShieldBridge:
+    """Create a ShieldBridge with a stubbed container ID and mock bus."""
+    container_id_path(tmp_path).write_text("aabbccddee12\n")
+    return ShieldBridge(state_dir=tmp_path, container=container, bus=mock.MagicMock())
+
+
+def _mock_process(
+    *,
+    stdout_lines: list[bytes] | None = None,
+    returncode: int | None = None,
+) -> mock.MagicMock:
+    """Build a mock asyncio.subprocess.Process with controllable stdout."""
+    proc = mock.MagicMock()
+    proc.returncode = returncode
+    proc.pid = 42
+    proc.terminate = mock.MagicMock()
+    proc.kill = mock.MagicMock()
+    proc.wait = mock.AsyncMock(return_value=0)
+
+    proc.stdin = mock.MagicMock()
+    proc.stdin.write = mock.MagicMock()
+    proc.stdin.drain = mock.AsyncMock()
+
+    if stdout_lines is not None:
+
+        async def _iter():
+            for line in stdout_lines:
+                yield line
+
+        proc.stdout = _iter()
+    else:
+        proc.stdout = mock.MagicMock()
+    return proc
+
+
 # ── Bus name construction ──────────────────────────────────
 
 
@@ -55,6 +93,15 @@ def test_container_id_read_from_state_dir(tmp_path: Path) -> None:
     assert bridge.container_id == "abc123def456"
 
 
+def test_container_id_cached_after_first_read(tmp_path: Path) -> None:
+    """container_id is cached — the file is only read once."""
+    container_id_path(tmp_path).write_text("abc123def456\n")
+    bridge = _bridge(tmp_path)
+    _ = bridge.container_id
+    container_id_path(tmp_path).write_text("changed\n")
+    assert bridge.container_id == "aabbccddee12"  # still cached from _bridge helper
+
+
 def test_container_id_missing_raises(tmp_path: Path) -> None:
     """ShieldBridge.container_id raises FileNotFoundError if not persisted."""
     bus = mock.MagicMock()
@@ -71,51 +118,60 @@ def test_bus_name_property(tmp_path: Path) -> None:
     assert bridge.bus_name == "org.terok.Shield1.Container_0deadbeef12"
 
 
-# ── Request ID mapping ─────────────────────────────────────
+# ── submit_verdict ─────────────────────────────────────────
 
 
 def test_submit_verdict_writes_stdin(tmp_path: Path) -> None:
     """submit_verdict() writes JSON to subprocess stdin."""
-    container_id_path(tmp_path).write_text("aabbccddee12\n")
-    bus = mock.MagicMock()
-    bridge = ShieldBridge(state_dir=tmp_path, container="myapp", bus=bus)
-
-    # Mock subprocess with a writable stdin
-    mock_stdin = mock.MagicMock()
-    mock_stdin.write = mock.MagicMock()
-    mock_stdin.drain = mock.AsyncMock()
-    mock_process = mock.MagicMock()
-    mock_process.stdin = mock_stdin
-    mock_process.returncode = None
-    bridge._process = mock_process
+    bridge = _bridge(tmp_path)
+    bridge._process = _mock_process()
 
     ok = asyncio.run(bridge.submit_verdict("myapp:42", "accept"))
 
     assert ok is True
-    written = mock_stdin.write.call_args[0][0]
+    written = bridge._process.stdin.write.call_args[0][0]
     parsed = json.loads(written.decode())
     assert parsed == {"type": "verdict", "id": 42, "action": "accept"}
 
 
-def test_submit_verdict_invalid_request_id(tmp_path: Path) -> None:
-    """submit_verdict() returns False for malformed request_id."""
-    container_id_path(tmp_path).write_text("aabbccddee12\n")
-    bus = mock.MagicMock()
-    bridge = ShieldBridge(state_dir=tmp_path, container="myapp", bus=bus)
-    bridge._process = mock.MagicMock()
-    bridge._process.stdin = mock.MagicMock()
-
+def test_submit_verdict_invalid_request_id_no_colon(tmp_path: Path) -> None:
+    """submit_verdict() returns False when request_id has no colon."""
+    bridge = _bridge(tmp_path)
+    bridge._process = _mock_process()
     assert asyncio.run(bridge.submit_verdict("no-colon", "accept")) is False
+
+
+def test_submit_verdict_invalid_request_id_non_integer(tmp_path: Path) -> None:
+    """submit_verdict() returns False when packet ID is not an integer."""
+    bridge = _bridge(tmp_path)
+    bridge._process = _mock_process()
     assert asyncio.run(bridge.submit_verdict("myapp:notanumber", "deny")) is False
 
 
 def test_submit_verdict_no_process(tmp_path: Path) -> None:
     """submit_verdict() returns False when subprocess is not running."""
-    container_id_path(tmp_path).write_text("aabbccddee12\n")
-    bus = mock.MagicMock()
-    bridge = ShieldBridge(state_dir=tmp_path, container="myapp", bus=bus)
+    bridge = _bridge(tmp_path)
+    assert asyncio.run(bridge.submit_verdict("myapp:1", "accept")) is False
+
+
+def test_submit_verdict_broken_pipe(tmp_path: Path) -> None:
+    """submit_verdict() returns False on BrokenPipeError."""
+    bridge = _bridge(tmp_path)
+    proc = _mock_process()
+    proc.stdin.write.side_effect = BrokenPipeError
+    bridge._process = proc
 
     assert asyncio.run(bridge.submit_verdict("myapp:1", "accept")) is False
+
+
+def test_submit_verdict_connection_reset(tmp_path: Path) -> None:
+    """submit_verdict() returns False on ConnectionResetError."""
+    bridge = _bridge(tmp_path)
+    proc = _mock_process()
+    proc.stdin.drain = mock.AsyncMock(side_effect=ConnectionResetError)
+    bridge._process = proc
+
+    assert asyncio.run(bridge.submit_verdict("myapp:1", "deny")) is False
 
 
 # ── Event dispatch ─────────────────────────────────────────
@@ -123,9 +179,7 @@ def test_submit_verdict_no_process(tmp_path: Path) -> None:
 
 def test_dispatch_pending_event(tmp_path: Path) -> None:
     """_dispatch_event() emits connection_blocked signal for 'pending' events."""
-    container_id_path(tmp_path).write_text("aabbccddee12\n")
-    bus = mock.MagicMock()
-    bridge = ShieldBridge(state_dir=tmp_path, container="myapp", bus=bus)
+    bridge = _bridge(tmp_path)
 
     with mock.patch.object(bridge._interface, "connection_blocked") as sig:
         bridge._dispatch_event(
@@ -143,9 +197,7 @@ def test_dispatch_pending_event(tmp_path: Path) -> None:
 
 def test_dispatch_verdict_applied_event(tmp_path: Path) -> None:
     """_dispatch_event() emits verdict_applied signal for 'verdict_applied' events."""
-    container_id_path(tmp_path).write_text("aabbccddee12\n")
-    bus = mock.MagicMock()
-    bridge = ShieldBridge(state_dir=tmp_path, container="myapp", bus=bus)
+    bridge = _bridge(tmp_path)
 
     with mock.patch.object(bridge._interface, "verdict_applied") as sig:
         bridge._dispatch_event(
@@ -162,12 +214,81 @@ def test_dispatch_verdict_applied_event(tmp_path: Path) -> None:
 
 def test_dispatch_unknown_event_type(tmp_path: Path) -> None:
     """_dispatch_event() silently ignores unknown event types."""
-    container_id_path(tmp_path).write_text("aabbccddee12\n")
-    bus = mock.MagicMock()
-    bridge = ShieldBridge(state_dir=tmp_path, container="myapp", bus=bus)
-
-    # Should not raise
+    bridge = _bridge(tmp_path)
     bridge._dispatch_event({"type": "unknown_thing", "data": 123})
+
+
+# ── _read_loop ─────────────────────────────────────────────
+
+
+def test_read_loop_dispatches_json_events(tmp_path: Path) -> None:
+    """_read_loop() parses JSON lines and dispatches events."""
+    bridge = _bridge(tmp_path)
+    pending_line = (
+        json.dumps(
+            {
+                "type": "pending",
+                "id": 1,
+                "dest": TEST_IP1,
+                "port": 443,
+                "proto": 6,
+                "domain": TEST_DOMAIN,
+            }
+        ).encode()
+        + b"\n"
+    )
+    bridge._process = _mock_process(stdout_lines=[pending_line])
+
+    with mock.patch.object(bridge._interface, "connection_blocked") as sig:
+        asyncio.run(bridge._read_loop())
+        sig.assert_called_once()
+
+
+def test_read_loop_skips_blank_lines(tmp_path: Path) -> None:
+    """_read_loop() skips blank lines without dispatching."""
+    bridge = _bridge(tmp_path)
+    bridge._process = _mock_process(stdout_lines=[b"\n", b"  \n"])
+
+    with mock.patch.object(bridge, "_dispatch_event") as dispatch:
+        asyncio.run(bridge._read_loop())
+        dispatch.assert_not_called()
+
+
+def test_read_loop_skips_non_json_lines(tmp_path: Path) -> None:
+    """_read_loop() warns on non-JSON lines and continues."""
+    bridge = _bridge(tmp_path)
+    bridge._process = _mock_process(stdout_lines=[b"not json\n"])
+
+    with mock.patch.object(bridge, "_dispatch_event") as dispatch:
+        asyncio.run(bridge._read_loop())
+        dispatch.assert_not_called()
+
+
+def test_read_loop_handles_exception(tmp_path: Path) -> None:
+    """_read_loop() logs exceptions from dispatch and exits cleanly."""
+    bridge = _bridge(tmp_path)
+    line = json.dumps({"type": "pending", "id": 1}).encode() + b"\n"
+    bridge._process = _mock_process(stdout_lines=[line])
+
+    with mock.patch.object(bridge, "_dispatch_event", side_effect=RuntimeError("boom")):
+        # Should not raise — exception is caught and logged
+        asyncio.run(bridge._read_loop())
+
+
+def test_read_loop_early_exit_no_process(tmp_path: Path) -> None:
+    """_read_loop() returns immediately when process is None."""
+    bridge = _bridge(tmp_path)
+    bridge._process = None
+    asyncio.run(bridge._read_loop())
+
+
+def test_read_loop_early_exit_no_stdout(tmp_path: Path) -> None:
+    """_read_loop() returns immediately when stdout is None."""
+    bridge = _bridge(tmp_path)
+    proc = mock.MagicMock()
+    proc.stdout = None
+    bridge._process = proc
+    asyncio.run(bridge._read_loop())
 
 
 # ── Interface class ────────────────────────────────────────
@@ -187,34 +308,113 @@ def test_shield_interface_stores_bridge_reference() -> None:
     assert iface._bridge is bridge
 
 
-# ── Lifecycle ──────────────────────────────────────────────
+# ── start / stop lifecycle ─────────────────────────────────
+
+
+def test_start_exports_interface_and_spawns_subprocess(tmp_path: Path) -> None:
+    """start() exports the D-Bus interface and spawns the interactive subprocess."""
+    bridge = _bridge(tmp_path)
+    proc = _mock_process(stdout_lines=[])
+
+    async def _test():
+        with mock.patch("asyncio.create_subprocess_exec", return_value=proc) as spawn:
+            await bridge.start()
+            bridge._bus.export.assert_called_once()
+            spawn.assert_awaited_once()
+            args = spawn.call_args[0]
+            assert "terok_shield.cli.interactive" in args
+
+    asyncio.run(_test())
+    # Cleanup
+    if bridge._read_task and not bridge._read_task.done():
+        asyncio.run(bridge.stop())
+
+
+def test_start_passes_raw_env(tmp_path: Path) -> None:
+    """start() sets _TEROK_SHIELD_NFLOG_RAW=1 in the subprocess environment."""
+    bridge = _bridge(tmp_path)
+    proc = _mock_process(stdout_lines=[])
+
+    async def _test():
+        with mock.patch("asyncio.create_subprocess_exec", return_value=proc) as spawn:
+            await bridge.start()
+            kwargs = spawn.call_args[1]
+            assert kwargs["env"]["_TEROK_SHIELD_NFLOG_RAW"] == "1"
+
+    asyncio.run(_test())
+    if bridge._read_task and not bridge._read_task.done():
+        asyncio.run(bridge.stop())
 
 
 def test_stop_terminates_subprocess(tmp_path: Path) -> None:
     """stop() terminates the subprocess and unexports the interface."""
-    container_id_path(tmp_path).write_text("aabbccddee12\n")
-    bus = mock.MagicMock()
-    bridge = ShieldBridge(state_dir=tmp_path, container="myapp", bus=bus)
-
-    mock_process = mock.MagicMock()
-    mock_process.returncode = None
-    mock_process.terminate = mock.MagicMock()
-    mock_process.kill = mock.MagicMock()
-    mock_process.wait = mock.AsyncMock(return_value=0)
-    bridge._process = mock_process
+    bridge = _bridge(tmp_path)
+    proc = _mock_process()
+    bridge._process = proc
     bridge._read_task = None
 
     asyncio.run(bridge.stop())
 
-    mock_process.terminate.assert_called_once()
-    bus.unexport.assert_called_once()
+    proc.terminate.assert_called_once()
+    bridge._bus.unexport.assert_called_once()
+
+
+def test_stop_cancels_read_task(tmp_path: Path) -> None:
+    """stop() cancels a running read task before terminating the subprocess."""
+    bridge = _bridge(tmp_path)
+    proc = _mock_process()
+    bridge._process = proc
+
+    async def _test():
+        # Create a real long-running task that we can cancel
+        stall = asyncio.Event()
+        task = asyncio.create_task(stall.wait())
+        bridge._read_task = task
+        await bridge.stop()
+        assert task.cancelled()
+
+    asyncio.run(_test())
+
+
+def test_stop_kills_on_timeout(tmp_path: Path) -> None:
+    """stop() escalates to kill() when terminate() does not exit in time."""
+    bridge = _bridge(tmp_path)
+    proc = _mock_process()
+    # wait() raises TimeoutError on the first call (wait_for wrapper), succeeds on second
+    proc.wait = mock.AsyncMock(side_effect=[TimeoutError(), 0])
+    bridge._process = proc
+    bridge._read_task = None
+
+    asyncio.run(bridge.stop())
+
+    proc.terminate.assert_called_once()
+    proc.kill.assert_called_once()
+
+
+def test_stop_logs_unexport_failure(tmp_path: Path) -> None:
+    """stop() logs a debug message when unexport raises."""
+    bridge = _bridge(tmp_path)
+    bridge._bus.unexport.side_effect = RuntimeError("no such object")
+    bridge._process = None
+    bridge._read_task = None
+
+    # Should not raise
+    asyncio.run(bridge.stop())
 
 
 def test_stop_without_process(tmp_path: Path) -> None:
     """stop() is safe to call when no subprocess has been started."""
-    container_id_path(tmp_path).write_text("aabbccddee12\n")
-    bus = mock.MagicMock()
-    bridge = ShieldBridge(state_dir=tmp_path, container="myapp", bus=bus)
-
-    # Should not raise
+    bridge = _bridge(tmp_path)
     asyncio.run(bridge.stop())
+
+
+def test_stop_already_exited_process(tmp_path: Path) -> None:
+    """stop() does not call terminate when the subprocess has already exited."""
+    bridge = _bridge(tmp_path)
+    proc = _mock_process(returncode=0)
+    bridge._process = proc
+    bridge._read_task = None
+
+    asyncio.run(bridge.stop())
+
+    proc.terminate.assert_not_called()

--- a/tests/unit/test_hook_mode_class.py
+++ b/tests/unit/test_hook_mode_class.py
@@ -79,7 +79,9 @@ def make_hook_mode(make_config: ConfigFactory) -> HookModeHarnessFactory:
         ruleset: mock.MagicMock | None = None,
     ) -> HookModeHarness:
         config = config or make_config()
-        runner = runner or mock.MagicMock()
+        if runner is None:
+            runner = mock.MagicMock()
+            runner.podman_inspect.return_value = "aabbccddee11223344556677"
         audit = audit or mock.MagicMock()
         dns = dns or mock.MagicMock()
         profiles = profiles or mock.MagicMock()
@@ -1241,6 +1243,32 @@ def test_pre_start_with_denied_ips_includes_deny_elements(
     ruleset = state.ruleset_path(config.state_dir).read_text()
     assert "deny_v4" in ruleset
     assert TEST_IP1 in ruleset
+
+
+# ── Container ID persistence ─────────────────────────────
+
+
+@mock.patch("terok_shield.core.mode_hook.has_global_hooks", return_value=True)
+def test_pre_start_persists_container_id(
+    _has_hooks: mock.Mock,
+    monkeypatch: pytest.MonkeyPatch,
+    make_hook_mode: HookModeHarnessFactory,
+    make_config: ConfigFactory,
+) -> None:
+    """pre_start() persists the short container ID to state_dir/container.id."""
+    _set_euid(monkeypatch, 0)
+    config = make_config()
+    harness = make_hook_mode(config=config)
+    harness.runner.run.return_value = _MODERN_PODMAN_INFO
+    harness.runner.podman_inspect.return_value = "abc123def456789abcdef0"
+    harness.profiles.compose_profiles.return_value = []
+
+    harness.mode.pre_start("test", ["dev-standard"])
+
+    harness.runner.podman_inspect.assert_any_call("test", "{{.Id}}")
+    id_file = state.container_id_path(config.state_dir)
+    assert id_file.is_file()
+    assert id_file.read_text().strip() == "abc123def456"
 
 
 def test_shield_up_interactive_uses_interactive_ruleset(

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -11,6 +11,7 @@ import pytest
 from terok_shield.core.state import (
     BUNDLE_VERSION,
     audit_path,
+    container_id_path,
     denied_domains_path,
     deny_path,
     dns_tier_path,
@@ -57,6 +58,7 @@ def test_bundle_version_is_positive_int() -> None:
         pytest.param(dns_tier_path, FAKE_STATE_DIR / "dns.tier", id="dns-tier"),
         pytest.param(live_domains_path, FAKE_STATE_DIR / "live.domains", id="live-domains"),
         pytest.param(denied_domains_path, FAKE_STATE_DIR / "denied.domains", id="denied-domains"),
+        pytest.param(container_id_path, FAKE_STATE_DIR / "container.id", id="container-id"),
     ],
 )
 def test_path_derivation_functions(


### PR DESCRIPTION
## Summary

Closes #165. Part of the interactive egress control epic (terok-ai/terok#400, phase 4c).

- **Container ID persistence** — `pre_start()` now writes the short (12-char) podman container ID to `state_dir/container.id`, used as the D-Bus bus name suffix
- **ShieldBridge** (`lib/dbus_bridge.py`) — Spawns `InteractiveSession` as a subprocess (JSON-lines mode via nsenter), translates events to `org.terok.Shield1` D-Bus signals, routes operator verdicts from D-Bus method calls back to the subprocess
- **MPRIS-style bus names** — `org.terok.Shield1.Container_<short_id>` allows unlimited coexistence of standalone + orchestrated bridges with no coordination daemon
- **CLI entry point** (`cli/dbus_bridge.py`) — `shield dbus-bridge <container>` acquires the per-container bus name and runs until interrupted
- **Optional dependencies** — `dbus-fast` + `terok-dbus` in a `[dbus]` Poetry group (`poetry install --with dbus`)
- **Module boundaries** — tach entries for both `lib.dbus_bridge` (support) and `cli.dbus_bridge` (cli)
- **Tests** — 16 bridge unit tests + container ID persistence test; all 1008 unit tests pass

### Design highlights

- Bridge class does **not** own the bus name — the caller decides (standalone CLI vs orchestrator), enabling the TUI to manage multiple bridges on one bus connection
- D-Bus interface uses `dbus_fast.service.ServiceInterface` with the canonical `SHIELD_XML` from `terok-dbus`
- `ruff F821` suppressed per-file for `dbus_bridge.py` since `dbus-fast` requires D-Bus type signature strings (`"s"`, `"q"`, `"b"`) as annotations

## Test plan

- [x] `make check` passes (lint, unit tests, tach, docstrings, security, deadcode, reuse)
- [ ] Manual: `poetry install --with dbus && shield dbus-bridge <container>` with a running shielded container
- [ ] Manual: `dbus-monitor "interface='org.terok.Shield1'"` shows `ConnectionBlocked` signals
- [ ] Manual: `busctl call` to send `Verdict` and observe `VerdictApplied` signal

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-container D-Bus bridge and new dbus-bridge CLI command to run it.
  * Persist container short-ID to state for stable bridge identification and per-container bus naming.

* **Chores**
  * Bumped package version to 0.6.0.
  * Added optional D-Bus dependency group and enabled it in CI/workflows.
  * Suppressed a linter warning for D-Bus type-signature annotations.
  * Declared new bridge modules in project metadata.

* **Tests**
  * Comprehensive unit tests for bridge naming, lifecycle, I/O, event dispatch, CLI entry, and state persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->