### PR TITLE
refactor: improve readability of CLI surface modules

### DIFF
--- a/src/terok_shield/cli/interactive.py
+++ b/src/terok_shield/cli/interactive.py
@@ -21,6 +21,8 @@ persisted to ``live.allowed``; denied IPs are added to the deny sets and
 persisted to ``deny.list``.
 """
 
+from __future__ import annotations
+
 import json
 import logging
 import os
@@ -40,202 +42,68 @@ from ..lib.watchers import DomainCache, NflogWatcher, WatchEvent
 
 logger = logging.getLogger(__name__)
 
-# ── I/O protocol ──────────────────────────────────────
-
-
-@runtime_checkable
-class SessionIO(Protocol):
-    """I/O protocol for the interactive session.
-
-    Decouples rendering and parsing from the verdict engine so the same
-    :class:`InteractiveSession` can drive both machine-readable JSON-lines
-    (``--raw``) and human-friendly CLI output.
-    """
-
-    def emit_pending(self, packet_id: int, dest: str, port: int, proto: int, domain: str) -> None:
-        """Emit a pending-connection event to the operator."""
-        ...
-
-    def emit_verdict_applied(self, verdict_id: int, dest: str, action: str, *, ok: bool) -> None:
-        """Emit a verdict-applied confirmation."""
-        ...
-
-    def parse_command(self, line: str) -> tuple[int, str] | None:
-        """Parse one line of operator input into *(packet_id, action)*.
-
-        Returns ``None`` when the line is invalid or unparseable.
-        """
-        ...
-
-    def emit_banner(self) -> None:
-        """Print a startup banner (no-op for machine protocols)."""
-        ...
-
-
-class JsonSessionIO:
-    """JSON-lines session I/O — machine-readable protocol.
-
-    Emits compact JSON objects (one per line) and expects JSON verdict
-    commands on stdin.  This is the original protocol from PR #162.
-    """
-
-    def emit_pending(self, packet_id: int, dest: str, port: int, proto: int, domain: str) -> None:
-        """Emit a pending event as a JSON line."""
-        out = {
-            "type": "pending",
-            "id": packet_id,
-            "dest": dest,
-            "port": port,
-            "proto": proto,
-            "domain": domain,
-        }
-        print(json.dumps(out, separators=(",", ":")), flush=True)
-
-    def emit_verdict_applied(self, verdict_id: int, dest: str, action: str, *, ok: bool) -> None:
-        """Emit a verdict-applied confirmation as a JSON line."""
-        out = {
-            "type": "verdict_applied",
-            "id": verdict_id,
-            "dest": dest,
-            "action": action,
-            "ok": ok,
-        }
-        print(json.dumps(out, separators=(",", ":")), flush=True)
-
-    def parse_command(self, line: str) -> tuple[int, str] | None:
-        """Parse a JSON verdict command.
-
-        Expected format: ``{"type": "verdict", "id": 1, "action": "accept"}``.
-        Returns ``(id, action)`` on success or ``None`` on any validation failure.
-        """
-        try:
-            cmd = json.loads(line)
-        except json.JSONDecodeError:
-            logger.warning("Invalid JSON on stdin: %s", line)
-            return None
-        if not isinstance(cmd, dict):
-            logger.warning("Expected JSON object, got %s", type(cmd).__name__)
-            return None
-        if cmd.get("type") != "verdict":
-            logger.warning("Unknown command type: %s", cmd.get("type"))
-            return None
-        verdict_id = cmd.get("id")
-        if isinstance(verdict_id, bool) or not isinstance(verdict_id, int):
-            logger.warning("Verdict id must be an integer, got %r", verdict_id)
-            return None
-        action = cmd.get("action")
-        if action not in ("accept", "deny"):
-            logger.warning("Verdict action must be 'accept' or 'deny', got %r", action)
-            return None
-        return (verdict_id, action)
-
-    def emit_banner(self) -> None:
-        """No-op — machine protocol has no banner."""
-
-
-# Mapping of human-friendly input to canonical action names.
-_INPUT_MAP: dict[str, str] = {
-    "a": "accept",
-    "allow": "accept",
-    "d": "deny",
-    "deny": "deny",
-}
-
-
-class CliSessionIO:
-    """Human-friendly interactive CLI session I/O.
-
-    Renders blocked connections as readable lines and accepts short
-    operator input (``a``/``d`` or ``allow``/``deny``).  Pending packets
-    are tracked in a FIFO queue — input always targets the oldest.
-    """
-
-    def __init__(self) -> None:
-        """Initialise with empty pending-packet queues."""
-        self._queue: list[int] = []
-        """FIFO of pending packet IDs awaiting a verdict."""
-
-        self._info: dict[int, tuple[str, int, str]] = {}
-        """Packet metadata: *id* → *(dest, port, domain)*."""
-
-    def _prompt_head(self) -> None:
-        """Print the allow/deny prompt for the head-of-queue packet."""
-        if not self._queue:
-            return
-        info = self._info.get(self._queue[0])
-        if info is None:
-            return
-        dest, port, domain = info
-        label = f"{dest} ({domain})" if domain else dest
-        print(f"[BLOCKED] {label} :{port} \u2014 allow/deny? ", end="", flush=True)
-
-    def emit_pending(self, packet_id: int, dest: str, port: int, proto: int, domain: str) -> None:
-        """Show a ``[BLOCKED]`` line and queue the packet for verdict."""
-        label = f"{dest} ({domain})" if domain else dest
-        self._queue.append(packet_id)
-        self._info[packet_id] = (dest, port, domain)
-        if len(self._queue) == 1:
-            self._prompt_head()
-        else:
-            # Additional pending while the operator is thinking.
-            print(f"\n[BLOCKED] {label} :{port} (queued)", flush=True)
-            self._prompt_head()
-
-    def emit_verdict_applied(self, verdict_id: int, dest: str, action: str, *, ok: bool) -> None:
-        """Show verdict result and prompt the next queued packet if any.
-
-        On success the packet is removed from the queue.  On failure it
-        stays queued so the operator can retry with the same ``a``/``d``
-        input (mirrors :meth:`InteractiveSession._process_command` which
-        keeps failed verdicts in ``_pending_by_ip``).
-        """
-        info = self._info.get(verdict_id)
-        target = info[2] if info and info[2] else dest
-        if ok:
-            self._info.pop(verdict_id, None)
-            if verdict_id in self._queue:
-                self._queue.remove(verdict_id)
-            mark = "\u2713" if action == "accept" else "\u2717"
-            verb = "allowed" if action == "accept" else "denied"
-            print(f"  {mark} {verb} {target}")
-        else:
-            print(f"  ! verdict failed for {target} (retry with a/d)")
-        self._prompt_head()
-
-    def parse_command(self, line: str) -> tuple[int, str] | None:
-        """Map operator input to the oldest pending packet.
-
-        Accepts ``a``, ``d``, ``allow``, ``deny`` (case-insensitive).
-        Returns ``None`` and prints a hint on unrecognised input.
-        """
-        action = _INPUT_MAP.get(line.strip().lower())
-        if action is None:
-            print("  Unknown input. Type 'a' to allow or 'd' to deny.", flush=True)
-            self._prompt_head()
-            return None
-        if not self._queue:
-            return None
-        return (self._queue[0], action)
-
-    def emit_banner(self) -> None:
-        """Print a startup message."""
-        print("Watching for blocked connections... (Ctrl-C to stop)\n", flush=True)
-
+# Environment variables for the nsenter re-exec handshake.
+_NSENTER_ENV = "_TEROK_SHIELD_NFLOG_NSENTER"
+_RAW_ENV = "_TEROK_SHIELD_NFLOG_RAW"
 
 # How often (seconds) to refresh the domain cache from the dnsmasq log.
 _DOMAIN_REFRESH_INTERVAL = 10.0
 
-# Module-level stop flag, set by signal handler.
-_running = True
+
+# ── Entry point ──────────────────────────────────────────
 
 
-def _handle_signal(_signum: int, _frame: object) -> None:
-    """Set the module-level stop flag on SIGINT/SIGTERM."""
-    global _running  # noqa: PLW0603
-    _running = False
+def run_interactive(state_dir: Path, container: str, *, raw: bool = False) -> None:
+    """Start the interactive NFLOG handler for a container.
+
+    The NFLOG netlink socket must be inside the container's network
+    namespace to receive packets logged by nft rules.  On first
+    invocation, re-execs via ``podman unshare nsenter`` into the
+    container's netns.  The re-exec sets ``_TEROK_SHIELD_NFLOG_NSENTER``
+    so the second invocation runs the handler directly.
+
+    Args:
+        state_dir: Per-container state directory (may be relative).
+        container: Container name.
+        raw: If ``True``, use JSON-lines protocol; otherwise use the
+            human-friendly CLI (default).
+
+    Raises:
+        SystemExit: If the interactive tier is not configured or NFLOG
+            watcher creation fails.
+    """
+    state_dir = state_dir.resolve()
+    tier = read_interactive_tier(state_dir)
+    if tier != "nflog":
+        print(
+            f"Error: interactive tier not configured (got {tier!r}, expected 'nflog').",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+
+    if os.environ.get(_NSENTER_ENV) != "1":
+        _nsenter_reexec(state_dir, container, raw=raw)
+        return
+
+    io: SessionIO = JsonSessionIO() if raw else CliSessionIO()
+    runner = SubprocessRunner()
+    session = InteractiveSession(runner=runner, state_dir=state_dir, container=container, io=io)
+    session.run()
 
 
-# ── Data types ─────────────────────────────────────────
+def _main() -> None:
+    """CLI entry point for ``python -m terok_shield.cli.interactive``."""
+    if len(sys.argv) != 3:
+        print(
+            f"Usage: {sys.executable} -m terok_shield.cli.interactive <state_dir> <container>",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
+    raw = os.environ.get(_RAW_ENV) == "1"
+    run_interactive(Path(sys.argv[1]), sys.argv[2], raw=raw)
+
+
+# ── Interactive session ──────────────────────────────────
 
 
 @dataclass
@@ -248,9 +116,6 @@ class _PendingPacket:
     queued_at: float
     domain: str = ""
     packet_id: int = 0
-
-
-# ── Session ────────────────────────────────────────────
 
 
 class InteractiveSession:
@@ -551,47 +416,189 @@ class InteractiveSession:
             return False
 
 
-# ── Helpers ────────────────────────────────────────────
+# ── I/O protocol ─────────────────────────────────────────
 
 
-def _readable_fds(readable: list) -> set[int]:
-    """Extract file descriptor ints from a ``select.select()`` readable list.
+@runtime_checkable
+class SessionIO(Protocol):
+    """I/O protocol for the interactive session.
 
-    Handles both raw int fds and objects with a ``fileno()`` method.
+    Decouples rendering and parsing from the verdict engine so the same
+    :class:`InteractiveSession` can drive both machine-readable JSON-lines
+    (``--raw``) and human-friendly CLI output.
     """
