### PR TITLE
refactor: improve readability of hook_install, watch, and state modules

### DIFF
--- a/src/terok_shield/cli/watch.py
+++ b/src/terok_shield/cli/watch.py
@@ -26,8 +26,10 @@ _running = True
 def run_watch(state_dir: Path, container: str) -> None:
     """Stream blocked-access events as JSON lines to stdout.
 
-    Validates the dnsmasq tier, opens the watchers, and enters a
-    ``select``-based event loop.
+    Only meaningful under the dnsmasq tier — the query log and nftset
+    integration that feed the watchers do not exist in the dig/getent
+    tiers.  Uses ``select`` so a single thread can multiplex the DNS
+    log, audit log, and NFLOG socket without blocking on any one source.
 
     Args:
         state_dir: Per-container state directory.

--- a/src/terok_shield/cli/watch.py
+++ b/src/terok_shield/cli/watch.py
@@ -1,12 +1,11 @@
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
-"""``shield watch`` entry point — signal handling and select loop.
+"""``shield watch`` — stream blocked-access events as JSON lines.
 
-This module contains the CLI/tool portion of the watch subsystem:
-signal handlers, tier validation, and the blocking ``run_watch()``
-event loop.  The library-level watcher classes live in
-:mod:`terok_shield.lib.watchers`.
+Tails the dnsmasq query log, per-container audit log, and (optionally)
+the NFLOG netlink socket.  Only works when the dnsmasq DNS tier is
+active.  Clean exit on SIGINT or SIGTERM.
 """
 
 import select
@@ -18,26 +17,50 @@ from ..common.config import DnsTier
 from ..core import state
 from ..lib.watchers import AuditLogWatcher, DnsLogWatcher, DomainCache, NflogWatcher, WatchEvent
 
-# ── Entry point ─────────────────────────────────────────
-
 _running = True
 
 
-def _handle_signal(_signum: int, _frame: object) -> None:
-    """Set the stop flag on SIGINT/SIGTERM."""
-    global _running  # noqa: PLW0603
-    _running = False
+# ── Entry point ─────────────────────────────────────────
 
 
-def _ensure_log_file(log_path: Path) -> None:
-    """Create the dnsmasq log file if it does not exist yet.
+def run_watch(state_dir: Path, container: str) -> None:
+    """Stream blocked-access events as JSON lines to stdout.
 
