### PR TITLE
refactor: restructure mode_hook.py by lifecycle phase

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,20 @@ make spdx NAME="Real Human Name" FILES="src/terok_shield/new_file.py"  # Add SPD
     # SPDX-License-Identifier: Apache-2.0
     ```
   When modifying an existing file, always run `make spdx` with the contributor's name to add their copyright line. NAME must be a real person's name (ASCII-only), not a project name. Use a single year (year of first contribution), not a range. Ask the user for their name if unknown. Files covered by `REUSE.toml` glob patterns (`.md`, `.yml`, `.toml`, `.json`, etc.) do not need inline headers.
+- **Workaround markers**: When an external limitation (upstream bug, platform deficiency) forces the code into an unnatural shape, use `WORKAROUND(tag-name)` comments:
+  - **Canonical site** — full explanation with issue links and removal condition:
+    ```python
+    # WORKAROUND(hooks-dir-persist): podman drops per-container --hooks-dir
+    # on stop/start even on 5.8.0 (containers/podman#17935, #121, #122).
+    # ... full explanation and removal conditions ...
+    HOOKS_DIR_PERSIST_VERSION = (99, 0, 0)
+    ```
+  - **Impact sites** — brief one-line reference (no re-explanation):
+    ```python
+    # WORKAROUND(hooks-dir-persist): currently always takes the global path
+    if info.hooks_dir_persists:
+    ```
+  - `grep 'WORKAROUND(hooks-dir-persist)'` finds every affected site. One canonical explanation, distributed awareness.
 - **Documentation filenames**: Markdown files under `docs/` use `lowercase.md` naming (e.g. `getting_started.md`, `cli.md`, `modes.md`) to match the MkDocs `index.md` convention. Root-level project files (e.g. `README.md`, `AGENTS.md`) stay UPPERCASE per standard convention.
 
 ## Security Boundary

--- a/src/terok_shield/common/podman_info.py
+++ b/src/terok_shield/common/podman_info.py
@@ -30,10 +30,12 @@ _SYSTEM_CONF_PATHS = (
 )
 
 # Minimum podman version where --hooks-dir persists on restart.
-# Ref: containers/podman#17935 — originally gated at (5, 6, 0) but
-# podman 5.8.0 still drops per-container --hooks-dir on stop/start
-# (issue #121, #122).  Set to (99, 0, 0) to effectively disable
-# per-container hooks until podman reliably persists them.
+# WORKAROUND(hooks-dir-persist): podman drops per-container --hooks-dir
+# on stop/start even on 5.8.0 (containers/podman#17935, #121, #122).
+# Originally gated at (5, 6, 0), set to (99, 0, 0) to effectively
+# disable per-container hooks until podman reliably persists them.
+# When lowered, per-container hooks become the default and global
+# hook installation is no longer required.
 HOOKS_DIR_PERSIST_VERSION = (99, 0, 0)
 
 # Hook JSON filename used to detect terok-shield global hooks.

--- a/src/terok_shield/core/hook_install.py
+++ b/src/terok_shield/core/hook_install.py
@@ -26,9 +26,10 @@ _HOOK_STAGES = ("createRuntime", "poststop")
 def install_hooks(*, hook_entrypoint: Path, hooks_dir: Path) -> None:
     """Write OCI hook entrypoint and JSON descriptors to a given directory.
 
-    Currently only used for global hooks (user or root) because podman
-    does not fire per-container hooks on ``podman start`` — only on
-    ``podman run``.  The per-container path is kept for near-future use.
+    WORKAROUND(hooks-dir-persist): currently only used for global hooks
+    (user or root) because podman does not persist per-container
+    ``--hooks-dir`` across stop/start.  The per-container code path is
+    kept for near-future use.
 
     Args:
         hook_entrypoint: Where to write the entrypoint script.

--- a/src/terok_shield/core/mode_hook.py
+++ b/src/terok_shield/core/mode_hook.py
@@ -65,7 +65,7 @@ if TYPE_CHECKING:
 
 
 class HookMode:
-    """Hook-mode shield backend (implements ``ShieldModeBackend``).
+    """Hook-mode shield backend (Strategy, implements ``ShieldModeBackend``).
 
     Manages the full lifecycle of OCI-hook-based container firewalling:
     pre-start DNS resolution and hook installation, live allow/deny,

--- a/src/terok_shield/core/mode_hook.py
+++ b/src/terok_shield/core/mode_hook.py
@@ -110,7 +110,8 @@ class HookMode:
         the podman CLI arguments needed for shield protection.
 
         Raises:
-            ShieldNeedsSetup: On podman < 5.6.0 without global hooks.
+            ShieldNeedsSetup: When global hooks are not installed
+                (see ``WORKAROUND(hooks-dir-persist)``).
         """
         sd = self._config.state_dir.resolve()
         info = self._get_podman_info()
@@ -167,7 +168,7 @@ class HookMode:
             f"{ANNOTATION_INTERACTIVE_KEY}={str(interactive).lower()}",
         ]
 
-        # Hooks dir: per-container on modern podman, global on old podman
+        # WORKAROUND(hooks-dir-persist): currently always takes the global path
         if info.hooks_dir_persists:
             args += ["--hooks-dir", str(state.hooks_dir(sd))]
         elif has_global_hooks():

--- a/src/terok_shield/core/mode_hook.py
+++ b/src/terok_shield/core/mode_hook.py
@@ -4,13 +4,10 @@
 """Hook mode: OCI hooks + per-container netns.
 
 Uses OCI hooks to apply per-container nftables rules inside each
-container's network namespace.  No root required -- only podman and nft.
-The stdlib-only ``hook_entrypoint.py`` applies the pre-generated ruleset at
-container creation; this module handles DNS pre-resolution, live
+container's network namespace.  No root required — only podman and nft.
+The stdlib-only ``hook_entrypoint.py`` applies the pre-generated ruleset
+at container creation; this module handles DNS pre-resolution, live
 allow/deny, and shield lifecycle (up/down/state).
-
-Provides ``HookMode`` (Strategy pattern, implements ``ShieldModeBackend``).
-Hook file installation lives in :mod:`hook_install`.
 """
 
 import logging
@@ -67,69 +64,12 @@ if TYPE_CHECKING:
     from .run import CommandRunner
 
 
-# ── Private helpers ──────────────────────────────────────
-
-
-def _upstream_dns_for_mode(network_mode: str) -> str:
-    """Return the upstream DNS forwarder address for a network mode.
-
-    Raises ValueError for unrecognised modes so new modes (e.g. bridge)
-    get an explicit implementation rather than a silent wrong default.
-    """
-    if network_mode == "slirp4netns":
-        return SLIRP4NETNS_DNS
-    if network_mode == "pasta":
-        return PASTA_DNS
-    raise ValueError(
-        f"Cannot determine upstream DNS for network mode {network_mode!r}. "
-        "Add support for this mode in _upstream_dns_for_mode()."
-    )
-
-
-def _split_domains_ips(entries: list[str]) -> tuple[list[str], list[str]]:
-    """Split profile entries into (domains, raw_ips).
-
-    Domains are forwarded to dnsmasq for runtime resolution via ``--nftset``.
-    Raw IPs are resolved/cached as before and loaded into nft sets at hook time.
-    """
-    domains: list[str] = []
-    raw_ips: list[str] = []
-    for entry in entries:
-        if _is_ip(entry):
-            raw_ips.append(entry)
-        else:
-            domains.append(entry)
-    return domains, raw_ips
-
-
-def _is_dnsmasq_tier(state_dir: Path) -> bool:
-    """Return True when the container's DNS tier is dnsmasq (or unknown).
-
-    ``allow_domain`` / ``deny_domain`` are dnsmasq-specific enhancements
-    (future IP rotation tracking via ``--nftset``).  On dig/getent tiers
-    the static IP-level allow/deny in ``allow_ip``/``deny_ip`` already ran;
-    the domain-tracking step is simply not available and callers skip it.
-
-    Returns True when ``dns_tier_path`` is absent (pre_start not yet run —
-    pass-through so the caller can still attempt the dnsmasq operation).
-    """
-    tier_path = state.dns_tier_path(state_dir)
-    if not tier_path.is_file():
-        return True
-    return tier_path.read_text().strip() == DnsTier.DNSMASQ.value
-
-
-# ── HookMode (Strategy) ─────────────────────────────────
-
-
 class HookMode:
-    """Strategy: hook-mode shield backend (implements ``ShieldModeBackend``).
+    """Hook-mode shield backend (implements ``ShieldModeBackend``).
 
     Manages the full lifecycle of OCI-hook-based container firewalling:
-    pre-start DNS resolution (including hook installation), live
-    allow/deny, bypass, and ruleset preview.  Collaborates with
-    ``RulesetBuilder``, ``CommandRunner``, ``AuditLogger``,
-    ``DnsResolver``, and ``ProfileLoader`` via constructor injection.
+    pre-start DNS resolution and hook installation, live allow/deny,
+    bypass (down/up), and ruleset preview.
     """
 
     def __init__(
@@ -160,88 +100,14 @@ class HookMode:
         self._ruleset = ruleset
         self._podman_info: PodmanInfo | None = None
 
-    def _resolve_and_write_allowlists(self, sd: Path, tier: DnsTier, entries: list[str]) -> None:
-        """Resolve profile entries and write allowlist files for the detected tier."""
-        if tier == DnsTier.DNSMASQ:
-            # dnsmasq handles domain→IP resolution at runtime via --nftset.
-            # Split entries: write domains for dnsmasq config, resolve only raw IPs.
-            domains, raw_ips = _split_domains_ips(entries)
-            state.profile_domains_path(sd).write_text("\n".join(domains) + "\n" if domains else "")
-            self._dns.resolve_and_cache(raw_ips, state.profile_allowed_path(sd))
-        else:
-            # dig/getent tier: resolve everything to IPs at pre-start time.
-            self._dns.resolve_and_cache(entries, state.profile_allowed_path(sd))
-
-    def _write_ruleset(self, sd: Path, tier: DnsTier, upstream_dns: str) -> None:
-        """Pre-generate the complete nft ruleset into the state bundle."""
-        set_timeout = NFT_SET_TIMEOUT_DNSMASQ if tier == DnsTier.DNSMASQ else ""
-        interactive = self._config.interactive
-        ruleset_builder = RulesetBuilder(
-            dns=upstream_dns,
-            loopback_ports=self._config.loopback_ports,
-            set_timeout=set_timeout,
-        )
-        ips = state.read_effective_ips(sd)
-        denied_ips = list(state.read_denied_ips(sd))
-        ruleset = ruleset_builder.build_hook(interactive=interactive)
-        ruleset += ruleset_builder.add_elements_dual(ips)
-        if denied_ips:
-            ruleset += add_deny_elements_dual(denied_ips)
-        state.ruleset_path(sd).write_text(ruleset)
-
-        # Persist interactive mode flag for shield_up() and the verdict handler
-        if interactive:
-            state.interactive_path(sd).write_text("nflog\n")
-        else:
-            state.interactive_path(sd).unlink(missing_ok=True)
-
-    def _write_dnsmasq_config_or_scrub(self, sd: Path, tier: DnsTier, upstream_dns: str) -> None:
-        """Pre-generate dnsmasq config for dnsmasq tier, or scrub stale artifacts."""
-        if tier == DnsTier.DNSMASQ:
-            domains = dnsmasq.read_merged_domains(sd)
-            conf = dnsmasq.generate_config(
-                upstream_dns,
-                domains,
-                state.dnsmasq_pid_path(sd),
-                log_path=state.dnsmasq_log_path(sd),
-            )
-            state.dnsmasq_conf_path(sd).write_text(conf)
-            state.resolv_conf_path(sd).write_text("nameserver 127.0.0.1\noptions ndots:0\n")
-        else:
-            for stale in (
-                state.dnsmasq_conf_path(sd),
-                state.dnsmasq_pid_path(sd),
-                state.resolv_conf_path(sd),
-            ):
-                stale.unlink(missing_ok=True)
-
-    def _build_network_args(self, mode: str) -> list[str]:
-        """Build rootless network arguments (pasta or slirp4netns)."""
-        if os.geteuid() == 0:
-            return []
-        if mode == "slirp4netns":
-            return [
-                "--network",
-                "slirp4netns:allow_host_loopback=true",
-                "--add-host",
-                "host.containers.internal:10.0.2.2",
-            ]
-        # Use pasta --map-host-loopback unconditionally so that
-        # host.containers.internal always resolves to an address
-        # pasta actually forwards to the host's 127.0.0.1.
-        return [
-            "--network",
-            f"pasta:--map-host-loopback,{PASTA_HOST_LOOPBACK_MAP}",
-            "--add-host",
-            f"host.containers.internal:{PASTA_HOST_LOOPBACK_MAP}",
-        ]
+    # ── Setup (pre_start) ───────────────────────────────
 
     def pre_start(self, container: str, profiles: list[str]) -> list[str]:
         """Prepare for container start in hook mode.
 
-        Installs hooks (idempotent), composes profiles, resolves DNS
-        domains, writes allowlist, detects DNS tier, sets annotations,
-        and returns the podman CLI arguments needed for shield protection.
+        Installs hooks, composes profiles, resolves DNS, writes
+        allowlist, detects DNS tier, sets annotations, and returns
+        the podman CLI arguments needed for shield protection.
 
         Raises:
             ShieldNeedsSetup: On podman < 5.6.0 without global hooks.
@@ -327,13 +193,84 @@ class HookMode:
         ]
         return args
 
-    def _detect_dns_tier(self) -> DnsTier:
-        """Detect the best available DNS resolution tier.
+    def _resolve_and_write_allowlists(self, sd: Path, tier: DnsTier, entries: list[str]) -> None:
+        """Resolve profile entries and write allowlist files for the detected tier."""
+        if tier == DnsTier.DNSMASQ:
+            # dnsmasq handles domain→IP resolution at runtime via --nftset.
+            # Split entries: write domains for dnsmasq config, resolve only raw IPs.
+            domains, raw_ips = _split_domains_ips(entries)
+            state.profile_domains_path(sd).write_text("\n".join(domains) + "\n" if domains else "")
+            self._dns.resolve_and_cache(raw_ips, state.profile_allowed_path(sd))
+        else:
+            # dig/getent tier: resolve everything to IPs at pre-start time.
+            self._dns.resolve_and_cache(entries, state.profile_allowed_path(sd))
 
-        Delegates to the shared :func:`detect_dns_tier` helper.
-        Probes the installed dnsmasq for ``--nftset`` support before
-        selecting the dnsmasq tier.
-        """
+    def _write_ruleset(self, sd: Path, tier: DnsTier, upstream_dns: str) -> None:
+        """Pre-generate the complete nft ruleset into the state bundle."""
+        set_timeout = NFT_SET_TIMEOUT_DNSMASQ if tier == DnsTier.DNSMASQ else ""
+        interactive = self._config.interactive
+        ruleset_builder = RulesetBuilder(
+            dns=upstream_dns,
+            loopback_ports=self._config.loopback_ports,
+            set_timeout=set_timeout,
+        )
+        ips = state.read_effective_ips(sd)
+        denied_ips = list(state.read_denied_ips(sd))
+        ruleset = ruleset_builder.build_hook(interactive=interactive)
+        ruleset += ruleset_builder.add_elements_dual(ips)
+        if denied_ips:
+            ruleset += add_deny_elements_dual(denied_ips)
+        state.ruleset_path(sd).write_text(ruleset)
+
+        # Persist interactive mode flag for shield_up() and the verdict handler
+        if interactive:
+            state.interactive_path(sd).write_text("nflog\n")
+        else:
+            state.interactive_path(sd).unlink(missing_ok=True)
+
+    def _write_dnsmasq_config_or_scrub(self, sd: Path, tier: DnsTier, upstream_dns: str) -> None:
+        """Pre-generate dnsmasq config for dnsmasq tier, or scrub stale artifacts."""
+        if tier == DnsTier.DNSMASQ:
+            domains = dnsmasq.read_merged_domains(sd)
+            conf = dnsmasq.generate_config(
+                upstream_dns,
+                domains,
+                state.dnsmasq_pid_path(sd),
+                log_path=state.dnsmasq_log_path(sd),
+            )
+            state.dnsmasq_conf_path(sd).write_text(conf)
+            state.resolv_conf_path(sd).write_text("nameserver 127.0.0.1\noptions ndots:0\n")
+        else:
+            for stale in (
+                state.dnsmasq_conf_path(sd),
+                state.dnsmasq_pid_path(sd),
+                state.resolv_conf_path(sd),
+            ):
+                stale.unlink(missing_ok=True)
+
+    def _build_network_args(self, mode: str) -> list[str]:
+        """Build rootless network arguments (pasta or slirp4netns)."""
+        if os.geteuid() == 0:
+            return []
+        if mode == "slirp4netns":
+            return [
+                "--network",
+                "slirp4netns:allow_host_loopback=true",
+                "--add-host",
+                "host.containers.internal:10.0.2.2",
+            ]
+        # Use pasta --map-host-loopback unconditionally so that
+        # host.containers.internal always resolves to an address
+        # pasta actually forwards to the host's 127.0.0.1.
+        return [
+            "--network",
+            f"pasta:--map-host-loopback,{PASTA_HOST_LOOPBACK_MAP}",
+            "--add-host",
+            f"host.containers.internal:{PASTA_HOST_LOOPBACK_MAP}",
+        ]
+
+    def _detect_dns_tier(self) -> DnsTier:
+        """Detect the best available DNS resolution tier."""
         return detect_dns_tier(self._runner.has, lambda: dnsmasq.has_nftset_support(self._runner))
 
     def _get_podman_info(self) -> PodmanInfo:
@@ -343,23 +280,7 @@ class HookMode:
             self._podman_info = parse_podman_info(output)
         return self._podman_info
 
-    def _set_for_ip(self, ip: str) -> str:
-        """Return the nft set name for an IP address."""
-        return "allow_v4" if is_ipv4(ip) else "allow_v6"
-
-    def _live_path(self) -> Path:
-        """Return the resolved path to live.allowed (prevents path traversal)."""
-        return state.live_allowed_path(self._config.state_dir).resolve()
-
-    def _nft_apply_best_effort(self, container: str, nft_cmd: str) -> None:
-        """Run multi-line nft commands via nsenter, swallowing errors."""
-        for line in nft_cmd.strip().splitlines():
-            parts = line.strip().split()
-            if parts:
-                try:
-                    self._runner.nft_via_nsenter(container, *parts)
-                except ExecError:
-                    pass
+    # ── Live operations (IP) ────────────────────────────
 
     def allow_ip(self, container: str, ip: str) -> None:
         """Live-allow an IP for a running container via nsenter."""
@@ -457,6 +378,26 @@ class HookMode:
                 with dp.open("a") as f:
                     f.write(f"{ip}\n")
 
+    def _set_for_ip(self, ip: str) -> str:
+        """Return the nft set name for an IP address."""
+        return "allow_v4" if is_ipv4(ip) else "allow_v6"
+
+    def _live_path(self) -> Path:
+        """Return the resolved path to live.allowed (prevents path traversal)."""
+        return state.live_allowed_path(self._config.state_dir).resolve()
+
+    def _nft_apply_best_effort(self, container: str, nft_cmd: str) -> None:
+        """Run multi-line nft commands via nsenter, swallowing errors."""
+        for line in nft_cmd.strip().splitlines():
+            parts = line.strip().split()
+            if parts:
+                try:
+                    self._runner.nft_via_nsenter(container, *parts)
+                except ExecError:
+                    pass
+
+    # ── Live operations (domain) ────────────────────────
+
     def allow_domain(self, domain: str) -> None:
         """Add a domain to the dnsmasq config and signal reload.
 
@@ -509,76 +450,7 @@ class HookMode:
         domains = dnsmasq.read_merged_domains(state_dir)
         dnsmasq.reload(state_dir, upstream, domains)
 
-    def list_rules(self, container: str) -> str:
-        """List current nft rules for a running container."""
-        try:
-            return self._runner.nft_via_nsenter(
-                container,
-                "list",
-                "table",
-                "inet",
-                "terok_shield",
-                check=False,
-            )
-        except ExecError:
-            return ""
-
-    def _read_container_dns(self, container: str) -> str:
-        """Read DNS nameserver from a running container's resolv.conf.
-
-        Uses ``/proc/{pid}/root/etc/resolv.conf`` via ``podman unshare``
-        to access the container's rootfs without entering its mount
-        namespace (avoids requiring ``cat`` inside the container).
-        """
-        pid = self._runner.podman_inspect(container, "{{.State.Pid}}")
-        output = self._runner.run(
-            ["podman", "unshare", "cat", f"/proc/{pid}/root/etc/resolv.conf"],
-            check=False,
-        )
-        dns = parse_resolv_conf(output)
-        if not dns:
-            raise RuntimeError(
-                f"Cannot determine DNS for container {container}: no nameserver in resolv.conf"
-            )
-        return dns
-
-    def _read_upstream_dns(self) -> str | None:
-        """Read persisted upstream DNS from state (written by the OCI hook).
-
-        Returns None if the file is absent (pre-dnsmasq container or
-        container started before this feature).
-        """
-        sd = self._config.state_dir.resolve()
-        path = state.upstream_dns_path(sd)
-        if not path.is_file():
-            return None
-        value = path.read_text().strip()
-        return value or None
-
-    def _container_ruleset(self, container: str) -> RulesetBuilder:
-        """Build a RulesetBuilder with the container's actual DNS settings.
-
-        Prefers persisted upstream DNS (from pre_start) over resolv.conf,
-        because dnsmasq mode rewrites resolv.conf to ``127.0.0.1``.
-        Reads persisted DNS tier to set nft element timeouts for dnsmasq mode.
-        """
-        upstream = self._read_upstream_dns()
-        dns = upstream if upstream else self._read_container_dns(container)
-
-        # Read persisted DNS tier to determine if set timeouts are needed
-        sd = self._config.state_dir.resolve()
-        tier_path = state.dns_tier_path(sd)
-        set_timeout = ""
-        if tier_path.is_file():
-            tier_str = tier_path.read_text().strip()
-            if tier_str == DnsTier.DNSMASQ.value:
-                set_timeout = NFT_SET_TIMEOUT_DNSMASQ
-
-        return RulesetBuilder(
-            dns=dns,
-            loopback_ports=self._config.loopback_ports,
-            set_timeout=set_timeout,
-        )
+    # ── State transitions ───────────────────────────────
 
     def shield_down(self, container: str, *, allow_all: bool = False) -> None:
         """Switch a running container to bypass mode."""
@@ -646,6 +518,64 @@ class HookMode:
         if errors:
             raise RuntimeError(f"Ruleset verification failed: {'; '.join(errors)}")
 
+    def _container_ruleset(self, container: str) -> RulesetBuilder:
+        """Build a RulesetBuilder with the container's actual DNS settings.
+
+        Prefers persisted upstream DNS (from pre_start) over resolv.conf,
+        because dnsmasq mode rewrites resolv.conf to ``127.0.0.1``.
+        """
+        upstream = self._read_upstream_dns()
+        dns = upstream if upstream else self._read_container_dns(container)
+
+        # Read persisted DNS tier to determine if set timeouts are needed
+        sd = self._config.state_dir.resolve()
+        tier_path = state.dns_tier_path(sd)
+        set_timeout = ""
+        if tier_path.is_file():
+            tier_str = tier_path.read_text().strip()
+            if tier_str == DnsTier.DNSMASQ.value:
+                set_timeout = NFT_SET_TIMEOUT_DNSMASQ
+
+        return RulesetBuilder(
+            dns=dns,
+            loopback_ports=self._config.loopback_ports,
+            set_timeout=set_timeout,
+        )
+
+    def _read_upstream_dns(self) -> str | None:
+        """Read persisted upstream DNS from state (written by pre_start).
+
+        Returns None if the file is absent (pre-dnsmasq container or
+        container started before this feature).
+        """
+        sd = self._config.state_dir.resolve()
+        path = state.upstream_dns_path(sd)
+        if not path.is_file():
+            return None
+        value = path.read_text().strip()
+        return value or None
+
+    def _read_container_dns(self, container: str) -> str:
+        """Read DNS nameserver from a running container's resolv.conf.
+
+        Uses ``/proc/{pid}/root/etc/resolv.conf`` via ``podman unshare``
+        to access the container's rootfs without entering its mount
+        namespace (avoids requiring ``cat`` inside the container).
+        """
+        pid = self._runner.podman_inspect(container, "{{.State.Pid}}")
+        output = self._runner.run(
+            ["podman", "unshare", "cat", f"/proc/{pid}/root/etc/resolv.conf"],
+            check=False,
+        )
+        dns = parse_resolv_conf(output)
+        if not dns:
+            raise RuntimeError(
+                f"Cannot determine DNS for container {container}: no nameserver in resolv.conf"
+            )
+        return dns
+
+    # ── Queries ─────────────────────────────────────────
+
     def shield_state(self, container: str) -> ShieldState:
         """Query the live nft ruleset to determine the container's shield state."""
         output = self.list_rules(container)
@@ -666,8 +596,74 @@ class HookMode:
 
         return ShieldState.ERROR
 
+    def list_rules(self, container: str) -> str:
+        """List current nft rules for a running container."""
+        try:
+            return self._runner.nft_via_nsenter(
+                container,
+                "list",
+                "table",
+                "inet",
+                "terok_shield",
+                check=False,
+            )
+        except ExecError:
+            return ""
+
     def preview(self, *, down: bool = False, allow_all: bool = False) -> str:
         """Generate the ruleset that would be applied to a container."""
         if down:
             return self._ruleset.build_bypass(allow_all=allow_all)
         return self._ruleset.build_hook(interactive=self._config.interactive)
+
+
+# ── Module-level helpers ────────────────────────────────
+
+
+def _upstream_dns_for_mode(network_mode: str) -> str:
+    """Return the upstream DNS forwarder address for a network mode.
+
+    Raises ValueError for unrecognised modes so new modes (e.g. bridge)
+    get an explicit implementation rather than a silent wrong default.
+    """
+    if network_mode == "slirp4netns":
+        return SLIRP4NETNS_DNS
+    if network_mode == "pasta":
+        return PASTA_DNS
+    raise ValueError(
+        f"Cannot determine upstream DNS for network mode {network_mode!r}. "
+        "Add support for this mode in _upstream_dns_for_mode()."
+    )
+
+
+def _split_domains_ips(entries: list[str]) -> tuple[list[str], list[str]]:
+    """Split profile entries into (domains, raw_ips).
+
+    Domains are forwarded to dnsmasq for runtime resolution via ``--nftset``.
+    Raw IPs are resolved/cached as before and loaded into nft sets at hook time.
+    """
+    domains: list[str] = []
+    raw_ips: list[str] = []
+    for entry in entries:
+        if _is_ip(entry):
+            raw_ips.append(entry)
+        else:
+            domains.append(entry)
+    return domains, raw_ips
+
+
+def _is_dnsmasq_tier(state_dir: Path) -> bool:
+    """Return True when the container's DNS tier is dnsmasq (or unknown).
+
+    ``allow_domain`` / ``deny_domain`` are dnsmasq-specific enhancements
+    (future IP rotation tracking via ``--nftset``).  On dig/getent tiers
+    the static IP-level allow/deny in ``allow_ip``/``deny_ip`` already ran;
+    the domain-tracking step is simply not available and callers skip it.
+
+    Returns True when ``dns_tier_path`` is absent (pre_start not yet run —
+    pass-through so the caller can still attempt the dnsmasq operation).
+    """
+    tier_path = state.dns_tier_path(state_dir)
+    if not tier_path.is_file():
+        return True
+    return tier_path.read_text().strip() == DnsTier.DNSMASQ.value

--- a/src/terok_shield/core/mode_hook.py
+++ b/src/terok_shield/core/mode_hook.py
@@ -280,6 +280,60 @@ class HookMode:
             self._podman_info = parse_podman_info(output)
         return self._podman_info
 
+    # ── Live operations (domain) ───────────────────────
+
+    def allow_domain(self, domain: str) -> None:
+        """Add a domain to the dnsmasq config and signal reload.
+
+        Delegates to ``dnsmasq.add_domain()``, which persists the domain to
+        ``live.domains`` (not ``profile.domains``) and removes any matching
+        entry from ``denied.domains``.  When dnsmasq is running, a SIGHUP is
+        sent so the change takes effect immediately without a container restart.
+        These entries are runtime additions: they survive dnsmasq reloads but
+        are separate from the pre-start ``profile.domains`` list.
+
+        The IP-level allow (nft set update) is handled separately by
+        ``allow_ip()`` — this method is the domain-tracking counterpart
+        that ensures future IP rotations are also captured.
+
+        No-op when the container is not using the dnsmasq DNS tier (the
+        static IP-level allow already happened via ``allow_ip()``).
+        """
+        sd = self._config.state_dir.resolve()
+        if not _is_dnsmasq_tier(sd):
+            return
+        if not dnsmasq.add_domain(sd, domain):
+            return  # already present
+        self._reload_dnsmasq(sd)
+
+    def deny_domain(self, domain: str) -> None:
+        """Remove a domain from the dnsmasq config and signal reload.
+
+        Counterpart of ``allow_domain()``.  Removes the domain so dnsmasq
+        stops auto-populating nft sets for it on future DNS queries.
+
+        No-op when the container is not using the dnsmasq DNS tier.
+        """
+        sd = self._config.state_dir.resolve()
+        if not _is_dnsmasq_tier(sd):
+            return
+        if not dnsmasq.remove_domain(sd, domain):
+            return  # not present
+        self._reload_dnsmasq(sd)
+
+    def _reload_dnsmasq(self, state_dir: Path) -> None:
+        """Regenerate dnsmasq config and send SIGHUP.
+
+        No-op if dnsmasq is not running (PID file absent).
+        Raises RuntimeError if dnsmasq is dead (stale PID).
+        """
+        upstream = self._read_upstream_dns()
+        if not upstream:
+            raise RuntimeError("Cannot reload dnsmasq: upstream DNS not persisted in state")
+
+        domains = dnsmasq.read_merged_domains(state_dir)
+        dnsmasq.reload(state_dir, upstream, domains)
+
     # ── Live operations (IP) ────────────────────────────
 
     def allow_ip(self, container: str, ip: str) -> None:
@@ -395,60 +449,6 @@ class HookMode:
                     self._runner.nft_via_nsenter(container, *parts)
                 except ExecError:
                     pass
-
-    # ── Live operations (domain) ────────────────────────
-
-    def allow_domain(self, domain: str) -> None:
-        """Add a domain to the dnsmasq config and signal reload.
-
-        Delegates to ``dnsmasq.add_domain()``, which persists the domain to
-        ``live.domains`` (not ``profile.domains``) and removes any matching
-        entry from ``denied.domains``.  When dnsmasq is running, a SIGHUP is
-        sent so the change takes effect immediately without a container restart.
-        These entries are runtime additions: they survive dnsmasq reloads but
-        are separate from the pre-start ``profile.domains`` list.
-
-        The IP-level allow (nft set update) is handled separately by
-        ``allow_ip()`` — this method is the domain-tracking counterpart
-        that ensures future IP rotations are also captured.
-
-        No-op when the container is not using the dnsmasq DNS tier (the
-        static IP-level allow already happened via ``allow_ip()``).
-        """
-        sd = self._config.state_dir.resolve()
-        if not _is_dnsmasq_tier(sd):
-            return
-        if not dnsmasq.add_domain(sd, domain):
-            return  # already present
-        self._reload_dnsmasq(sd)
-
-    def deny_domain(self, domain: str) -> None:
-        """Remove a domain from the dnsmasq config and signal reload.
-
-        Counterpart of ``allow_domain()``.  Removes the domain so dnsmasq
-        stops auto-populating nft sets for it on future DNS queries.
-
-        No-op when the container is not using the dnsmasq DNS tier.
-        """
-        sd = self._config.state_dir.resolve()
-        if not _is_dnsmasq_tier(sd):
-            return
-        if not dnsmasq.remove_domain(sd, domain):
-            return  # not present
-        self._reload_dnsmasq(sd)
-
-    def _reload_dnsmasq(self, state_dir: Path) -> None:
-        """Regenerate dnsmasq config and send SIGHUP.
-
-        No-op if dnsmasq is not running (PID file absent).
-        Raises RuntimeError if dnsmasq is dead (stale PID).
-        """
-        upstream = self._read_upstream_dns()
-        if not upstream:
-            raise RuntimeError("Cannot reload dnsmasq: upstream DNS not persisted in state")
-
-        domains = dnsmasq.read_merged_domains(state_dir)
-        dnsmasq.reload(state_dir, upstream, domains)
 
     # ── State transitions ───────────────────────────────
 


### PR DESCRIPTION
## Summary

Restructure the largest module (673 lines) for top-down reading, grouped by shield lifecycle phases.

### Lifecycle ordering

1. **Setup** (`pre_start`) — the headline, followed by its helpers
2. **Live domain operations** (`allow_domain`, `deny_domain`) — higher-level concept first
3. **Live IP operations** (`allow_ip`, `deny_ip`) — lower-level mechanics
4. **State transitions** (`shield_down`, `shield_up`)
5. **Queries** (`shield_state`, `list_rules`, `preview`)

Within each group: public methods lead, their private helpers follow. Module-level helpers move below the class.

### Other improvements

- Restore "Strategy" pattern label in `HookMode` docstring — signals intentional structure
- Domain ops before IP ops — narrative flows from user intent to nft mechanics
- Add greppable `WORKAROUND(hooks-dir-persist)` tags across `podman_info.py`, `mode_hook.py`, and `hook_install.py` — canonical explanation at `HOOKS_DIR_PERSIST_VERSION`, impact points reference it
- Fix inaccurate "podman < 5.6.0" in pre_start docstring (affects all current podman versions)

No functional changes. All 993 unit tests pass, tach and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced standardized workaround marker patterns for documenting external limitations and their resolution conditions.
  * Established documentation naming conventions for project consistency.

* **Refactor**
  * Reorganized internal code structure and helper functions to improve maintainability while preserving all existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->