-    return {r if isinstance(r, int) else r.fileno() for r in readable}
+
+    def emit_pending(self, packet_id: int, dest: str, port: int, proto: int, domain: str) -> None:
+        """Emit a pending-connection event to the operator."""
+        ...
+
+    def emit_verdict_applied(self, verdict_id: int, dest: str, action: str, *, ok: bool) -> None:
+        """Emit a verdict-applied confirmation."""
+        ...
+
+    def parse_command(self, line: str) -> tuple[int, str] | None:
+        """Parse one line of operator input into *(packet_id, action)*.
+
+        Returns ``None`` when the line is invalid or unparseable.
+        """
+        ...
+
+    def emit_banner(self) -> None:
+        """Print a startup banner (no-op for machine protocols)."""
+        ...
 
 
-def _set_nonblocking(fd: int) -> None:
-    """Set a file descriptor to non-blocking mode."""
-    import fcntl
+class JsonSessionIO:
+    """JSON-lines session I/O — machine-readable protocol.
 
-    flags = fcntl.fcntl(fd, fcntl.F_GETFL)
-    fcntl.fcntl(fd, fcntl.F_SETFL, flags | os.O_NONBLOCK)
-
-
-def _append_unique(path: Path, value: str) -> None:
-    """Append *value* to a newline-delimited file if not already present.
-
-    Creates the file if it does not exist.
-
-    Args:
-        path: Path to the file.
-        value: The value to append (without trailing newline).
+    Emits compact JSON objects (one per line) and expects JSON verdict
+    commands on stdin.  This is the original protocol from PR #162.
     """
-    existing: set[str] = set()
-    if path.is_file():
-        existing = {line.strip() for line in path.read_text().splitlines() if line.strip()}
-    if value in existing:
-        return
-    with open(path, "a") as f:
-        f.write(value + "\n")
+
+    def emit_pending(self, packet_id: int, dest: str, port: int, proto: int, domain: str) -> None:
+        """Emit a pending event as a JSON line."""
+        out = {
+            "type": "pending",
+            "id": packet_id,
+            "dest": dest,
+            "port": port,
+            "proto": proto,
+            "domain": domain,
+        }
+        print(json.dumps(out, separators=(",", ":")), flush=True)
+
+    def emit_verdict_applied(self, verdict_id: int, dest: str, action: str, *, ok: bool) -> None:
+        """Emit a verdict-applied confirmation as a JSON line."""
+        out = {
+            "type": "verdict_applied",
+            "id": verdict_id,
+            "dest": dest,
+            "action": action,
+            "ok": ok,
+        }
+        print(json.dumps(out, separators=(",", ":")), flush=True)
+
+    def parse_command(self, line: str) -> tuple[int, str] | None:
+        """Parse a JSON verdict command.
+
+        Expected format: ``{"type": "verdict", "id": 1, "action": "accept"}``.
+        Returns ``(id, action)`` on success or ``None`` on any validation failure.
+        """
+        try:
+            cmd = json.loads(line)
+        except json.JSONDecodeError:
+            logger.warning("Invalid JSON on stdin: %s", line)
+            return None
+        if not isinstance(cmd, dict):
+            logger.warning("Expected JSON object, got %s", type(cmd).__name__)
+            return None
+        if cmd.get("type") != "verdict":
+            logger.warning("Unknown command type: %s", cmd.get("type"))
+            return None
+        verdict_id = cmd.get("id")
+        if isinstance(verdict_id, bool) or not isinstance(verdict_id, int):
+            logger.warning("Verdict id must be an integer, got %r", verdict_id)
+            return None
+        action = cmd.get("action")
+        if action not in ("accept", "deny"):
+            logger.warning("Verdict action must be 'accept' or 'deny', got %r", action)
+            return None
+        return (verdict_id, action)
+
+    def emit_banner(self) -> None:
+        """No-op — machine protocol has no banner."""
 
 
-# ── nsenter re-exec ───────────────────────────────────
+# Mapping of human-friendly input to canonical action names.
+_INPUT_MAP: dict[str, str] = {
+    "a": "accept",
+    "allow": "accept",
+    "d": "deny",
+    "deny": "deny",
+}
 
-_NSENTER_ENV = "_TEROK_SHIELD_NFLOG_NSENTER"
-_RAW_ENV = "_TEROK_SHIELD_NFLOG_RAW"
+
+class CliSessionIO:
+    """Human-friendly interactive CLI session I/O.
+
+    Renders blocked connections as readable lines and accepts short
+    operator input (``a``/``d`` or ``allow``/``deny``).  Pending packets
+    are tracked in a FIFO queue — input always targets the oldest.
+    """
+
+    def __init__(self) -> None:
+        """Initialise with empty pending-packet queues."""
+        self._queue: list[int] = []
+        """FIFO of pending packet IDs awaiting a verdict."""
+
+        self._info: dict[int, tuple[str, int, str]] = {}
+        """Packet metadata: *id* → *(dest, port, domain)*."""
+
+    def _prompt_head(self) -> None:
+        """Print the allow/deny prompt for the head-of-queue packet."""
+        if not self._queue:
+            return
+        info = self._info.get(self._queue[0])
+        if info is None:
+            return
+        dest, port, domain = info
+        label = f"{dest} ({domain})" if domain else dest
+        print(f"[BLOCKED] {label} :{port} \u2014 allow/deny? ", end="", flush=True)
+
+    def emit_pending(self, packet_id: int, dest: str, port: int, proto: int, domain: str) -> None:
+        """Show a ``[BLOCKED]`` line and queue the packet for verdict."""
+        label = f"{dest} ({domain})" if domain else dest
+        self._queue.append(packet_id)
+        self._info[packet_id] = (dest, port, domain)
+        if len(self._queue) == 1:
+            self._prompt_head()
+        else:
+            # Additional pending while the operator is thinking.
+            print(f"\n[BLOCKED] {label} :{port} (queued)", flush=True)
+            self._prompt_head()
+
+    def emit_verdict_applied(self, verdict_id: int, dest: str, action: str, *, ok: bool) -> None:
+        """Show verdict result and prompt the next queued packet if any.
+
+        On success the packet is removed from the queue.  On failure it
+        stays queued so the operator can retry with the same ``a``/``d``
+        input (mirrors :meth:`InteractiveSession._process_command` which
+        keeps failed verdicts in ``_pending_by_ip``).
+        """
+        info = self._info.get(verdict_id)
+        target = info[2] if info and info[2] else dest
+        if ok:
+            self._info.pop(verdict_id, None)
+            if verdict_id in self._queue:
+                self._queue.remove(verdict_id)
+            mark = "\u2713" if action == "accept" else "\u2717"
+            verb = "allowed" if action == "accept" else "denied"
+            print(f"  {mark} {verb} {target}")
+        else:
+            print(f"  ! verdict failed for {target} (retry with a/d)")
+        self._prompt_head()
+
+    def parse_command(self, line: str) -> tuple[int, str] | None:
+        """Map operator input to the oldest pending packet.
+
+        Accepts ``a``, ``d``, ``allow``, ``deny`` (case-insensitive).
+        Returns ``None`` and prints a hint on unrecognised input.
+        """
+        action = _INPUT_MAP.get(line.strip().lower())
+        if action is None:
+            print("  Unknown input. Type 'a' to allow or 'd' to deny.", flush=True)
+            self._prompt_head()
+            return None
+        if not self._queue:
+            return None
+        return (self._queue[0], action)
+
+    def emit_banner(self) -> None:
+        """Print a startup message."""
+        print("Watching for blocked connections... (Ctrl-C to stop)\n", flush=True)
+
+
+# ── nsenter re-exec ──────────────────────────────────────
 
 
 def _nsenter_reexec(state_dir: Path, container: str, *, raw: bool) -> None:
@@ -636,57 +643,50 @@ def _nsenter_reexec(state_dir: Path, container: str, *, raw: bool) -> None:
         raise SystemExit(e.returncode) from e
 
 
-# ── Entry point ────────────────────────────────────────
+# ── Helpers ──────────────────────────────────────────────
+
+# Module-level stop flag, set by signal handler.
+_running = True
 
 
-def run_interactive(state_dir: Path, container: str, *, raw: bool = False) -> None:
-    """Start the interactive NFLOG handler for a container.
+def _handle_signal(_signum: int, _frame: object) -> None:
+    """Set the module-level stop flag on SIGINT/SIGTERM."""
+    global _running  # noqa: PLW0603
+    _running = False
 
