### PR TITLE
fix: add keyring warning with proper TOML format in run-matrix.sh

### DIFF
--- a/tests/containers/run-matrix.sh
+++ b/tests/containers/run-matrix.sh
@@ -83,6 +83,33 @@ usage() {
     return 0
 }
 
+warn_keyring() {
+    # Warn when the host's containers.conf does not disable kernel keyrings.
+    # Matrix runs cycle many containers and can exhaust the per-user 200-key
+    # quota, causing misleading "Disk quota exceeded" (EDQUOT) from crun.
+    local conf="${CONTAINERS_CONF:-}"
+    if [[ -z "$conf" ]]; then
+        for candidate in "$HOME/.config/containers/containers.conf" \
+                         /etc/containers/containers.conf; do
+            [[ -f "$candidate" ]] && conf="$candidate" && break
+        done
+    fi
+    if [[ -z "$conf" ]] || ! grep -qE '^\s*keyring\s*=\s*false' "$conf" 2>/dev/null; then
+        echo -e "${C_YELLOW}WARNING: kernel keyring is not disabled in containers.conf"
+        echo -e ""
+        echo -e "  Matrix tests create many containers and may exhaust the per-user"
+        echo -e "  keyring quota (200 keys), causing spurious EDQUOT errors."
+        echo -e ""
+        echo -e "  Add to ${C_BOLD}~/.config/containers/containers.conf${C_YELLOW}:"
+        echo -e ""
+        echo -e "    ${C_BOLD}[containers]${C_YELLOW}"
+        echo -e "    ${C_BOLD}keyring = false${C_YELLOW}"
+        echo -e ""
+        echo -e "  See: https://terok-ai.github.io/terok/kernel-keyring/${C_RESET}"
+        echo ""
+    fi
+}
+
 build_image() {
     local name="$1"
     local file="$SCRIPT_DIR/Containerfile.${DISTROS[$name]}"
@@ -252,6 +279,8 @@ for target in "${TARGETS[@]}"; do
         exit 1
     fi
 done
+
+warn_keyring
 
 for target in "${TARGETS[@]}"; do
     build_image "$target"


### PR DESCRIPTION
## Summary

- Add `warn_keyring()` pre-flight check to `run-matrix.sh`
- Show the TOML fix as a proper multi-line block instead of the ambiguous single-line `[containers] keyring = false` which users might paste literally

Companion PRs across all repos with the same change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test infrastructure with automated configuration validation. Test script startup now validates container configuration settings related to kernel keyrings and displays an informative warning message with recommended configuration adjustments and example configuration snippets when the setting is not found, needs modification, or cannot be properly validated during startup checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->