### PR TITLE
fix: restore registry re-exports dropped by tach layer split

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.poetry]
 name = "terok-shield"
-version = "0.6.0"
+version = "0.6.1"
 description = "nftables-based egress firewalling for Podman containers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/terok_shield/__init__.py
+++ b/src/terok_shield/__init__.py
@@ -68,6 +68,10 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "ShieldNeedsSetup": ("terok_shield.core.run", "ShieldNeedsSetup"),
     "SubprocessRunner": ("terok_shield.core.run", "SubprocessRunner"),
     "setup_global_hooks": ("terok_shield.core.hook_install", "setup_global_hooks"),
+    # CLI registry — re-exported for terok integration layer
+    "ArgDef": ("terok_shield.cli.registry", "ArgDef"),
+    "COMMANDS": ("terok_shield.cli.registry", "COMMANDS"),
+    "CommandDef": ("terok_shield.cli.registry", "CommandDef"),
 }
 
 
@@ -397,8 +401,11 @@ class Shield:
 
 
 __all__ = [
+    "ArgDef",
     "AuditFileConfig",
     "AuditLogger",
+    "COMMANDS",
+    "CommandDef",
     "CommandRunner",
     "DigNotFoundError",
     "DnsResolver",

--- a/tests/unit/test_api_surface.py
+++ b/tests/unit/test_api_surface.py
@@ -23,8 +23,11 @@ from terok_shield import (
 )
 
 EXPECTED_ALL = [
+    "ArgDef",
     "AuditFileConfig",
     "AuditLogger",
+    "COMMANDS",
+    "CommandDef",
     "CommandRunner",
     "DigNotFoundError",
     "DnsResolver",


### PR DESCRIPTION
## Summary

- Restores `COMMANDS`, `ArgDef`, and `CommandDef` re-exports from `terok_shield.__init__` via lazy `__getattr__` dispatch
- These were inadvertently dropped during the tach layer refactoring (PR #167), breaking `from terok_shield import COMMANDS, ArgDef, CommandDef` in downstream terok (terok-ai/terok#608)
- Updates the API surface snapshot test to include the three new entries
- Bumps version to 0.6.1

## Test plan

- [x] `make check` passes (lint, unit tests, tach, docstrings, reuse)
- [x] `python -c "from terok_shield import COMMANDS, ArgDef, CommandDef, ExecError"` succeeds
- [ ] CI green on this PR
- [ ] After release: update terok-sandbox → terok-agent → terok wheel chain to pick up 0.6.1

Fixes terok-ai/terok#608

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Exposed CLI registry symbols (`ArgDef`, `COMMANDS`, `CommandDef`) in the public API for broader accessibility.

* **Chores**
  * Bumped package version from 0.6.0 to 0.6.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->