-    The NFLOG netlink socket must be inside the container's network
-    namespace to receive packets logged by nft rules.  On first
-    invocation, re-execs via ``podman unshare nsenter`` into the
-    container's netns.  The re-exec sets ``_TEROK_SHIELD_NFLOG_NSENTER``
-    so the second invocation runs the handler directly.
+
+def _readable_fds(readable: list) -> set[int]:
+    """Extract file descriptor ints from a ``select.select()`` readable list.
+
+    Handles both raw int fds and objects with a ``fileno()`` method.
+    """
+    return {r if isinstance(r, int) else r.fileno() for r in readable}
+
+
+def _set_nonblocking(fd: int) -> None:
+    """Set a file descriptor to non-blocking mode."""
+    import fcntl
+
+    flags = fcntl.fcntl(fd, fcntl.F_GETFL)
+    fcntl.fcntl(fd, fcntl.F_SETFL, flags | os.O_NONBLOCK)
+
+
+def _append_unique(path: Path, value: str) -> None:
+    """Append *value* to a newline-delimited file if not already present.
+
+    Creates the file if it does not exist.
 
     Args:
-        state_dir: Per-container state directory (may be relative).
-        container: Container name.
-        raw: If ``True``, use JSON-lines protocol; otherwise use the
-            human-friendly CLI (default).
-
-    Raises:
-        SystemExit: If the interactive tier is not configured or NFLOG
-            watcher creation fails.
+        path: Path to the file.
+        value: The value to append (without trailing newline).
     """
