### PR TITLE
fix: move container ID persistence from pre_start to OCI hook

### DIFF
--- a/src/terok_shield/core/mode_hook.py
+++ b/src/terok_shield/core/mode_hook.py
@@ -257,10 +257,6 @@ class HookMode:
             hooks_dir=state.hooks_dir(sd),
         )
 
-        # Persist container ID for D-Bus bridge bus name derivation
-        container_id = self._runner.podman_inspect(container, "{{.Id}}")
-        state.container_id_path(sd).write_text(container_id[:12] + "\n")
-
         # Detect DNS tier and upstream DNS
         tier = self._detect_dns_tier()
         mode = info.network_mode or "pasta"

--- a/src/terok_shield/resources/hook_entrypoint.py
+++ b/src/terok_shield/resources/hook_entrypoint.py
@@ -350,6 +350,13 @@ def main() -> int:
         if not pid:
             _log("terok-shield hook: missing pid in OCI state", log_path)
             return 1
+
+        # Persist container ID for D-Bus bridge bus name derivation.
+        # The OCI state includes "id" (full 64-char hex); store the short form.
+        container_id = str(oci.get("id") or "")
+        if container_id:
+            (sd / "container.id").write_text(container_id[:12] + "\n")
+
         _createruntime(pid, sd)
     except Exception as exc:  # noqa: BLE001
         _log(f"terok-shield hook: {exc}", log_path)

--- a/tests/unit/test_hook_entrypoint.py
+++ b/tests/unit/test_hook_entrypoint.py
@@ -40,10 +40,16 @@ _ROUTE_NO_DEFAULT = (
 )
 
 
-def _oci_json(pid: int = 42, state_dir: str = "/tmp/sd", version: int = 4) -> str:
+def _oci_json(
+    pid: int = 42,
+    state_dir: str = "/tmp/sd",
+    version: int = 4,
+    container_id: str = "abc123def456789abcdef0123456789abcdef0123456789abcdef0123456789a",
+) -> str:
     """Return a minimal OCI state JSON for hook_entrypoint.main()."""
     return json.dumps(
         {
+            "id": container_id,
             "pid": pid,
             "annotations": {
                 "terok.shield.state_dir": state_dir,
@@ -668,6 +674,22 @@ def test_main_dispatches_createruntime_and_returns_0(tmp_path: Path) -> None:
 
     assert rc == 0
     mock_cr.assert_called_once_with("42", sd)
+
+
+def test_main_persists_container_id(tmp_path: Path) -> None:
+    """main() writes the short container ID to state_dir/container.id."""
+    sd = tmp_path / "sd"
+    sd.mkdir()
+    full_id = "abc123def456789abcdef0123456789abcdef0123456789abcdef0123456789a"
+    oci = _oci_json(pid=42, state_dir=str(sd), container_id=full_id)
+
+    with mock.patch("terok_shield.resources.hook_entrypoint._createruntime"):
+        rc = _run_main(oci)
+
+    assert rc == 0
+    id_file = sd / "container.id"
+    assert id_file.is_file()
+    assert id_file.read_text().strip() == "abc123def456"
 
 
 def test_main_dispatches_poststop_and_returns_0(tmp_path: Path) -> None:

--- a/tests/unit/test_hook_mode_class.py
+++ b/tests/unit/test_hook_mode_class.py
@@ -1249,26 +1249,23 @@ def test_pre_start_with_denied_ips_includes_deny_elements(
 
 
 @mock.patch("terok_shield.core.mode_hook.has_global_hooks", return_value=True)
-def test_pre_start_persists_container_id(
+def test_pre_start_does_not_inspect_container(
     _has_hooks: mock.Mock,
     monkeypatch: pytest.MonkeyPatch,
     make_hook_mode: HookModeHarnessFactory,
     make_config: ConfigFactory,
 ) -> None:
-    """pre_start() persists the short container ID to state_dir/container.id."""
+    """pre_start() must not call podman inspect (container doesn't exist yet)."""
     _set_euid(monkeypatch, 0)
     config = make_config()
     harness = make_hook_mode(config=config)
     harness.runner.run.return_value = _MODERN_PODMAN_INFO
-    harness.runner.podman_inspect.return_value = "abc123def456789abcdef0"
     harness.profiles.compose_profiles.return_value = []
 
     harness.mode.pre_start("test", ["dev-standard"])
 
-    harness.runner.podman_inspect.assert_any_call("test", "{{.Id}}")
-    id_file = state.container_id_path(config.state_dir)
-    assert id_file.is_file()
-    assert id_file.read_text().strip() == "abc123def456"
+    harness.runner.podman_inspect.assert_not_called()
+    assert not state.container_id_path(config.state_dir).exists()
 
 
 def test_shield_up_interactive_uses_interactive_ruleset(


### PR DESCRIPTION
## Summary

- `pre_start()` called `podman inspect` to get the container ID, but `pre_start` runs before `podman run` — the container doesn't exist yet, causing `ExecError: no such object`
- Moved container ID persistence to the OCI hook's `createRuntime` stage, where the container ID is already available in the OCI runtime state JSON (`oci["id"]`)
- Updated tests: replaced the pre_start inspect assertion with a negative test, added a hook-level test for container.id writing

## Test plan

- [x] `make check` passes (lint, 993 unit tests, tach, docstrings, reuse)
- [ ] Manual: `terok task start` no longer crashes on shield pre_start

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Container ID persistence mechanism has been reorganized to execute at the proper stage in the container lifecycle. The container identification process now occurs during the runtime creation phase rather than during initial setup phases, ensuring more reliable and accurate container tracking throughout the initialization sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->