-    ``pre_start()`` configures ``log-facility=<path>`` in the dnsmasq
-    config, but dnsmasq may not have written any queries yet when
-    ``shield watch`` starts.  Creating the file ensures the watcher
-    can open it immediately.
+    Validates the dnsmasq tier, opens the watchers, and enters a
+    ``select``-based event loop.
+
+    Args:
+        state_dir: Per-container state directory.
+        container: Container name (for event metadata).
+
+    Raises:
+        SystemExit: If the DNS tier is not dnsmasq.
     """
-    log_path.touch(exist_ok=True)
+    _validate_dnsmasq_tier(state_dir)
+
+    log_path = state.dnsmasq_log_path(state_dir)
+    _ensure_log_file(log_path)
+
+    _install_signal_handlers()
+
+    dns_watcher = DnsLogWatcher(log_path, state_dir, container)
+    audit_watcher = AuditLogWatcher(state.audit_path(state_dir), container)
+    nflog_watcher = NflogWatcher.create(container)
+    domain_cache = DomainCache(state_dir)
+
+    try:
+        while _running:
+            _poll_nflog_or_sleep(nflog_watcher, domain_cache)
+            _emit_events(dns_watcher.poll())
+            _emit_events(audit_watcher.poll())
+    finally:
+        dns_watcher.close()
+        audit_watcher.close()
+        if nflog_watcher:
+            nflog_watcher.close()
+
+
+# ── Validation ──────────────────────────────────────────
 
 
 def _validate_dnsmasq_tier(state_dir: Path) -> None:
@@ -61,6 +84,42 @@ def _validate_dnsmasq_tier(state_dir: Path) -> None:
             file=sys.stderr,
         )
         raise SystemExit(1)
+
+
+def _ensure_log_file(log_path: Path) -> None:
+    """Create the dnsmasq log file if it does not exist yet.
+
+    ``pre_start()`` configures ``log-facility=<path>``, but dnsmasq
+    may not have written any queries yet when ``shield watch`` starts.
+    """
+    log_path.touch(exist_ok=True)
+
+
+# ── Event loop mechanics ────────────────────────────────
+
+
+def _install_signal_handlers() -> None:
+    """Reset the stop flag and register SIGINT/SIGTERM for clean shutdown."""
+    global _running  # noqa: PLW0603
+    _running = True
+    signal.signal(signal.SIGINT, _handle_signal)
+    signal.signal(signal.SIGTERM, _handle_signal)
+
+
+def _handle_signal(_signum: int, _frame: object) -> None:
+    """Set the stop flag on SIGINT/SIGTERM."""
+    global _running  # noqa: PLW0603
+    _running = False
+
+
+def _poll_nflog_or_sleep(nflog_watcher: NflogWatcher | None, domain_cache: DomainCache) -> None:
+    """Wait on the NFLOG socket (or sleep 1s) and emit any packets."""
+    if nflog_watcher:
+        readable, _, _ = select.select([nflog_watcher], [], [], 1.0)
+        if readable:
+            _emit_events(_enrich_nflog(nflog_watcher.poll(), domain_cache))
+    else:
+        select.select([], [], [], 1.0)
 
 
 def _emit_events(events: list[WatchEvent]) -> None:
@@ -90,55 +149,3 @@ def _enrich_nflog(events: list[WatchEvent], cache: DomainCache) -> list[WatchEve
                 ev = replace(ev, domain=domain)
         enriched.append(ev)
     return enriched
-
-
-def _poll_nflog_or_sleep(nflog_watcher: NflogWatcher | None, domain_cache: DomainCache) -> None:
-    """Wait on the NFLOG socket (or sleep) and emit any packets."""
-    if nflog_watcher:
-        readable, _, _ = select.select([nflog_watcher], [], [], 1.0)
-        if readable:
-            _emit_events(_enrich_nflog(nflog_watcher.poll(), domain_cache))
-    else:
-        select.select([], [], [], 1.0)
-
-
-def run_watch(state_dir: Path, container: str) -> None:
-    """Stream blocked-access events as JSON lines to stdout.
-
-    Validates that the dnsmasq tier is active, then enters a
-    ``select.select()`` loop tailing the query log, audit log,
-    and (optionally) the NFLOG netlink socket.  Clean exit
-    on SIGINT or SIGTERM.
-
-    Args:
-        state_dir: Per-container state directory.
-        container: Container name (for event metadata).
-
-    Raises:
-        SystemExit: If the DNS tier is not dnsmasq.
-    """
-    _validate_dnsmasq_tier(state_dir)
-
-    log_path = state.dnsmasq_log_path(state_dir)
-    _ensure_log_file(log_path)
-
-    global _running  # noqa: PLW0603
-    _running = True
-    signal.signal(signal.SIGINT, _handle_signal)
-    signal.signal(signal.SIGTERM, _handle_signal)
-
-    dns_watcher = DnsLogWatcher(log_path, state_dir, container)
-    audit_watcher = AuditLogWatcher(state.audit_path(state_dir), container)
-    nflog_watcher = NflogWatcher.create(container)
-    domain_cache = DomainCache(state_dir)
-
-    try:
-        while _running:
-            _poll_nflog_or_sleep(nflog_watcher, domain_cache)
-            _emit_events(dns_watcher.poll())
-            _emit_events(audit_watcher.poll())
-    finally:
-        dns_watcher.close()
-        audit_watcher.close()
-        if nflog_watcher:
-            nflog_watcher.close()

--- a/src/terok_shield/core/hook_install.py
+++ b/src/terok_shield/core/hook_install.py
@@ -3,13 +3,12 @@
 
 """OCI hook file generation and installation.
 