-    state_dir = state_dir.resolve()
-    tier = read_interactive_tier(state_dir)
-    if tier != "nflog":
-        print(
-            f"Error: interactive tier not configured (got {tier!r}, expected 'nflog').",
-            file=sys.stderr,
-        )
-        raise SystemExit(1)
-
-    if os.environ.get(_NSENTER_ENV) != "1":
-        _nsenter_reexec(state_dir, container, raw=raw)
+    existing: set[str] = set()
+    if path.is_file():
+        existing = {line.strip() for line in path.read_text().splitlines() if line.strip()}
+    if value in existing:
         return
-
-    io: SessionIO = JsonSessionIO() if raw else CliSessionIO()
-    runner = SubprocessRunner()
-    session = InteractiveSession(runner=runner, state_dir=state_dir, container=container, io=io)
-    session.run()
-
-
-def _main() -> None:
-    """CLI entry point for ``python -m terok_shield.cli.interactive``."""
-    if len(sys.argv) != 3:
-        print(
-            f"Usage: {sys.executable} -m terok_shield.cli.interactive <state_dir> <container>",
-            file=sys.stderr,
-        )
-        raise SystemExit(2)
-    raw = os.environ.get(_RAW_ENV) == "1"
-    run_interactive(Path(sys.argv[1]), sys.argv[2], raw=raw)
+    with open(path, "a") as f:
+        f.write(value + "\n")
 
 
 if __name__ == "__main__":

--- a/src/terok_shield/cli/interactive.py
+++ b/src/terok_shield/cli/interactive.py
@@ -21,6 +21,8 @@ persisted to ``live.allowed``; denied IPs are added to the deny sets and
 persisted to ``deny.list``.
 """
 
+# Needed for forward-referencing SessionIO in InteractiveSession annotations.
+# Remove once we target Python 3.14+ (PEP 649 makes evaluation lazy by default).
 from __future__ import annotations
 
 import json

--- a/src/terok_shield/cli/main.py
+++ b/src/terok_shield/cli/main.py
@@ -1,7 +1,13 @@
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
-"""CLI entry point for terok-shield."""
+"""Standalone CLI — parses argv, builds a Shield, and dispatches commands.
+
+Constructs :class:`ShieldConfig` from ``config.yml``, XDG conventions,
+and environment variables, then routes each subcommand through the
+:data:`~.registry.COMMANDS` registry.  Commands that need standalone CLI
+logic (``prepare``, ``run``, ``setup``) are handled directly here.
+"""
 
 import argparse
 import json
@@ -17,123 +23,103 @@ from ..common.config import ShieldFileConfig
 from ..common.validation import validate_container_name
 from .registry import COMMANDS, ArgDef, CommandDef
 
-# ── Config construction (formerly in config.py) ──────────
+# ── Entry point ──────────────────────────────────────────
 
 
-def _resolve_state_root() -> Path:
-    """Resolve the state root from env / XDG / default."""
-    env = os.environ.get("TEROK_SHIELD_STATE_DIR")
-    if env:
-        return Path(env)
-    xdg = os.environ.get("XDG_STATE_HOME")
-    base = Path(xdg) if xdg else Path.home() / ".local" / "state"
-    return base / "terok" / "shield"
+def main(argv: list[str] | None = None) -> None:
+    """Run the terok-shield CLI."""
+    if argv is None:
+        argv = sys.argv[1:]
 
+    # The 'run' subcommand uses '--' to separate shield args from podman args.
+    # Split before argparse to avoid REMAINDER quirks with optional flags.
+    saw_separator = "--" in argv
+    run_trailing: list[str] = []
+    if saw_separator:
+        sep = argv.index("--")
+        run_trailing = argv[sep + 1 :]
+        argv = argv[:sep]
 
-def _resolve_config_root() -> Path:
-    """Resolve the config root from env / XDG / default."""
-    env = os.environ.get("TEROK_SHIELD_CONFIG_DIR")
-    if env:
-        return Path(env)
-    xdg = os.environ.get("XDG_CONFIG_HOME")
-    base = Path(xdg) if xdg else Path.home() / ".config"
-    return base / "terok" / "shield"
+    parser = _build_parser()
+    args = parser.parse_args(argv)
 
+    if saw_separator and args.command != "run":
+        parser.error("'--' separator is only supported by the 'run' subcommand")
 
-def _auto_detect_mode() -> ShieldMode:
-    """Auto-detect the best available shield mode.
+    if args.command is None:
+        parser.print_help()
+        sys.exit(0)
 
