### PR TITLE
refactor: improve readability of foundation modules

### DIFF
--- a/src/terok_shield/common/config.py
+++ b/src/terok_shield/common/config.py
@@ -1,11 +1,11 @@
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
-"""Shield configuration and mode protocol.
+"""Shield configuration types, enums, and mode protocol.
 
-Houses the core value types (``ShieldConfig``, ``ShieldMode``,
-``ShieldState``) and the ``ShieldModeBackend`` protocol that strategy
-implementations must satisfy.
+Defines the vocabulary shared across the entire codebase: what a shield
+configuration looks like, what modes and states exist, and what contract
+a mode backend must satisfy.
 """
 
 import enum
@@ -16,6 +16,9 @@ from typing import Literal, Protocol, runtime_checkable
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+# ── OCI annotation keys ─────────────────────────────────
+
+
 ANNOTATION_KEY = "terok.shield.profiles"
 ANNOTATION_NAME_KEY = "terok.shield.name"
 ANNOTATION_STATE_DIR_KEY = "terok.shield.state_dir"
@@ -25,6 +28,9 @@ ANNOTATION_AUDIT_ENABLED_KEY = "terok.shield.audit_enabled"
 ANNOTATION_UPSTREAM_DNS_KEY = "terok.shield.upstream_dns"
 ANNOTATION_DNS_TIER_KEY = "terok.shield.dns_tier"
 ANNOTATION_INTERACTIVE_KEY = "terok.shield.interactive"
+
+
+# ── DNS tier ────────────────────────────────────────────
 
 
 class DnsTier(enum.Enum):
@@ -49,22 +55,23 @@ def detect_dns_tier(
 ) -> DnsTier:
     """Detect the best available DNS resolution tier.
 
-    Uses *has* to probe for executables on ``PATH``.  Shared by
-    ``HookMode._detect_dns_tier`` and ``Shield.check_environment``.
+    Probes for executables in priority order: dnsmasq (with nftset
+    support) > dig > getent.
 
     Args:
-        has: Callable that returns True if the named executable exists
-            (e.g. ``CommandRunner.has``).
-        dnsmasq_nftset_ok: Callable that returns True if the installed
-            dnsmasq supports ``--nftset``.  Defaults to ``lambda: True``
-            (skip capability probe); production callers with a live runner
-            should pass :func:`~terok_shield.dnsmasq.has_nftset_support`.
+        has: Returns True if the named executable exists on PATH.
+        dnsmasq_nftset_ok: Returns True if installed dnsmasq supports
+            ``--nftset``.  Defaults to ``lambda: True`` (skip probe);
+            production callers should pass a real capability check.
     """
     if has("dnsmasq") and dnsmasq_nftset_ok():
         return DnsTier.DNSMASQ
     if has("dig"):
         return DnsTier.DIG
     return DnsTier.GETENT
+
+
+# ── Shield mode and state ───────────────────────────────
 
 
 class ShieldMode(enum.Enum):
@@ -94,7 +101,7 @@ class ShieldState(enum.Enum):
     ERROR = "error"
 
 
-# -- ShieldConfig -----------------------------------------
+# ── ShieldConfig ────────────────────────────────────────
 
 
 @dataclass(frozen=True)
@@ -115,7 +122,7 @@ class ShieldConfig:
     interactive: bool = False
 
 
-# -- Config-file schema (Pydantic) ------------------------
+# ── Config-file schema (Pydantic) ───────────────────────
 
 
 class AuditFileConfig(BaseModel):
@@ -176,7 +183,7 @@ class ShieldFileConfig(BaseModel):
         return ports
 
 
-# -- ShieldModeBackend Protocol ---------------------------
+# ── ShieldModeBackend protocol ──────────────────────────
 
 
 @runtime_checkable

--- a/src/terok_shield/common/util.py
+++ b/src/terok_shield/common/util.py
@@ -1,17 +1,13 @@
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
-"""Shared utility functions."""
+"""IPv4 / IPv6 address and CIDR validation helpers."""
 
 import ipaddress
 
 
 def is_ipv4(value: str) -> bool:
-    """Return True if *value* is an IPv4 address or CIDR notation.
-
-    Uses ``ipaddress.IPv4Address`` for plain addresses and
-    ``ipaddress.IPv4Network(..., strict=False)`` for CIDRs.
-    """
+    """Return True if *value* is an IPv4 address or CIDR notation."""
     try:
         if "/" in value:
             ipaddress.IPv4Network(value, strict=False)
@@ -23,11 +19,7 @@ def is_ipv4(value: str) -> bool:
 
 
 def is_ipv6(value: str) -> bool:
-    """Return True if *value* is an IPv6 address or CIDR notation.
-
-    Uses ``ipaddress.IPv6Address`` for plain addresses and
-    ``ipaddress.IPv6Network(..., strict=False)`` for CIDRs.
-    """
+    """Return True if *value* is an IPv6 address or CIDR notation."""
     try:
         if "/" in value:
             ipaddress.IPv6Network(value, strict=False)

--- a/src/terok_shield/common/validation.py
+++ b/src/terok_shield/common/validation.py
@@ -1,17 +1,15 @@
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
-"""Shared input validators for container and profile names.
+"""Input validators for container names, profile names, and allowlist files.
 
-Pure functions with no internal dependencies -- safe to import from any module.
-Eliminates ``_SAFE_NAME`` / ``_SAFE_CONTAINER`` regex duplication across
-audit.py, dns.py, and profiles.py.
+Pure functions with no internal dependencies — safe to import from any module.
 """
 
 import re
 
 SAFE_CONTAINER = re.compile(r"^[A-Za-z0-9_][A-Za-z0-9_.-]*$")