-Generates the hook entrypoint script (read from ``resources/hook_entrypoint.py``)
-and the OCI hook JSON descriptors, then writes them to per-container or
-global hooks directories.  Pure file I/O — no runtime container interaction.
+Writes the hook entrypoint script and JSON descriptors that tell podman
+to invoke terok-shield at ``createRuntime`` and ``poststop``.  Two entry
+points: :func:`install_hooks` for per-container setup during pre_start,
+and :func:`setup_global_hooks` for one-time system-wide installation.
 
-Provides ``install_hooks()`` for per-container setup (called by
-``HookMode.pre_start()``) and ``setup_global_hooks()`` for one-time
-global installation (called by the ``setup`` CLI command).
+Pure file I/O — no runtime container interaction.
 """
 
 import json
@@ -17,19 +16,113 @@ from pathlib import Path
 
 from ..common.config import ANNOTATION_KEY
 
+_ENTRYPOINT_NAME = "terok-shield-hook"
+_HOOK_STAGES = ("createRuntime", "poststop")
+
+
+# ── Public API ──────────────────────────────────────────
+
+
+def install_hooks(*, hook_entrypoint: Path, hooks_dir: Path) -> None:
+    """Install OCI hooks for a single container's state bundle.
+
+    Called by ``HookMode.pre_start()`` to write the entrypoint and
+    hook JSONs into the per-container state directory.
+
+    Args:
+        hook_entrypoint: Where to write the entrypoint script.
+        hooks_dir: Directory for hook JSON descriptors.
+    """
+    hook_entrypoint.parent.mkdir(parents=True, exist_ok=True)
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+    _write_hook_files(hook_entrypoint, hooks_dir)
+
+
+def setup_global_hooks(target_dir: Path, *, use_sudo: bool = False) -> None:
+    """Install OCI hooks system-wide for restart persistence.
+
+    Called by the ``setup`` CLI command.  When *use_sudo* is True, writes
+    to a temp directory first and copies via ``sudo cp`` — avoids needing
+    the Python process itself to run as root.
+
+    Args:
+        target_dir: Global hooks directory to install into.
+        use_sudo: Copy files via ``sudo`` instead of writing directly.
+    """
+    if use_sudo:
+        _install_via_sudo(target_dir)
+    else:
+        target_dir.mkdir(parents=True, exist_ok=True)
+        _write_hook_files(target_dir / _ENTRYPOINT_NAME, target_dir)
+
+
+# ── Installation mechanics ──────────────────────────────
+
+
+def _install_via_sudo(target_dir: Path) -> None:
+    """Write hooks to a temp dir, then sudo-copy to the target."""
+    import subprocess
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        # JSONs must reference the final entrypoint path, not the temp copy
+        final_entrypoint = target_dir / _ENTRYPOINT_NAME
+        _write_hook_files(tmp_path / _ENTRYPOINT_NAME, tmp_path, final_entrypoint)
+
+        subprocess.run(
+            ["sudo", "mkdir", "-p", str(target_dir)],
+            check=True,  # noqa: S603, S607
+        )
+        files = [str(tmp_path / _ENTRYPOINT_NAME)]
+        for stage in _HOOK_STAGES:
+            files.append(str(tmp_path / f"terok-shield-{stage}.json"))
+        subprocess.run(
+            ["sudo", "cp", *files, str(target_dir) + "/"],
+            check=True,  # noqa: S603, S607
+        )
+        subprocess.run(
+            ["sudo", "chmod", "+x", str(final_entrypoint)],  # noqa: S603, S607
+            check=True,
+        )
+
+
+def _write_hook_files(
+    hook_entrypoint: Path,
+    hooks_dir: Path,
+    json_entrypoint_path: Path | None = None,
+) -> None:
+    """Write the entrypoint script and hook JSON descriptors.
+
+    Args:
+        hook_entrypoint: Where to write the entrypoint script.
+        hooks_dir: Where to write the hook JSON files.
+        json_entrypoint_path: Path to embed in hook JSONs.  Defaults to
+            *hook_entrypoint*; overridden for sudo installs where the
+            temp write location differs from the final install path.
+    """
+    hook_entrypoint.write_text(_generate_entrypoint())
+    hook_entrypoint.chmod(0o755)
+    ref_path = str(json_entrypoint_path or hook_entrypoint)
+    for stage in _HOOK_STAGES:
+        hook_json = _generate_hook_json(ref_path, stage)
+        (hooks_dir / f"terok-shield-{stage}.json").write_text(hook_json)
+
+
+# ── Generators ──────────────────────────────────────────
+
 
 def _generate_entrypoint() -> str:
-    """Return the self-contained OCI hook entrypoint script.
+    """Read the self-contained OCI hook entrypoint from bundled resources.
 
-    The script uses ``#!/usr/bin/env python3`` so it resolves Python at
-    execution time — no virtualenv path is baked in at setup time.
-    Works for all install methods: pip, pipx, Poetry, system package.
+    Uses ``#!/usr/bin/env python3`` so it resolves Python at execution
+    time — no virtualenv path is baked in at install time.
     """
     return (Path(__file__).parent.parent / "resources" / "hook_entrypoint.py").read_text()
 
 
 def _generate_hook_json(entrypoint: str, stage: str) -> str:
-    """Generate an OCI hook JSON descriptor for a given stage.
+    """Build an OCI hook JSON descriptor for a given lifecycle stage.
 
     Args:
         entrypoint: Absolute path to the hook entrypoint script.
@@ -42,81 +135,3 @@ def _generate_hook_json(entrypoint: str, stage: str) -> str:
         "stages": [stage],
     }
     return json.dumps(hook, indent=2) + "\n"
-
-
-def _write_hook_files(
-    hook_entrypoint: Path,
-    hooks_dir: Path,
-    json_entrypoint_path: Path | None = None,
-) -> None:
-    """Write entrypoint script and hook JSON files.
-
-    Args:
-        hook_entrypoint: Where to write the entrypoint script.
-        hooks_dir: Where to write the hook JSON files.
-        json_entrypoint_path: Path to embed in hook JSONs (defaults to
-            *hook_entrypoint*).  Used when writing to a temp dir but
-            the JSONs need to reference the final install location.
-    """
-    hook_entrypoint.write_text(_generate_entrypoint())
-    hook_entrypoint.chmod(0o755)
-    ref_path = str(json_entrypoint_path or hook_entrypoint)
-    for stage_name in ("createRuntime", "poststop"):
-        hook_json = _generate_hook_json(ref_path, stage_name)
-        (hooks_dir / f"terok-shield-{stage_name}.json").write_text(hook_json)
-
-
-def setup_global_hooks(target_dir: Path, *, use_sudo: bool = False) -> None:
-    """Install OCI hooks in a global directory for restart persistence.
-
-    Writes the entrypoint script and hook JSON files directly into
-    *target_dir*.  When *use_sudo* is True, writes to a temp directory
-    first and copies via ``sudo cp``.
-
-    Args:
-        target_dir: Global hooks directory to install into.
-        use_sudo: Use ``sudo`` for writing to the target directory.
-    """
-    import subprocess
-    import tempfile
-
-    entrypoint_name = "terok-shield-hook"
-
-    if use_sudo:
-        with tempfile.TemporaryDirectory() as tmp:
-            tmp_path = Path(tmp)
-            # Generate JSONs referencing the FINAL entrypoint path
-            final_entrypoint = target_dir / entrypoint_name
-            _write_hook_files(tmp_path / entrypoint_name, tmp_path, final_entrypoint)
-            subprocess.run(
-                ["sudo", "mkdir", "-p", str(target_dir)],
-                check=True,  # noqa: S603, S607
-            )
-            files = [str(tmp_path / entrypoint_name)]
-            for stage in ("createRuntime", "poststop"):
-                files.append(str(tmp_path / f"terok-shield-{stage}.json"))
-            subprocess.run(
-                ["sudo", "cp", *files, str(target_dir) + "/"],
-                check=True,  # noqa: S603, S607
-            )
-            subprocess.run(
-                ["sudo", "chmod", "+x", str(final_entrypoint)],  # noqa: S603, S607
-                check=True,
-            )
-    else:
-        target_dir.mkdir(parents=True, exist_ok=True)
-        _write_hook_files(target_dir / entrypoint_name, target_dir)
-
-
-def install_hooks(*, hook_entrypoint: Path, hooks_dir: Path) -> None:
-    """Install OCI hook entrypoint and hook JSON files.
-
-    Installs hooks for the ``createRuntime`` and ``poststop`` stages.
-
-    Args:
-        hook_entrypoint: Path for the entrypoint script.
-        hooks_dir: Directory for hook JSON files.
-    """
-    hook_entrypoint.parent.mkdir(parents=True, exist_ok=True)
-    hooks_dir.mkdir(parents=True, exist_ok=True)
-    _write_hook_files(hook_entrypoint, hooks_dir)