-    Currently only hook mode is supported.
-
-    Raises:
-        NftNotFoundError: If nft is not installed.
-    """
-    from ..core.run import NftNotFoundError, find_nft
-
-    if find_nft():
-        return ShieldMode.HOOK
-
-    raise NftNotFoundError("No supported shield mode available. Install nft for hook mode.")
-
-
-def _load_config_file() -> ShieldFileConfig:
-    """Load and validate ``config.yml`` via :class:`ShieldFileConfig`.
-
-    Returns defaults when the file is missing or contains invalid YAML.
-    Validation errors (typos, wrong types) abort with a clear message.
-    """
-    import yaml
-    from pydantic import ValidationError
-
-    config_file = _resolve_config_root() / "config.yml"
-    if not config_file.is_file():
-        return ShieldFileConfig()
+    if args.command == "run":
+        args.podman_args = run_trailing
 
     try:
-        raw = yaml.safe_load(config_file.read_text()) or {}
-    except yaml.YAMLError as e:
-        print(f"Warning [shield]: failed to parse {config_file}: {e}", file=sys.stderr)
-        return ShieldFileConfig()
-    except OSError as e:
-        print(f"Warning [shield]: failed to read {config_file}: {e}", file=sys.stderr)
-        return ShieldFileConfig()
-
-    if not isinstance(raw, dict):
-        print(
-            f"Warning [shield]: {config_file}: expected mapping, got {type(raw).__name__}",
-            file=sys.stderr,
-        )
-        return ShieldFileConfig()
-
-    try:
-        return ShieldFileConfig(**raw)
-    except ValidationError as e:
-        print(f"Error [shield]: invalid {config_file}:\n{e}", file=sys.stderr)
+        _dispatch(args)
+    except (RuntimeError, ValueError, ExecError, OSError) as e:
+        print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)
 
 
-def _build_config(
-    container: str | None = None,
-    *,
-    state_dir_override: Path | None = None,
-    interactive: bool | None = None,
-) -> ShieldConfig:
-    """Build a ShieldConfig from config.yml + env vars.
+# ── Command dispatch ─────────────────────────────────────
 