-"""Container name pattern -- allows leading underscore (podman convention)."""
+"""Container name pattern — allows leading underscore (podman convention)."""
 
 SAFE_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 """Strict name pattern for profiles, cache keys, etc."""
@@ -31,7 +29,7 @@ def validate_container_name(name: str) -> str:
 def validate_safe_name(name: str) -> str:
     """Validate a generic safe name (profiles, cache keys).
 
-    Stricter than container names -- no leading underscore.
+    Stricter than container names — no leading underscore.
 
     Raises:
         ValueError: If the name contains path separators or other unsafe chars.
@@ -42,11 +40,7 @@ def validate_safe_name(name: str) -> str:
 
 
 def parse_entries(text: str) -> list[str]:
-    """Parse a text file into a list of non-blank, non-comment lines.
-
-    Strips leading/trailing whitespace from each line.
-    Lines starting with ``#`` (after stripping) are treated as comments.
-    """
+    """Parse an allowlist text file into non-blank, non-comment lines."""
     return [
         line.strip()
         for line in text.splitlines()

--- a/src/terok_shield/core/run.py
+++ b/src/terok_shield/core/run.py
@@ -68,40 +68,6 @@ class CommandRunner(Protocol):
         ...
 
 
-# ── Exceptions ──────────────────────────────────────────
-
-
-class ExecError(Exception):
-    """Raised when a subprocess fails."""
-
-    def __init__(self, cmd: list[str], rc: int, stderr: str) -> None:
-        """Store command details and format the error message."""
-        self.cmd = cmd
-        self.rc = rc
-        self.stderr = stderr
-        super().__init__(f"{cmd!r} failed (rc={rc}): {stderr.strip()}")
-
-
-class NftNotFoundError(RuntimeError):
-    """Raised when the ``nft`` binary is not found on the host."""
-
-
-class DigNotFoundError(RuntimeError):
-    """Raised when the ``dig`` binary is not found on the host.
-
-    DNS resolution requires ``dig`` (from ``bind-utils`` / ``dnsutils``).
-    """
-
-
-class ShieldNeedsSetup(RuntimeError):
-    """Raised when global OCI hooks are not installed.
-
-    Per-container ``--hooks-dir`` does not persist across container
-    restarts, so global hooks are required.  The message includes
-    system-specific setup hints.
-    """
-
-
 # ── SubprocessRunner (default implementation) ───────────
 
 
@@ -247,6 +213,40 @@ class SubprocessRunner:
             except ValueError:
                 continue
         return result
+
+
+# ── Exceptions ──────────────────────────────────────────
+
+
+class ExecError(Exception):
+    """Raised when a subprocess fails."""
+
+    def __init__(self, cmd: list[str], rc: int, stderr: str) -> None:
+        """Store command details and format the error message."""
+        self.cmd = cmd
+        self.rc = rc
+        self.stderr = stderr
+        super().__init__(f"{cmd!r} failed (rc={rc}): {stderr.strip()}")
+
+
+class NftNotFoundError(RuntimeError):
+    """Raised when the ``nft`` binary is not found on the host."""
+
+
+class DigNotFoundError(RuntimeError):
+    """Raised when the ``dig`` binary is not found on the host.
+
+    DNS resolution requires ``dig`` (from ``bind-utils`` / ``dnsutils``).
+    """
+
+
+class ShieldNeedsSetup(RuntimeError):
+    """Raised when global OCI hooks are not installed.
+
+    Per-container ``--hooks-dir`` does not persist across container
+    restarts, so global hooks are required.  The message includes
+    system-specific setup hints.
+    """
 
 
 # ── Standalone helpers ──────────────────────────────────

--- a/src/terok_shield/core/run.py
+++ b/src/terok_shield/core/run.py
@@ -15,40 +15,6 @@ import subprocess
 from pathlib import Path
 from typing import Protocol, runtime_checkable
 
-# ── Exceptions ──────────────────────────────────────────
-
-
-class ExecError(Exception):
-    """Raised when a subprocess fails."""
-
-    def __init__(self, cmd: list[str], rc: int, stderr: str) -> None:
-        """Store command details and format the error message."""
-        self.cmd = cmd
-        self.rc = rc
-        self.stderr = stderr
-        super().__init__(f"{cmd!r} failed (rc={rc}): {stderr.strip()}")
-
-
-class NftNotFoundError(RuntimeError):
-    """Raised when the ``nft`` binary is not found on the host."""
-
-
-class DigNotFoundError(RuntimeError):
-    """Raised when the ``dig`` binary is not found on the host.
-
-    DNS resolution requires ``dig`` (from ``bind-utils`` / ``dnsutils``).
-    """
-
-
-class ShieldNeedsSetup(RuntimeError):
-    """Raised when global OCI hooks are not installed.
-
-    Per-container ``--hooks-dir`` does not persist across container
-    restarts, so global hooks are required.  The message includes
-    system-specific setup hints.
-    """
-
-
 # ── CommandRunner protocol ──────────────────────────────
 
 
@@ -100,6 +66,40 @@ class CommandRunner(Protocol):
     def getent_hosts(self, domain: str) -> list[str]:
         """Resolve domain via ``getent hosts`` (fallback when dig is missing)."""
         ...
+
+
+# ── Exceptions ──────────────────────────────────────────
+
+
+class ExecError(Exception):
+    """Raised when a subprocess fails."""
+
+    def __init__(self, cmd: list[str], rc: int, stderr: str) -> None:
+        """Store command details and format the error message."""
+        self.cmd = cmd
+        self.rc = rc
+        self.stderr = stderr
+        super().__init__(f"{cmd!r} failed (rc={rc}): {stderr.strip()}")
+
+
+class NftNotFoundError(RuntimeError):
+    """Raised when the ``nft`` binary is not found on the host."""
+
+
+class DigNotFoundError(RuntimeError):
+    """Raised when the ``dig`` binary is not found on the host.
+
+    DNS resolution requires ``dig`` (from ``bind-utils`` / ``dnsutils``).
+    """
+
+
+class ShieldNeedsSetup(RuntimeError):
+    """Raised when global OCI hooks are not installed.
+
+    Per-container ``--hooks-dir`` does not persist across container
+    restarts, so global hooks are required.  The message includes
+    system-specific setup hints.
+    """
 
 
 # ── SubprocessRunner (default implementation) ───────────

--- a/src/terok_shield/core/run.py
+++ b/src/terok_shield/core/run.py
@@ -1,10 +1,12 @@
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
-"""Subprocess helpers for shield.
+"""Subprocess execution boundary for all external commands.
 
-Provides ``CommandRunner`` (Protocol) and ``SubprocessRunner``
-(default implementation).  Every external command goes through here.
+Every shell-out in terok-shield flows through the :class:`CommandRunner`
+protocol.  Production code uses :class:`SubprocessRunner`; tests inject
+fakes.  This keeps external dependencies auditable and mockable in one
+place.
 """
 
 import ipaddress as _ipaddress