--- a/src/terok_shield/core/hook_install.py
+++ b/src/terok_shield/core/hook_install.py
@@ -24,10 +24,11 @@ _HOOK_STAGES = ("createRuntime", "poststop")
 
 
 def install_hooks(*, hook_entrypoint: Path, hooks_dir: Path) -> None:
-    """Install OCI hooks for a single container's state bundle.
+    """Write OCI hook entrypoint and JSON descriptors to a given directory.
 
-    Called by ``HookMode.pre_start()`` to write the entrypoint and
-    hook JSONs into the per-container state directory.
+    Currently only used for global hooks (user or root) because podman
+    does not fire per-container hooks on ``podman start`` — only on
+    ``podman run``.  The per-container path is kept for near-future use.
 
     Args:
         hook_entrypoint: Where to write the entrypoint script.

--- a/src/terok_shield/core/state.py
+++ b/src/terok_shield/core/state.py
@@ -3,10 +3,10 @@
 
 """Per-container state bundle layout contract.
 
-Defines the canonical directory structure for a container's state
-bundle and provides pure path-derivation functions.  Zero dependencies
-beyond ``pathlib`` — this module is the single source of truth for
-where files live within a state directory.
+Every shielded container gets an isolated state directory.  This module
+is the single source of truth for where files live within it — all paths
+are derived from a single ``state_dir`` root.  Zero dependencies beyond
+``pathlib``.
 
 Bundle layout::
 
@@ -17,10 +17,15 @@ Bundle layout::
     ├── terok-shield-hook              # entrypoint script (stdlib-only Python)
     ├── ruleset.nft                    # pre-generated nft ruleset (written by pre_start)
     ├── gateway                        # discovered gateway IP (written by OCI hook)
+    ├── gateway_v6                     # discovered IPv6 gateway
+    ├── upstream.dns                   # upstream DNS address
+    ├── dns.tier                       # active DNS tier (dig/getent/dnsmasq)
     ├── profile.allowed                # IPs from DNS resolution
     ├── profile.domains                # domain names for dnsmasq config
     ├── live.allowed                   # IPs from allow/deny
+    ├── live.domains                   # domain overrides from allow_domain
     ├── deny.list                      # persistent deny overrides
+    ├── denied.domains                 # denied domains from deny_domain
     ├── dnsmasq.conf                   # generated dnsmasq configuration
     ├── dnsmasq.pid                    # dnsmasq PID (in container netns)
     ├── dnsmasq.log                    # dnsmasq query log (for shield watch)
@@ -40,6 +45,9 @@ The OCI hook hard-fails if the annotation version does not match.
 """
 
 
+# ── OCI hook paths ──────────────────────────────────────
+
+
 def hooks_dir(state_dir: Path) -> Path:
     """Return the OCI hooks directory within the state bundle."""
     return state_dir / "hooks"
@@ -55,49 +63,12 @@ def hook_json_path(state_dir: Path, stage: str) -> Path:
     return hooks_dir(state_dir) / f"terok-shield-{stage}.json"
 
 