-    Args:
-        container: Container name (used for per-container state_dir).
-        state_dir_override: Explicit state_dir from --state-dir flag.
-        interactive: Override config.yml interactive flag (CLI ``--interactive``).
-    """
-    file_cfg = _load_config_file()
+# Command lookup for dispatch
+_CMD_LOOKUP: dict[str, CommandDef] = {cmd.name: cmd for cmd in COMMANDS}
 
-    # Resolve mode
-    mode = _auto_detect_mode() if file_cfg.mode == "auto" else ShieldMode.HOOK
 
-    # State dir
-    if state_dir_override:
-        state_root = state_dir_override.resolve()
-    else:
-        state_root = _resolve_state_root().resolve()
+def _dispatch(args: argparse.Namespace) -> None:
+    """Dispatch to the appropriate subcommand handler."""
+    cmd_name = args.command
+    state_dir_override = getattr(args, "state_dir", None)
 
-    if container:
-        validate_container_name(container)
-        state_dir = state_root / "containers" / container
-    else:
-        state_dir = state_root / "containers" / "_default"
+    # CLI-only: setup doesn't need Shield
+    if cmd_name == "setup":
+        _cmd_setup(root=getattr(args, "root", False), user=getattr(args, "user", False))
+        return
 
-    # Profiles dir
-    profiles_dir = _resolve_config_root() / "profiles"
+    # CLI-only: logs with aggregated mode (no container -> scan all)
+    if cmd_name == "logs":
+        _cmd_logs_cli(
+            state_dir_override=state_dir_override,
+            container=getattr(args, "container", None),
+            n=args.n,
+        )
+        return
 
-    return ShieldConfig(
-        state_dir=state_dir,
-        mode=mode,
-        default_profiles=tuple(file_cfg.default_profiles),
-        loopback_ports=tuple(file_cfg.loopback_ports),
-        audit_enabled=file_cfg.audit.enabled,
-        profiles_dir=profiles_dir,
-        interactive=interactive if interactive is not None else file_cfg.interactive,
+    # All other commands need a per-container config + Shield
+    container = getattr(args, "container", None)
+    interactive_override = getattr(args, "interactive", None) or None  # False → None
+    config = _build_config(
+        container, state_dir_override=state_dir_override, interactive=interactive_override
     )
+    shield = Shield(config)
+
+    # CLI-only standalone commands with custom logic
+    if cmd_name == "prepare":
+        _cmd_prepare(shield, args.container, profiles=args.profiles, output_json=args.output_json)
+    elif cmd_name == "run":
+        _cmd_run(shield, args.container, profiles=args.profiles, podman_args=args.podman_args)
+    elif cmd_name == "resolve":
+        _cmd_resolve(shield, args.container, force=args.force)
+    else:
+        # Generic registry dispatch
+        cmd_def = _CMD_LOOKUP[cmd_name]
+        if cmd_def.handler is None:
+            raise RuntimeError(f"Command {cmd_name!r} has no handler (standalone-only)")
+        kwargs = _extract_handler_kwargs(args, cmd_def)
+        if cmd_def.needs_container:
+            cmd_def.handler(shield, container, **kwargs)
+        else:
+            cmd_def.handler(shield, **kwargs)
+
+
+def _extract_handler_kwargs(args: argparse.Namespace, cmd: CommandDef) -> dict:
+    """Extract keyword arguments for a registry handler from parsed args."""
+    kwargs: dict = {}
+    for arg in cmd.args:
+        key = arg.dest or arg.name.lstrip("-").replace("-", "_")
+        if hasattr(args, key):
+            kwargs[key] = getattr(args, key)
+    return kwargs
 
 
 # ── Argument parser ──────────────────────────────────────
@@ -151,27 +137,6 @@ _DESCRIPTIONS: dict[str, str] = {
         "  terok-shield run my-container -- alpine:latest sh"
     ),
 }
-
-# Command lookup for dispatch
-_CMD_LOOKUP: dict[str, CommandDef] = {cmd.name: cmd for cmd in COMMANDS}
-
-
-def _add_argdef(parser: argparse.ArgumentParser, arg: ArgDef) -> None:
-    """Add an :class:`ArgDef` to an argparse parser."""
-    kwargs: dict = {}
-    if arg.help:
-        kwargs["help"] = arg.help
-    if arg.type is not None:
-        kwargs["type"] = arg.type
-    if arg.default is not None:
-        kwargs["default"] = arg.default
-    if arg.action is not None:
-        kwargs["action"] = arg.action
-    if arg.dest is not None:
-        kwargs["dest"] = arg.dest
-    if arg.nargs is not None:
-        kwargs["nargs"] = arg.nargs
-    parser.add_argument(arg.name, **kwargs)
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -236,97 +201,25 @@ def _build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def main(argv: list[str] | None = None) -> None:
-    """Run the terok-shield CLI."""
-    if argv is None:
-        argv = sys.argv[1:]
-
-    # The 'run' subcommand uses '--' to separate shield args from podman args.
-    # Split before argparse to avoid REMAINDER quirks with optional flags.
-    saw_separator = "--" in argv
-    run_trailing: list[str] = []
-    if saw_separator:
-        sep = argv.index("--")
-        run_trailing = argv[sep + 1 :]
-        argv = argv[:sep]
-
-    parser = _build_parser()
-    args = parser.parse_args(argv)
-
-    if saw_separator and args.command != "run":
-        parser.error("'--' separator is only supported by the 'run' subcommand")
-
-    if args.command is None:
-        parser.print_help()
-        sys.exit(0)
-
-    if args.command == "run":
-        args.podman_args = run_trailing
-
-    try:
-        _dispatch(args)
-    except (RuntimeError, ValueError, ExecError, OSError) as e:
-        print(f"Error: {e}", file=sys.stderr)
-        sys.exit(1)
-
-
-def _extract_handler_kwargs(args: argparse.Namespace, cmd: CommandDef) -> dict:
-    """Extract keyword arguments for a registry handler from parsed args."""
+def _add_argdef(parser: argparse.ArgumentParser, arg: ArgDef) -> None:
+    """Add an :class:`ArgDef` to an argparse parser."""
     kwargs: dict = {}
-    for arg in cmd.args:
-        key = arg.dest or arg.name.lstrip("-").replace("-", "_")
-        if hasattr(args, key):
-            kwargs[key] = getattr(args, key)
-    return kwargs
+    if arg.help:
+        kwargs["help"] = arg.help
+    if arg.type is not None:
+        kwargs["type"] = arg.type
+    if arg.default is not None:
+        kwargs["default"] = arg.default
+    if arg.action is not None:
+        kwargs["action"] = arg.action
+    if arg.dest is not None:
+        kwargs["dest"] = arg.dest
+    if arg.nargs is not None:
+        kwargs["nargs"] = arg.nargs
+    parser.add_argument(arg.name, **kwargs)
 
 
-def _dispatch(args: argparse.Namespace) -> None:
-    """Dispatch to the appropriate subcommand handler."""
-    cmd_name = args.command
-    state_dir_override = getattr(args, "state_dir", None)
-
-    # CLI-only: setup doesn't need Shield
-    if cmd_name == "setup":
-        _cmd_setup(root=getattr(args, "root", False), user=getattr(args, "user", False))
-        return
-
-    # CLI-only: logs with aggregated mode (no container -> scan all)
-    if cmd_name == "logs":
-        _cmd_logs_cli(
-            state_dir_override=state_dir_override,
-            container=getattr(args, "container", None),
-            n=args.n,
-        )
-        return
-
-    # All other commands need a per-container config + Shield
-    container = getattr(args, "container", None)
-    interactive_override = getattr(args, "interactive", None) or None  # False → None
-    config = _build_config(
-        container, state_dir_override=state_dir_override, interactive=interactive_override
-    )
-    shield = Shield(config)
-
-    # CLI-only standalone commands with custom logic
-    if cmd_name == "prepare":
-        _cmd_prepare(shield, args.container, profiles=args.profiles, output_json=args.output_json)
-    elif cmd_name == "run":
-        _cmd_run(shield, args.container, profiles=args.profiles, podman_args=args.podman_args)
-    elif cmd_name == "resolve":
-        _cmd_resolve(shield, args.container, force=args.force)
-    else:
-        # Generic registry dispatch
-        cmd_def = _CMD_LOOKUP[cmd_name]
-        if cmd_def.handler is None:
-            raise RuntimeError(f"Command {cmd_name!r} has no handler (standalone-only)")
-        kwargs = _extract_handler_kwargs(args, cmd_def)
-        if cmd_def.needs_container:
-            cmd_def.handler(shield, container, **kwargs)
-        else:
-            cmd_def.handler(shield, **kwargs)
-
-
-# ── CLI-only command handlers ─────────────────────────────
+# ── CLI-only command handlers ────────────────────────────
 
 
 def _cmd_prepare(
@@ -343,6 +236,29 @@ def _cmd_prepare(
         print(json.dumps(podman_args))
     else:
         print(" ".join(shlex.quote(a) for a in podman_args))
+
+
+def _cmd_run(
+    shield: Shield,
+    container: str,
+    *,
+    profiles: list[str] | None,
+    podman_args: list[str],
+) -> None:
+    """Launch a shielded container by exec-ing into podman run."""
+    if not podman_args:
+        raise ValueError(
+            "No image specified. Usage: terok-shield run <container> -- <image> [cmd...]"
+        )
+
+    _reject_shield_managed_flags(podman_args)
+
+    podman = _find_podman()
+    shield_args = shield.pre_start(container, profiles)
+    argv = [podman, "run", "--name", container, *shield_args, *podman_args]
+    # Exec replaces the current process; argv is constructed locally and uses
+    # an absolute podman path, so shell injection and PATH spoofing do not apply.
+    os.execv(podman, argv)  # nosec B606
 
 
 _SHIELD_MANAGED_FLAGS = frozenset(
@@ -381,29 +297,6 @@ def _reject_shield_managed_flags(podman_args: list[str]) -> None:
         )
 
 
-def _cmd_run(
-    shield: Shield,
-    container: str,
-    *,
-    profiles: list[str] | None,
-    podman_args: list[str],
-) -> None:
-    """Launch a shielded container by exec-ing into podman run."""
-    if not podman_args:
-        raise ValueError(
-            "No image specified. Usage: terok-shield run <container> -- <image> [cmd...]"
-        )
-
-    _reject_shield_managed_flags(podman_args)
-
-    podman = _find_podman()
-    shield_args = shield.pre_start(container, profiles)
-    argv = [podman, "run", "--name", container, *shield_args, *podman_args]
-    # Exec replaces the current process; argv is constructed locally and uses
-    # an absolute podman path, so shell injection and PATH spoofing do not apply.
-    os.execv(podman, argv)  # nosec B606
-
-
 def _cmd_resolve(shield: Shield, container: str, force: bool) -> None:
     """Resolve DNS profiles and cache results."""
     ips = shield.resolve(force=force)
@@ -413,32 +306,13 @@ def _cmd_resolve(shield: Shield, container: str, force: bool) -> None:
         print(f"  {ip}")
 
 
-# ── CLI-only logs with aggregation ────────────────────────
-
-
-def _collect_all_audit_entries(state_root: Path, n: int) -> list[dict]:
-    """Collect audit entries from all containers, sorted by timestamp, trimmed to n."""
-    from ..lib.audit import AuditLogger
-
-    containers_dir = state_root / "containers"
-    if not containers_dir.is_dir():
-        return []
-    entries: list[dict] = []
-    for ctr_dir in sorted(containers_dir.iterdir()):
-        audit_file = ctr_dir / "audit.jsonl"
-        if audit_file.is_file():
-            entries.extend(AuditLogger(audit_path=audit_file).tail_log(n))
-    entries.sort(key=lambda e: e.get("ts", ""))
-    return entries[-n:]
-
-
 def _cmd_logs_cli(
     *,
     state_dir_override: Path | None,
     container: str | None,
     n: int,
 ) -> None:
-    """Show audit log entries (CLI-only: supports aggregated mode).
+    """Show audit log entries — supports aggregated mode without Shield.
 
     When ``container`` is given, tails that container's audit log directly
     (no Shield needed — avoids requiring nft for a read-only operation).
@@ -460,6 +334,22 @@ def _cmd_logs_cli(
             return
         for entry in entries:
             print(json.dumps(entry))
+
+
+def _collect_all_audit_entries(state_root: Path, n: int) -> list[dict]:
+    """Collect audit entries from all containers, sorted by timestamp, trimmed to n."""
+    from ..lib.audit import AuditLogger
+
+    containers_dir = state_root / "containers"
+    if not containers_dir.is_dir():
+        return []
+    entries: list[dict] = []
+    for ctr_dir in sorted(containers_dir.iterdir()):
+        audit_file = ctr_dir / "audit.jsonl"
+        if audit_file.is_file():
+            entries.extend(AuditLogger(audit_path=audit_file).tail_log(n))
+    entries.sort(key=lambda e: e.get("ts", ""))
+    return entries[-n:]
 
 
 def _cmd_setup(*, root: bool, user: bool) -> None:
@@ -506,11 +396,126 @@ def _cmd_setup(*, root: bool, user: bool) -> None:
         print("Done. Global hooks installed.")
 
 
-def _get_version() -> str:
-    """Return the package version."""
-    from .. import __version__
+# ── Config construction ──────────────────────────────────
 
-    return __version__
+
+def _build_config(
+    container: str | None = None,
+    *,
+    state_dir_override: Path | None = None,
+    interactive: bool | None = None,
+) -> ShieldConfig:
+    """Build a ShieldConfig from config.yml + env vars.
+
+    Args:
+        container: Container name (used for per-container state_dir).
+        state_dir_override: Explicit state_dir from --state-dir flag.
+        interactive: Override config.yml interactive flag (CLI ``--interactive``).
+    """
+    file_cfg = _load_config_file()
+
+    # Resolve mode
+    mode = _auto_detect_mode() if file_cfg.mode == "auto" else ShieldMode.HOOK
+
+    # State dir
+    if state_dir_override:
+        state_root = state_dir_override.resolve()
+    else:
+        state_root = _resolve_state_root().resolve()
+
+    if container:
+        validate_container_name(container)
+        state_dir = state_root / "containers" / container
+    else:
+        state_dir = state_root / "containers" / "_default"
+
+    # Profiles dir
+    profiles_dir = _resolve_config_root() / "profiles"
+
+    return ShieldConfig(
+        state_dir=state_dir,
+        mode=mode,
+        default_profiles=tuple(file_cfg.default_profiles),
+        loopback_ports=tuple(file_cfg.loopback_ports),
+        audit_enabled=file_cfg.audit.enabled,
+        profiles_dir=profiles_dir,
+        interactive=interactive if interactive is not None else file_cfg.interactive,
+    )
+
+
+def _load_config_file() -> ShieldFileConfig:
+    """Load and validate ``config.yml`` via :class:`ShieldFileConfig`.
+
+    Returns defaults when the file is missing or contains invalid YAML.
+    Validation errors (typos, wrong types) abort with a clear message.
+    """
+    import yaml
+    from pydantic import ValidationError
+
+    config_file = _resolve_config_root() / "config.yml"
+    if not config_file.is_file():
+        return ShieldFileConfig()
+
+    try:
+        raw = yaml.safe_load(config_file.read_text()) or {}
+    except yaml.YAMLError as e:
+        print(f"Warning [shield]: failed to parse {config_file}: {e}", file=sys.stderr)
+        return ShieldFileConfig()
+    except OSError as e:
+        print(f"Warning [shield]: failed to read {config_file}: {e}", file=sys.stderr)
+        return ShieldFileConfig()
+
+    if not isinstance(raw, dict):
+        print(
+            f"Warning [shield]: {config_file}: expected mapping, got {type(raw).__name__}",
+            file=sys.stderr,
+        )
+        return ShieldFileConfig()
+
+    try:
+        return ShieldFileConfig(**raw)
+    except ValidationError as e:
+        print(f"Error [shield]: invalid {config_file}:\n{e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def _resolve_state_root() -> Path:
+    """Resolve the state root from env / XDG / default."""
+    env = os.environ.get("TEROK_SHIELD_STATE_DIR")
+    if env:
+        return Path(env)
+    xdg = os.environ.get("XDG_STATE_HOME")
+    base = Path(xdg) if xdg else Path.home() / ".local" / "state"
+    return base / "terok" / "shield"
+
+
+def _resolve_config_root() -> Path:
+    """Resolve the config root from env / XDG / default."""
+    env = os.environ.get("TEROK_SHIELD_CONFIG_DIR")
+    if env:
+        return Path(env)
+    xdg = os.environ.get("XDG_CONFIG_HOME")
+    base = Path(xdg) if xdg else Path.home() / ".config"
+    return base / "terok" / "shield"
+
+
+def _auto_detect_mode() -> ShieldMode:
+    """Auto-detect the best available shield mode.
+
+    Currently only hook mode is supported.
+
+    Raises:
+        NftNotFoundError: If nft is not installed.
+    """
+    from ..core.run import NftNotFoundError, find_nft
+
+    if find_nft():
+        return ShieldMode.HOOK
+
+    raise NftNotFoundError("No supported shield mode available. Install nft for hook mode.")
+
+
+# ── Version display ──────────────────────────────────────
 
 
 def _version_string() -> str:
@@ -536,3 +541,10 @@ def _version_string() -> str:
     nft = find_nft()
     lines.append(f"nft {'found' if nft else 'not found'}")
     return "\n".join(lines)
+
+
+def _get_version() -> str:
+    """Return the package version."""
+    from .. import __version__
+
+    return __version__

--- a/src/terok_shield/cli/main.py
+++ b/src/terok_shield/cli/main.py
@@ -272,6 +272,11 @@ _SHIELD_MANAGED_FLAGS = frozenset(
     }
 )
 
+# Podman flag aliases that map to a canonical shield-managed flag.
+_FLAG_ALIASES: dict[str, str] = {
+    "--net": "--network",
+}
+
 
 def _find_podman() -> str:
     """Locate the podman binary for the ``run`` subcommand."""
@@ -289,6 +294,7 @@ def _reject_shield_managed_flags(podman_args: list[str]) -> None:
     for arg in podman_args:
         if arg.startswith("--"):
             flag = arg.split("=", 1)[0]
+            flag = _FLAG_ALIASES.get(flag, flag)
             if flag in _SHIELD_MANAGED_FLAGS:
                 conflicts.add(flag)
     if conflicts:

--- a/src/terok_shield/cli/registry.py
+++ b/src/terok_shield/cli/registry.py
@@ -1,15 +1,12 @@
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
-"""Command registry for terok-shield.
+"""Every subcommand terok-shield exposes — arguments, handler, and help text.
 
-Provides :class:`CommandDef` and :class:`ArgDef` dataclasses that describe
-every shield subcommand — its arguments, handler function, and metadata.
 The ``COMMANDS`` tuple is the single source of truth consumed by both the
-standalone CLI and the terok integration layer.
-
-Handler functions accept ``(shield, container?, **kwargs)`` and print to
-stdout, making them reusable across different CLI frontends.
+standalone CLI and the terok integration layer.  Handler functions accept
+``(shield, container?, **kwargs)`` and print to stdout, making them
+reusable across different CLI frontends.
 """
 
 import json