@@ -13,22 +15,18 @@ import subprocess
 from pathlib import Path
 from typing import Protocol, runtime_checkable
 
-_SBIN_DIRS = ("/usr/sbin", "/sbin")
+# ── Exceptions ──────────────────────────────────────────
 
 
-def find_nft() -> str:
-    """Locate the nft binary, checking PATH then common sbin directories.
+class ExecError(Exception):
+    """Raised when a subprocess fails."""
 
-    Returns the absolute path as a string, or empty string if not found.
-    """
-    found = shutil.which("nft")
-    if found:
-        return found
-    for d in _SBIN_DIRS:
-        candidate = Path(d) / "nft"
-        if candidate.is_file():
-            return str(candidate)
-    return ""
+    def __init__(self, cmd: list[str], rc: int, stderr: str) -> None:
+        """Store command details and format the error message."""
+        self.cmd = cmd
+        self.rc = rc
+        self.stderr = stderr
+        super().__init__(f"{cmd!r} failed (rc={rc}): {stderr.strip()}")
 
 
 class NftNotFoundError(RuntimeError):
@@ -43,26 +41,15 @@ class DigNotFoundError(RuntimeError):
 
 
 class ShieldNeedsSetup(RuntimeError):
-    """Raised when the podman environment requires one-time setup.
+    """Raised when global OCI hooks are not installed.
 