-def profile_allowed_path(state_dir: Path) -> Path:
-    """Return the path to the profile-derived allowlist file."""
-    return state_dir / "profile.allowed"
-
-
-def live_allowed_path(state_dir: Path) -> Path:
-    """Return the path to the live allow/deny allowlist file."""
-    return state_dir / "live.allowed"
-
-
-def deny_path(state_dir: Path) -> Path:
-    """Return the path to the persistent denylist file."""
-    return state_dir / "deny.list"
-
-
-def audit_path(state_dir: Path) -> Path:
-    """Return the path to the per-container audit log."""
-    return state_dir / "audit.jsonl"
-
-
-def profile_domains_path(state_dir: Path) -> Path:
-    """Return the path to the profile domain names list (for dnsmasq config)."""
-    return state_dir / "profile.domains"
-
-
-def dnsmasq_conf_path(state_dir: Path) -> Path:
-    """Return the path to the generated dnsmasq configuration file."""
-    return state_dir / "dnsmasq.conf"
-
-
-def dnsmasq_pid_path(state_dir: Path) -> Path:
-    """Return the path to the dnsmasq PID file."""
-    return state_dir / "dnsmasq.pid"
-
-
-def dnsmasq_log_path(state_dir: Path) -> Path:
-    """Return the path to the dnsmasq query log (tailed by ``shield watch``)."""
-    return state_dir / "dnsmasq.log"
-
-
 def ruleset_path(state_dir: Path) -> Path:
     """Return the path to the pre-generated nft ruleset file."""
     return state_dir / "ruleset.nft"
+
+
+# ── Network discovery ───────────────────────────────────
 
 
 def gateway_path(state_dir: Path) -> Path:
@@ -120,22 +91,22 @@ def dns_tier_path(state_dir: Path) -> Path:
     return state_dir / "dns.tier"
 
 
-def interactive_path(state_dir: Path) -> Path:
-    """Return the path to the interactive tier marker file."""
-    return state_dir / "interactive"
+# ── Allowlists and denylists ───────────────────────────
 
 
-def read_interactive_tier(state_dir: Path) -> str | None:
-    """Read the interactive tier from the state bundle.
+def profile_allowed_path(state_dir: Path) -> Path:
+    """Return the path to the profile-derived allowlist file."""
+    return state_dir / "profile.allowed"
 
-    Returns ``"nflog"`` (or whatever tier string is stored) if the file
-    exists and contains a non-empty value, otherwise ``None``.
-    """
-    path = interactive_path(state_dir)
-    if not path.is_file():
-        return None
-    value = path.read_text().strip()
-    return value or None
+
+def profile_domains_path(state_dir: Path) -> Path:
+    """Return the path to the profile domain names list (for dnsmasq config)."""
+    return state_dir / "profile.domains"
+
+
+def live_allowed_path(state_dir: Path) -> Path:
+    """Return the path to the live allow/deny allowlist file."""
+    return state_dir / "live.allowed"
 
 
 def live_domains_path(state_dir: Path) -> Path:
@@ -143,9 +114,32 @@ def live_domains_path(state_dir: Path) -> Path:
     return state_dir / "live.domains"
 
 
+def deny_path(state_dir: Path) -> Path:
+    """Return the path to the persistent denylist file."""
+    return state_dir / "deny.list"
+
+
 def denied_domains_path(state_dir: Path) -> Path:
     """Return the path to the denied domains file (from deny_domain)."""
     return state_dir / "denied.domains"
+
+
+# ── Dnsmasq tier ────────────────────────────────────────
+
+
+def dnsmasq_conf_path(state_dir: Path) -> Path:
+    """Return the path to the generated dnsmasq configuration file."""
+    return state_dir / "dnsmasq.conf"
+
+
+def dnsmasq_pid_path(state_dir: Path) -> Path:
+    """Return the path to the dnsmasq PID file."""
+    return state_dir / "dnsmasq.pid"
+
+
+def dnsmasq_log_path(state_dir: Path) -> Path:
+    """Return the path to the dnsmasq query log (tailed by ``shield watch``)."""
+    return state_dir / "dnsmasq.log"
 
 
 def resolv_conf_path(state_dir: Path) -> Path:
@@ -161,11 +155,49 @@ def resolv_conf_path(state_dir: Path) -> Path:
     return state_dir / "resolv.conf"
 
 