@@ -54,23 +51,7 @@ class CommandDef:
     standalone_only: bool = False
 
 
-# ── Handler functions ─────────────────────────────────────
-
-
-def _format_version(v: tuple[int, ...]) -> str:
-    """Format a version tuple as a dotted string."""
-    return ".".join(str(p) for p in v) if v != (0,) else "unknown"
-
-
-def _print_env_hint(env: EnvironmentCheck) -> None:
-    """Print human-readable environment issues and setup hint."""
-    if env.issues:
-        print()
-        for issue in env.issues:
-            print(f"  {issue}")
-    if env.setup_hint:
-        print()
-        print(env.setup_hint)
+# ── Handler functions (ordered to match COMMANDS) ────────
 
 
 def _handle_status(shield: Shield, *, container: str | None = None) -> None:
@@ -139,29 +120,6 @@ def _handle_rules(shield: Shield, container: str) -> None:
         print(f"No rules found for {container}")
 
 
-def _handle_logs(shield: Shield, container: str, *, n: int = 50) -> None:
-    """Show per-container audit log entries."""
-    for entry in shield.tail_log(n):
-        print(json.dumps(entry))
-
-
-def _handle_profiles(shield: Shield) -> None:
-    """List available shield profiles."""
-    for name in shield.profiles_list():
-        print(name)
-
-
-def _handle_check_environment(shield: Shield) -> None:
-    """Check podman environment for compatibility issues."""
-    result = shield.check_environment()
-    # Machine-readable block
-    print(f"podman_version={_format_version(result.podman_version)}")
-    print(f"hooks={result.hooks}")
-    print(f"health={result.health}")
-    # Human-readable details (shared with status)
-    _print_env_hint(result)
-
-
 def _handle_watch(shield: Shield, container: str) -> None:
     """Stream blocked-access events as JSON lines."""
     from .watch import run_watch