-    Raised when global hooks are not installed and per-container
-    ``--hooks-dir`` would not persist across container restarts.
-    The message includes system-specific setup hints.
+    Per-container ``--hooks-dir`` does not persist across container
+    restarts, so global hooks are required.  The message includes
+    system-specific setup hints.
     """
 
 
-class ExecError(Exception):
-    """Raised when a subprocess fails."""
-
-    def __init__(self, cmd: list[str], rc: int, stderr: str) -> None:
-        """Store command details and format the error message."""
-        self.cmd = cmd
-        self.rc = rc
-        self.stderr = stderr
-        super().__init__(f"{cmd!r} failed (rc={rc}): {stderr.strip()}")
-
-
-# ── CommandRunner Protocol ───────────────────────────────
+# ── CommandRunner protocol ──────────────────────────────
 
 
 @runtime_checkable
@@ -70,7 +57,6 @@ class CommandRunner(Protocol):
     """Protocol for executing external commands.
 
     Decouples all subprocess calls behind a testable interface.
-    Production code uses ``SubprocessRunner``; tests inject fakes.
     """
 
     def run(
@@ -116,7 +102,7 @@ class CommandRunner(Protocol):
         ...
 
 
-# ── SubprocessRunner ─────────────────────────────────────
+# ── SubprocessRunner (default implementation) ───────────
 
 
 class SubprocessRunner:
@@ -138,6 +124,8 @@ class SubprocessRunner:
                 "  Arch:          sudo pacman -S nftables"
             )
 
+    # ── Core execution ──────────────────────────────────
+
     def run(
         self,
         cmd: list[str],
@@ -148,8 +136,7 @@ class SubprocessRunner:
     ) -> str:
         """Run a command, return stdout.  Raise ExecError on failure when check=True."""
         try:
-            # All external commands flow through this boundary as explicit argv
-            # lists with ``shell=False`` so call sites stay auditable and testable.
+            # Explicit argv list with shell=False — auditable and testable
             r = subprocess.run(
                 cmd,
                 input=stdin,
@@ -176,6 +163,8 @@ class SubprocessRunner:
             self._has_cache[name] = shutil.which(name) is not None
         return self._has_cache[name]
 
+    # ── nft ─────────────────────────────────────────────
+
     def nft(self, *args: str, stdin: str | None = None, check: bool = True) -> str:
         """Run nft command directly (hook mode, inside container netns)."""
         if stdin is not None:
@@ -198,16 +187,23 @@ class SubprocessRunner:
             return self.run([*cmd, *args, "-f", "-"], stdin=stdin, check=check)
         return self.run([*cmd, *args], check=check)
 
+    # ── Podman ──────────────────────────────────────────
+
     def podman_inspect(self, container: str, fmt: str) -> str:
         """Inspect a container attribute via podman."""
         return self.run(["podman", "inspect", "--format", fmt, container]).strip()
+
+    # ── DNS resolution ──────────────────────────────────
 
     def dig_all(self, domain: str, *, timeout: int = 10) -> list[str]:
         """Resolve domain to both IPv4 and IPv6 addresses in a single query.
 
         Runs ``dig +short domain A domain AAAA`` and validates each line