-def read_allowed_ips(state_dir: Path) -> list[str]:
-    """Read IPs from both profile.allowed and live.allowed, merged and deduplicated.
+# ── Container identity and observability ────────────────
 
-    Returns a stable-order list: profile IPs first, then live IPs, with
-    duplicates removed (first occurrence wins).
+
+def interactive_path(state_dir: Path) -> Path:
+    """Return the path to the interactive tier marker file."""
+    return state_dir / "interactive"
+
+
+def container_id_path(state_dir: Path) -> Path:
+    """Return the path to the persisted podman container ID file."""
+    return state_dir / "container.id"
+
+
+def audit_path(state_dir: Path) -> Path:
+    """Return the path to the per-container audit log."""
+    return state_dir / "audit.jsonl"
+
+
+# ── State readers ───────────────────────────────────────
+#
+# The path functions above are pure derivations.  The functions below
+# read file contents and compute derived state (merging, deduplication,
+# set subtraction).
+
+
+def read_interactive_tier(state_dir: Path) -> str | None:
+    """Read the interactive tier from the state bundle.
+
+    Returns ``"nflog"`` (or whatever tier string is stored) if the file
+    exists and contains a non-empty value, otherwise ``None``.
+    """
+    path = interactive_path(state_dir)
+    if not path.is_file():
+        return None
+    value = path.read_text().strip()
+    return value or None
+
+
+def read_allowed_ips(state_dir: Path) -> list[str]:
+    """Merge IPs from profile.allowed and live.allowed, deduplicated.
+
+    Returns a stable-order list: profile IPs first, then live IPs,
+    with duplicates removed (first occurrence wins).
     """
     ips: list[str] = []
     for path in (profile_allowed_path(state_dir), live_allowed_path(state_dir)):
@@ -192,7 +224,7 @@ def read_denied_ips(state_dir: Path) -> set[str]:
 
 
 def read_effective_ips(state_dir: Path) -> list[str]:
-    """Compute effective allowed IPs: (profile ∪ live) - deny.
+    """Compute effective allowed IPs: (profile ∪ live) − deny.
 
     Returns a stable-order list with denied IPs subtracted.
     """
@@ -201,9 +233,7 @@ def read_effective_ips(state_dir: Path) -> list[str]:
     return [ip for ip in allowed if ip not in denied]
 
 
-def container_id_path(state_dir: Path) -> Path:
-    """Return the path to the persisted podman container ID file."""
-    return state_dir / "container.id"
+# ── Setup ───────────────────────────────────────────────
 
 
 def ensure_state_dirs(state_dir: Path) -> None:


### PR DESCRIPTION
## Summary

Readability improvements to three modules — reordering for top-down reading, grouping by domain concern, and tightening docstrings.

### `core/hook_install.py` (narrative file)

- Public entry points (`install_hooks`, `setup_global_hooks`) move to the top
- Extract sudo install path into `_install_via_sudo()` 
- Deduplicate stage names and entrypoint name into module constants
- Clarify that `install_hooks` currently serves global hooks only (podman limitation)

### `cli/watch.py` (narrative file)

- `run_watch` entry point moves to the top — you see the event loop story first
- Validation and setup helpers follow in call order
- Event loop mechanics (signal handling, polling, enrichment) at the bottom
- Extract signal handler setup into `_install_signal_handlers()`

### `core/state.py` (catalog file)

- Group path derivation functions by domain concern: OCI hooks, network discovery, allowlists/denylists, dnsmasq tier, container identity
- Separate `read_*` functions (merge/dedup logic) from pure path derivations with a clear boundary
- Update ASCII bundle diagram with missing entries (`gateway_v6`, `live.domains`, `denied.domains`)

No functional changes. All 993 unit tests pass, tach and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved event loop and signal handling organization in the watch system for enhanced code maintainability.
  * Restructured hook installation mechanisms to better handle privilege escalation during setup.
  * Expanded state management infrastructure to support additional persisted artifacts with reorganized path derivation helpers for improved modularity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->