@@ -183,6 +141,27 @@ def _handle_dbus_bridge(shield: Shield, container: str) -> None:
     run_dbus_bridge(shield.config.state_dir, container)
 
 
+def _handle_logs(shield: Shield, container: str, *, n: int = 50) -> None:
+    """Show per-container audit log entries."""
+    for entry in shield.tail_log(n):
+        print(json.dumps(entry))
+
+
+def _handle_profiles(shield: Shield) -> None:
+    """List available shield profiles."""
+    for name in shield.profiles_list():
+        print(name)
+
+
+def _handle_check_environment(shield: Shield) -> None:
+    """Check podman environment for compatibility issues."""
+    result = shield.check_environment()
+    print(f"podman_version={_format_version(result.podman_version)}")
+    print(f"hooks={result.hooks}")
+    print(f"health={result.health}")
+    _print_env_hint(result)
+
+
 def _handle_preview(shield: Shield, *, down: bool = False, allow_all: bool = False) -> None:
     """Show ruleset that would be applied."""
     if allow_all and not down:
@@ -193,6 +172,22 @@ def _handle_preview(shield: Shield, *, down: bool = False, allow_all: bool = Fal
         label += " (all traffic)"
     print(f"# Ruleset preview ({label}):")
     print(ruleset)
+
+
+def _format_version(v: tuple[int, ...]) -> str:
+    """Format a version tuple as a dotted string."""
+    return ".".join(str(p) for p in v) if v != (0,) else "unknown"
+
+
+def _print_env_hint(env: EnvironmentCheck) -> None:
+    """Print human-readable environment issues and setup hint."""
+    if env.issues:
+        print()
+        for issue in env.issues:
+            print(f"  {issue}")
+    if env.setup_hint:
+        print()
+        print(env.setup_hint)
 
 
 # ── Command definitions ───────────────────────────────────

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -449,6 +449,8 @@ def test_run_and_separator_validation(
         pytest.param("--hooks-dir=/tmp", id="hooks-dir-equals"),
         pytest.param("--cap-add=NET_ADMIN", id="cap-add-equals"),
         pytest.param("--cap-drop=ALL", id="cap-drop-equals"),
+        pytest.param("--net", id="net-alias"),
+        pytest.param("--net=host", id="net-alias-equals"),
     ],
 )
 def test_run_rejects_shield_managed_flags(


### PR DESCRIPTION
## Summary
- Reorder `registry.py`, `main.py`, and `interactive.py` so each file reads top-down in the order a developer would follow the logic
- Handler definitions in registry now match COMMANDS tuple order
- Entry points lead each narrative file, implementation details follow

## Changes
- **registry.py**: handlers reordered to match COMMANDS, formatting helpers moved below handlers
- **main.py**: `main()` leads → dispatch → parser → CLI-only handlers → config assembly → version
- **interactive.py**: `run_interactive` leads → InteractiveSession → I/O protocol → nsenter → helpers

## Test plan
- [x] `make lint` — passes
- [x] `make test-unit` — 993 passed
- [x] `make tach` — module boundaries validated
- [x] `make docstrings` — 100% coverage
- [x] `make reuse` — SPDX compliant

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized CLI entry points, command routing, and configuration initialization for clearer, more reliable behavior.
  * Reworked interactive mode startup and IO selection to streamline interactive sessions.
* **Bug Fixes**
  * Improved handling of networking flag aliases to correctly detect and reject managed flags.
* **Tests**
  * Added test cases covering podman networking flag aliases to ensure proper rejection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->