-        with ``ipaddress``.  Raises ``DigNotFoundError`` if ``dig`` is
-        not installed.  Returns empty list on lookup failure or timeout.
+        with ``ipaddress``.  Returns empty list on lookup failure or
+        timeout.
+
+        Raises:
+            DigNotFoundError: If ``dig`` is not installed.
         """
         if not self.has("dig"):
             raise DigNotFoundError(
@@ -238,7 +234,6 @@ class SubprocessRunner:
 
         Returns validated IP addresses from NSS resolution.  Typically
         returns fewer results than ``dig`` (often a single address).
-        Returns empty list on lookup failure.
         """
         out = self.run(["getent", "hosts", domain], check=False, timeout=10)
         result: list[str] = []
@@ -252,3 +247,24 @@ class SubprocessRunner:
             except ValueError:
                 continue
         return result
+
+
+# ── Standalone helpers ──────────────────────────────────
+
+_SBIN_DIRS = ("/usr/sbin", "/sbin")
+
+
+def find_nft() -> str:
+    """Locate the nft binary, checking PATH then common sbin directories.
+
+    sbin directories are checked explicitly because rootless users often
+    lack them in PATH.  Returns empty string if not found.
+    """
+    found = shutil.which("nft")
+    if found:
+        return found
+    for d in _SBIN_DIRS:
+        candidate = Path(d) / "nft"
+        if candidate.is_file():
+            return str(candidate)
+    return ""


### PR DESCRIPTION
## Summary

Readability improvements to the four foundation modules — the vocabulary and infrastructure layer that the rest of the codebase imports.

### `common/util.py` (catalog)
- Domain-first module docstring ("IPv4/IPv6 address and CIDR validation helpers") instead of generic "Shared utility functions"
- Trim docstrings that restated stdlib class names

### `common/validation.py` (catalog)
- Domain-first module docstring
- Remove reference to specific consumer files (they drift over time)

### `common/config.py` (catalog)
- Add section labels matching domain concepts: OCI annotation keys, DNS tier, mode/state, config, schema, protocol
- Domain-first module docstring ("Defines the vocabulary shared across the entire codebase")

### `core/run.py` (narrative + catalog)
- Group `SubprocessRunner` methods by concern: core execution, nft, podman, DNS resolution
- Move `find_nft()` and `_SBIN_DIRS` to the bottom (standalone helper, not part of the Protocol/Runner story)
- Exceptions above Protocol (error vocabulary the protocol references)
- Add "why" comment for sbin directory probing (rootless users lack sbin in PATH)

No functional changes. All 993 unit tests pass, tach and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified module documentation across configuration, validation, and execution components for improved understanding of available types, validators, and command routing.
  * Enhanced internal documentation structure with improved section organization and concept categorization.

* **Refactor**
  * Reorganized code structure within core modules to improve logical grouping and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->