### PR TITLE
refactor: remove interactive flag — always use BLOCKED terminal prefix

### DIFF
--- a/src/terok_shield/cli/interactive.py
+++ b/src/terok_shield/cli/interactive.py
@@ -39,7 +39,6 @@ from typing import Protocol, runtime_checkable
 from ..core import state
 from ..core.nft import add_deny_elements_dual, add_elements_dual
 from ..core.run import CommandRunner, SubprocessRunner
-from ..core.state import read_interactive_tier
 from ..lib.watchers import DomainCache, NflogWatcher, WatchEvent
 
 logger = logging.getLogger(__name__)
@@ -64,24 +63,17 @@ def run_interactive(state_dir: Path, container: str, *, raw: bool = False) -> No
     container's netns.  The re-exec sets ``_TEROK_SHIELD_NFLOG_NSENTER``
     so the second invocation runs the handler directly.
 
+    The terminal deny rule always logs with the BLOCKED prefix to
+    NFLOG group 100, so the interactive handler works for any shielded
+    container without special configuration.
+
     Args:
         state_dir: Per-container state directory (may be relative).
         container: Container name.
         raw: If ``True``, use JSON-lines protocol; otherwise use the
             human-friendly CLI (default).
-
-    Raises:
-        SystemExit: If the interactive tier is not configured or NFLOG
-            watcher creation fails.
     """
     state_dir = state_dir.resolve()
-    tier = read_interactive_tier(state_dir)
-    if tier != "nflog":
-        print(
-            f"Error: interactive tier not configured (got {tier!r}, expected 'nflog').",
-            file=sys.stderr,
-        )
-        raise SystemExit(1)
 
     if os.environ.get(_NSENTER_ENV) != "1":
         _nsenter_reexec(state_dir, container, raw=raw)

--- a/src/terok_shield/cli/main.py
+++ b/src/terok_shield/cli/main.py
@@ -90,10 +90,7 @@ def _dispatch(args: argparse.Namespace) -> None:
 
     # All other commands need a per-container config + Shield
     container = getattr(args, "container", None)
-    interactive_override = getattr(args, "interactive", None) or None  # False → None
-    config = _build_config(
-        container, state_dir_override=state_dir_override, interactive=interactive_override
-    )
+    config = _build_config(container, state_dir_override=state_dir_override)
     shield = Shield(config)
 
     # CLI-only standalone commands with custom logic
@@ -412,14 +409,12 @@ def _build_config(
     container: str | None = None,
     *,
     state_dir_override: Path | None = None,
-    interactive: bool | None = None,
 ) -> ShieldConfig:
     """Build a ShieldConfig from config.yml + env vars.
 
     Args:
         container: Container name (used for per-container state_dir).
         state_dir_override: Explicit state_dir from --state-dir flag.
-        interactive: Override config.yml interactive flag (CLI ``--interactive``).
     """
     file_cfg = _load_config_file()
 
@@ -448,7 +443,6 @@ def _build_config(
         loopback_ports=tuple(file_cfg.loopback_ports),
         audit_enabled=file_cfg.audit.enabled,
         profiles_dir=profiles_dir,
-        interactive=interactive if interactive is not None else file_cfg.interactive,
     )
 
 

--- a/src/terok_shield/cli/registry.py
+++ b/src/terok_shield/cli/registry.py
@@ -213,11 +213,6 @@ COMMANDS: tuple[CommandDef, ...] = (
         standalone_only=True,
         args=(
             ArgDef(name="--profiles", nargs="+", help="Override default profiles"),
-            ArgDef(
-                name="--interactive",
-                action="store_true",
-                help="Enable NFLOG interactive verdict mode",
-            ),
             ArgDef(name="--json", action="store_true", dest="output_json", help="JSON output"),
         ),
     ),
@@ -226,14 +221,7 @@ COMMANDS: tuple[CommandDef, ...] = (
         help="Launch a shielded container via podman",
         needs_container=True,
         standalone_only=True,
-        args=(
-            ArgDef(name="--profiles", nargs="+", help="Override default profiles"),
-            ArgDef(
-                name="--interactive",
-                action="store_true",
-                help="Enable NFLOG interactive verdict mode",
-            ),
-        ),
+        args=(ArgDef(name="--profiles", nargs="+", help="Override default profiles"),),
     ),
     CommandDef(
         name="resolve",

--- a/src/terok_shield/common/config.py
+++ b/src/terok_shield/common/config.py
@@ -27,7 +27,6 @@ ANNOTATION_VERSION_KEY = "terok.shield.version"
 ANNOTATION_AUDIT_ENABLED_KEY = "terok.shield.audit_enabled"
 ANNOTATION_UPSTREAM_DNS_KEY = "terok.shield.upstream_dns"
 ANNOTATION_DNS_TIER_KEY = "terok.shield.dns_tier"
-ANNOTATION_INTERACTIVE_KEY = "terok.shield.interactive"
 
 
 # ── DNS tier ────────────────────────────────────────────
@@ -119,7 +118,6 @@ class ShieldConfig:
     loopback_ports: tuple[int, ...] = ()
     audit_enabled: bool = True
     profiles_dir: Path | None = None
-    interactive: bool = False
 
 
 # ── Config-file schema (Pydantic) ───────────────────────
@@ -151,7 +149,6 @@ class ShieldFileConfig(BaseModel):
         default_factory=list,
         description="TCP ports forwarded to host loopback (via pasta ``-T``)",
     )
-    interactive: bool = Field(default=False, description="Enable interactive NFLOG approval mode")
     audit: AuditFileConfig = Field(
         default_factory=AuditFileConfig, description="Audit logging settings"
     )

--- a/src/terok_shield/core/mode_hook.py
+++ b/src/terok_shield/core/mode_hook.py
@@ -27,7 +27,6 @@ from typing import TYPE_CHECKING
 from ..common.config import (
     ANNOTATION_AUDIT_ENABLED_KEY,
     ANNOTATION_DNS_TIER_KEY,
-    ANNOTATION_INTERACTIVE_KEY,
     ANNOTATION_KEY,
     ANNOTATION_LOOPBACK_PORTS_KEY,
     ANNOTATION_NAME_KEY,
@@ -125,7 +124,6 @@ class HookMode:
         """
         sd = self._config.state_dir.resolve()
         info = self._get_podman_info()
-        interactive = self._config.interactive
 
         # Ensure state dirs and install hooks (idempotent)
         state.ensure_state_dirs(sd)
@@ -174,8 +172,6 @@ class HookMode:
             f"{ANNOTATION_UPSTREAM_DNS_KEY}={upstream_dns}",
             "--annotation",
             f"{ANNOTATION_DNS_TIER_KEY}={tier.value}",
-            "--annotation",
-            f"{ANNOTATION_INTERACTIVE_KEY}={str(interactive).lower()}",
         ]
 
         # WORKAROUND(hooks-dir-persist): currently always takes the global path
@@ -219,7 +215,6 @@ class HookMode:
     def _write_ruleset(self, sd: Path, tier: DnsTier, upstream_dns: str) -> None:
         """Pre-generate the complete nft ruleset into the state bundle."""
         set_timeout = NFT_SET_TIMEOUT_DNSMASQ if tier == DnsTier.DNSMASQ else ""
-        interactive = self._config.interactive
         ruleset_builder = RulesetBuilder(
             dns=upstream_dns,
             loopback_ports=self._config.loopback_ports,
@@ -227,17 +222,11 @@ class HookMode:
         )
         ips = state.read_effective_ips(sd)
         denied_ips = list(state.read_denied_ips(sd))
-        ruleset = ruleset_builder.build_hook(interactive=interactive)
+        ruleset = ruleset_builder.build_hook()
         ruleset += ruleset_builder.add_elements_dual(ips)
         if denied_ips:
             ruleset += add_deny_elements_dual(denied_ips)
         state.ruleset_path(sd).write_text(ruleset)
-
-        # Persist interactive mode flag for shield_up() and the verdict handler
-        if interactive:
-            state.interactive_path(sd).write_text("nflog\n")
-        else:
-            state.interactive_path(sd).unlink(missing_ok=True)
 
     def _write_dnsmasq_config_or_scrub(self, sd: Path, tier: DnsTier, upstream_dns: str) -> None:
         """Pre-generate dnsmasq config for dnsmasq tier, or scrub stale artifacts."""
@@ -392,8 +381,8 @@ class HookMode:
         """Live-deny an IP for a running container via nsenter.
 
         Removes from the nft allow set (best-effort) and from live.allowed.
-        Adds to the nft deny set.  Persists to deny.list when the IP would
-        otherwise be re-allowed (profile IP or interactive mode).
+        Adds to the nft deny set.  Always persists to deny.list so operator
+        deny decisions stick across restarts.
         """
         ip = safe_ip(ip)
         sd = self._config.state_dir.resolve()
@@ -429,19 +418,11 @@ class HookMode:
             self._nft_apply_best_effort(container, nft_cmd)
 
         # Persist to deny.list so deny sets survive shield_up / restart.
-        # In interactive mode: always persist (operator rejects must stick).
-        # In strict mode: only persist when the IP came from a profile.
-        should_persist = state.interactive_path(sd).is_file()
-        if not should_persist:
-            profile_path = state.profile_allowed_path(sd)
-            should_persist = profile_path.is_file() and ip in {
-                ln.strip() for ln in profile_path.read_text().splitlines() if ln.strip()
-            }
-        if should_persist:
-            dp = state.deny_path(sd)
-            if ip not in state.read_denied_ips(sd):
-                with dp.open("a") as f:
-                    f.write(f"{ip}\n")
+        # Operator deny decisions always stick.
+        dp = state.deny_path(sd)
+        if ip not in state.read_denied_ips(sd):
+            with dp.open("a") as f:
+                f.write(f"{ip}\n")
 
     def _set_for_ip(self, ip: str) -> str:
         """Return the nft set name for an IP address."""
@@ -481,10 +462,9 @@ class HookMode:
     def shield_up(self, container: str) -> None:
         """Restore normal deny-all mode for a running container."""
         sd = self._config.state_dir.resolve()
-        interactive = state.interactive_path(sd).is_file()
 
         ruleset = self._container_ruleset(container)
-        rs = ruleset.build_hook(interactive=interactive)
+        rs = ruleset.build_hook()
         current = self.shield_state(container)
         if current == ShieldState.INACTIVE:
             stdin = rs
@@ -525,7 +505,7 @@ class HookMode:
                     )
 
         output = self._runner.nft_via_nsenter(container, "list", "ruleset")
-        errors = ruleset.verify_hook(output, interactive=interactive)
+        errors = ruleset.verify_hook(output)
         if errors:
             raise RuntimeError(f"Ruleset verification failed: {'; '.join(errors)}")
 
@@ -599,10 +579,7 @@ class HookMode:
         if not self._ruleset.verify_bypass(output, allow_all=True):
             return ShieldState.DOWN_ALL
 
-        # Check both strict and interactive hook rulesets
         if not self._ruleset.verify_hook(output):
-            return ShieldState.UP
-        if not self._ruleset.verify_hook(output, interactive=True):
             return ShieldState.UP
 
         return ShieldState.ERROR
@@ -625,7 +602,7 @@ class HookMode:
         """Generate the ruleset that would be applied to a container."""
         if down:
             return self._ruleset.build_bypass(allow_all=allow_all)
-        return self._ruleset.build_hook(interactive=self._config.interactive)
+        return self._ruleset.build_hook()
 
 
 # ── Module-level helpers ────────────────────────────────

--- a/src/terok_shield/core/nft.py
+++ b/src/terok_shield/core/nft.py
@@ -18,6 +18,7 @@ import textwrap
 
 from .nft_constants import (
     ALLOWED_LOG_PREFIX,
+    BLOCKED_LOG_PREFIX,
     BYPASS_LOG_PREFIX,
     DENIED_LOG_PREFIX,
     NFLOG_GROUP,
@@ -26,7 +27,6 @@ from .nft_constants import (
     PASTA_HOST_LOOPBACK_MAP,
     PRIVATE_LOG_PREFIX,
     PRIVATE_RANGES,
-    QUEUED_LOG_PREFIX,
 )
 
 _SAFE_TIMEOUT_RE = re.compile(r"^\d+[smhd]$")
@@ -73,13 +73,12 @@ class RulesetBuilder:
         self._loopback_ports = loopback_ports
         self._set_timeout = set_timeout
 
-    def build_hook(self, *, interactive: bool = False) -> str:
+    def build_hook(self) -> str:
         """Generate the hook-mode (deny-all) nftables ruleset."""
         return hook_ruleset(
             dns=self._dns,
             loopback_ports=self._loopback_ports,
             set_timeout=self._set_timeout,
-            interactive=interactive,
         )
 
     def build_bypass(self, *, allow_all: bool = False) -> str:
@@ -91,9 +90,9 @@ class RulesetBuilder:
             set_timeout=self._set_timeout,
         )
 
-    def verify_hook(self, nft_output: str, *, interactive: bool = False) -> list[str]:
+    def verify_hook(self, nft_output: str) -> list[str]:
         """Check applied hook ruleset invariants.  Returns errors (empty = OK)."""
-        return verify_ruleset(nft_output, interactive=interactive)
+        return verify_ruleset(nft_output)
 
     def verify_bypass(self, nft_output: str, *, allow_all: bool = False) -> list[str]:
         """Check applied bypass ruleset invariants.  Returns errors (empty = OK)."""
@@ -116,8 +115,6 @@ def hook_ruleset(
     dns: str = PASTA_DNS,
     loopback_ports: tuple[int, ...] = (),
     set_timeout: str = "",
-    *,
-    interactive: bool = False,
 ) -> str:
     """Generate a per-container nftables ruleset for hook mode.
 
@@ -131,14 +128,17 @@ def hook_ruleset(
 
     Chain order (output):
         loopback -> established -> DNS -> gateway ports -> loopback ports
-        -> allow sets -> deny sets -> private-range reject -> deny/interactive-reject
+        -> allow sets -> deny sets -> private-range reject -> terminal deny
+
+    The terminal rule always logs with ``BLOCKED`` prefix to NFLOG.
+    NFLOG is fire-and-forget: if a clearance handler is listening it can
+    prompt the operator; if nobody subscribes the events are silently
+    dropped by the kernel at near-zero cost.
 
     Args:
         dns: DNS server address (pasta default forwarder).
         loopback_ports: TCP ports to allow on the loopback interface.
         set_timeout: nft set element timeout (e.g. ``30m``).
-        interactive: When True, replaces the terminal deny-all rule with an
-            NFLOG+reject rule using the QUEUED prefix for interactive handling.
     """
     dns = safe_ip(dns)
     if set_timeout:
@@ -161,7 +161,7 @@ def hook_ruleset(
     allow_rules = _audit_allow_rules()
     deny_rules = _deny_set_rules()
     private_rules = _private_range_rules()
-    terminal_rule = _interactive_reject_rule() if interactive else _audit_deny_rule()
+    terminal_rule = _terminal_deny_rule()
     return textwrap.dedent(f"""\
         table {NFT_TABLE} {{
             {set_v4}
@@ -403,7 +403,7 @@ def delete_elements(set_name: str, ips: list[str], table: str = NFT_TABLE) -> st
 # ── Verification ────────────────────────────────────────
 
 
-def verify_ruleset(nft_output: str, *, interactive: bool = False) -> list[str]:
+def verify_ruleset(nft_output: str) -> list[str]:
     """Check applied ruleset invariants.  Returns errors (empty = OK).
 
     Verifies:
@@ -413,8 +413,7 @@ def verify_ruleset(nft_output: str, *, interactive: bool = False) -> list[str]:
     - Dual-stack allow sets are declared
     - Dual-stack deny sets are declared
     - All private ranges are present (RFC 1918 + RFC 4193/4291)
-    - Interactive mode: queued nflog prefix present
-    - Non-interactive mode: deny nflog prefix present
+    - Terminal deny-all rule with BLOCKED prefix present
     """
     errors: list[str] = []
     if "policy drop" not in nft_output:
@@ -432,21 +431,14 @@ def verify_ruleset(nft_output: str, *, interactive: bool = False) -> list[str]:
         errors.append("deny_v4 set missing")
     if "deny_v6" not in nft_output:
         errors.append("deny_v6 set missing")
-    if interactive:
-        if QUEUED_LOG_PREFIX not in nft_output:
-            errors.append("queued nflog prefix missing")
-    else:
-        # Verify the terminal deny-all rule specifically — not just the prefix
-        # string, which also appears in deny-set rules (ip daddr @deny_v4 ...).
-        # The terminal rule is a standalone log+reject without a daddr selector.
-        # nft output ordering varies by version (group before/after prefix),
-        # so match any log line containing the denied prefix.
-        _terminal_deny_re = re.compile(
-            rf'^\s*log\s+.*prefix\s+"{re.escape(DENIED_LOG_PREFIX)}',
-            re.MULTILINE,
-        )
-        if not _terminal_deny_re.search(nft_output):
-            errors.append("terminal deny-all rule missing")
+    # Verify the terminal deny-all rule — a standalone log+reject with the
+    # BLOCKED prefix (no daddr selector, unlike deny-set rules).
+    _terminal_deny_re = re.compile(
+        rf'^\s*log\s+.*prefix\s+"{re.escape(BLOCKED_LOG_PREFIX)}',
+        re.MULTILINE,
+    )
+    if not _terminal_deny_re.search(nft_output):
+        errors.append("terminal deny-all rule missing")
     errors.extend(_verify_private_blocks(nft_output))
     return errors
 
@@ -511,15 +503,20 @@ def _audit_allow_rules() -> str:
     )
 
 
-def _audit_deny_rule() -> str:
-    """Generate the deny-all rule with audit logging.
+def _terminal_deny_rule() -> str:
+    """Generate the terminal default-deny rule with NFLOG audit.
 
-    Uses ``icmpx`` for cross-family reject in ``inet`` tables --
+    Unclassified packets (not in any allow or deny set) are rejected and
+    logged with the ``BLOCKED`` prefix.  NFLOG is fire-and-forget: if a
+    clearance handler subscribes it can prompt the operator; otherwise
+    events are silently dropped by the kernel.
+
+    Uses ``icmpx`` for cross-family reject in ``inet`` tables —
     auto-selects ICMP (IPv4) or ICMPv6 (IPv6).
     """
     return (
-        f'        log group {NFLOG_GROUP} prefix "{DENIED_LOG_PREFIX}: " counter\n'
-        "        reject with icmpx admin-prohibited"
+        f'        log group {NFLOG_GROUP} prefix "{BLOCKED_LOG_PREFIX}: " '
+        f"counter reject with icmpx admin-prohibited"
     )
 
 
@@ -532,18 +529,6 @@ def _deny_set_rules() -> str:
     return (
         f'        ip daddr @deny_v4 log group {NFLOG_GROUP} prefix "{DENIED_LOG_PREFIX}: " counter reject with icmpx admin-prohibited\n'
         f'        ip6 daddr @deny_v6 log group {NFLOG_GROUP} prefix "{DENIED_LOG_PREFIX}: " counter reject with icmpx admin-prohibited'
-    )
-
-
-def _interactive_reject_rule() -> str:
-    """Generate the NFLOG+reject terminal rule for interactive mode.
-
-    Rejects unmatched packets immediately but logs them with the QUEUED prefix
-    so the interactive handler can detect them via NFLOG.
-    """
-    return (
-        f'        log group {NFLOG_GROUP} prefix "{QUEUED_LOG_PREFIX}: " '
-        f"counter reject with icmpx admin-prohibited"
     )
 
 

--- a/src/terok_shield/core/nft_constants.py
+++ b/src/terok_shield/core/nft_constants.py
@@ -53,8 +53,8 @@ NFT_SET_TIMEOUT_DNSMASQ = "30m"  # set element timeout when dnsmasq manages IPs
 NFLOG_GROUP = 100  # nflog group number for terok-shield rules
 
 # ── Log prefixes ───────────────────────────────────────
-DENIED_LOG_PREFIX = "TEROK_SHIELD_DENIED"
+BLOCKED_LOG_PREFIX = "TEROK_SHIELD_BLOCKED"  # terminal default-deny (unclassified)
+DENIED_LOG_PREFIX = "TEROK_SHIELD_DENIED"  # explicit deny set (operator refused)
 PRIVATE_LOG_PREFIX = "TEROK_SHIELD_PRIVATE"
 ALLOWED_LOG_PREFIX = "TEROK_SHIELD_ALLOWED"
 BYPASS_LOG_PREFIX = "TEROK_SHIELD_BYPASS"
-QUEUED_LOG_PREFIX = "TEROK_SHIELD_QUEUED"

--- a/src/terok_shield/core/state.py
+++ b/src/terok_shield/core/state.py
@@ -30,7 +30,6 @@ Bundle layout::
     ├── dnsmasq.pid                    # dnsmasq PID (in container netns)
     ├── dnsmasq.log                    # dnsmasq query log (for shield watch)
     ├── resolv.conf                    # bind-mounted over /etc/resolv.conf (dnsmasq tier)
-    ├── interactive                    # interactive tier marker (e.g. "nflog")
     ├── container.id                   # podman container ID (short, 12-char hex)
     └── audit.jsonl                    # per-container audit log
 """
@@ -159,11 +158,6 @@ def resolv_conf_path(state_dir: Path) -> Path:
 # ── Container identity and observability ────────────────
 
 
-def interactive_path(state_dir: Path) -> Path:
-    """Return the path to the interactive tier marker file."""
-    return state_dir / "interactive"
-
-
 def container_id_path(state_dir: Path) -> Path:
     """Return the path to the persisted podman container ID file."""
     return state_dir / "container.id"
@@ -179,19 +173,6 @@ def audit_path(state_dir: Path) -> Path:
 # The path functions above are pure derivations.  The functions below
 # read file contents and compute derived state (merging, deduplication,
 # set subtraction).
-
-
-def read_interactive_tier(state_dir: Path) -> str | None:
-    """Read the interactive tier from the state bundle.
-
-    Returns ``"nflog"`` (or whatever tier string is stored) if the file
-    exists and contains a non-empty value, otherwise ``None``.
-    """
-    path = interactive_path(state_dir)
-    if not path.is_file():
-        return None
-    value = path.read_text().strip()
-    return value or None
 
 
 def read_allowed_ips(state_dir: Path) -> list[str]:

--- a/src/terok_shield/lib/watchers/nflog.py
+++ b/src/terok_shield/lib/watchers/nflog.py
@@ -147,7 +147,9 @@ class NflogWatcher:
         prefix_raw = attrs.get(_NFULA_PREFIX, b"")
         prefix = prefix_raw.rstrip(b"\x00").decode("ascii", errors="replace").strip()
 
-        if "DENIED" in prefix:
+        if "BLOCKED" in prefix:
+            action = "queued_connection"
+        elif "DENIED" in prefix:
             action = "blocked_connection"
         elif "PRIVATE" in prefix:
             action = "private_range"
@@ -155,8 +157,6 @@ class NflogWatcher:
             action = "allowed_connection"
         elif "BYPASS" in prefix:
             action = "bypass_connection"
-        elif "QUEUED" in prefix:
-            action = "queued_connection"
         else:
             action = "nflog"
 

--- a/tests/unit/test_api_surface.py
+++ b/tests/unit/test_api_surface.py
@@ -90,7 +90,6 @@ class TestAPISurface:
             "loopback_ports",
             "audit_enabled",
             "profiles_dir",
-            "interactive",
         ]
 
         cfg = make_config()
@@ -99,7 +98,6 @@ class TestAPISurface:
         assert cfg.loopback_ports == ()
         assert cfg.audit_enabled is True
         assert cfg.profiles_dir is None
-        assert cfg.interactive is False
 
     def test_shield_config_frozen(self, make_config):
         """ShieldConfig is frozen — assignment raises FrozenInstanceError."""

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -200,23 +200,6 @@ def test_logs_parser_supports_optional_container_and_count(parser: argparse.Argu
     assert filtered_args.n == 10
 
 
-@pytest.mark.parametrize(
-    ("command", "flag_attr"),
-    [
-        pytest.param("prepare", "interactive", id="prepare-interactive"),
-        pytest.param("run", "interactive", id="run-interactive"),
-    ],
-)
-def test_parser_prepare_and_run_accept_interactive(
-    parser: argparse.ArgumentParser,
-    command: str,
-    flag_attr: str,
-) -> None:
-    """prepare and run subcommands accept the --interactive flag."""
-    parsed = parser.parse_args([command, _CONTAINER, "--interactive"])
-    assert getattr(parsed, flag_attr) is True
-
-
 def test_down_parser_supports_allow_all(parser: argparse.ArgumentParser) -> None:
     """down defaults to allow_all=False and flips with --all."""
     assert not parser.parse_args(["down", "ctr"]).allow_all
@@ -1112,25 +1095,6 @@ class TestSetupInteractive:
         mock_setup.assert_called_once()
         _, kwargs = mock_setup.call_args
         assert kwargs.get("use_sudo") is True
-
-
-# ── --interactive flag dispatch tests ─────────────────────
-
-
-def test_prepare_without_interactive_passes_none(cli_dispatch: CliDispatchHarness) -> None:
-    """prepare without --interactive passes interactive=None to _build_config."""
-    cli_dispatch.shield.pre_start.return_value = ["--annotation", "a=b"]
-    main(["prepare", _CONTAINER])
-    call_kwargs = cli_dispatch.build_config.call_args
-    assert call_kwargs[1].get("interactive") is None
-
-
-def test_prepare_with_interactive_passes_true(cli_dispatch: CliDispatchHarness) -> None:
-    """prepare --interactive passes interactive=True to _build_config."""
-    cli_dispatch.shield.pre_start.return_value = ["--annotation", "a=b"]
-    main(["prepare", _CONTAINER, "--interactive"])
-    call_kwargs = cli_dispatch.build_config.call_args
-    assert call_kwargs[1].get("interactive") is True
 
 
 def test_interactive_command_routes_to_handler(cli_dispatch: CliDispatchHarness) -> None:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -117,7 +117,6 @@ class TestShieldFileConfigDefaults:
         assert cfg.mode == "auto"
         assert cfg.default_profiles == ["dev-standard"]
         assert cfg.loopback_ports == []
-        assert cfg.interactive is False
         assert cfg.audit.enabled is True
 
     def test_audit_defaults(self) -> None:
@@ -134,13 +133,11 @@ class TestShieldFileConfigValid:
             mode="hook",
             default_profiles=["base", "dev-python"],
             loopback_ports=[8080, 9090],
-            interactive=True,
             audit=AuditFileConfig(enabled=False),
         )
         assert cfg.mode == "hook"
         assert cfg.default_profiles == ["base", "dev-python"]
         assert cfg.loopback_ports == [8080, 9090]
-        assert cfg.interactive is True
         assert cfg.audit.enabled is False
 
     def test_single_port_int_coerced_to_list(self) -> None:

--- a/tests/unit/test_hook_mode_class.py
+++ b/tests/unit/test_hook_mode_class.py
@@ -303,7 +303,7 @@ def test_allow_ip_no_timeout_zero_without_dnsmasq_tier(
     ("profile_lines", "live_lines", "expect_deny_file", "nft_side_effect"),
     [
         pytest.param([TEST_IP1], [], True, None, id="profile-ip-persists-to-deny-list"),
-        pytest.param([], [TEST_IP1], False, None, id="live-only-no-deny-list"),
+        pytest.param([], [TEST_IP1], True, None, id="live-only-always-persists"),
         pytest.param(
             [TEST_IP1],
             [TEST_IP1],
@@ -1197,30 +1197,6 @@ def test_shield_up_repopulates_gateway_v6_from_file(
     assert gateway_calls, "Expected nft call to add gateway_v6 element"
 
 
-# ── Interactive mode coverage ────────────────────────────
-
-
-@mock.patch("terok_shield.core.mode_hook.has_global_hooks", return_value=True)
-def test_pre_start_interactive_writes_nflog_tier(
-    _has_hooks: mock.Mock,
-    monkeypatch: pytest.MonkeyPatch,
-    make_hook_mode: HookModeHarnessFactory,
-    make_config: ConfigFactory,
-) -> None:
-    """pre_start(interactive=True) writes 'nflog' to the interactive marker file."""
-    _set_euid(monkeypatch, 0)
-    config = make_config(interactive=True)
-    harness = make_hook_mode(config=config)
-    harness.runner.run.return_value = _MODERN_PODMAN_INFO
-    harness.profiles.compose_profiles.return_value = []
-
-    harness.mode.pre_start("test", ["dev-standard"])
-
-    marker = state.interactive_path(config.state_dir)
-    assert marker.is_file()
-    assert marker.read_text().strip() == "nflog"
-
-
 @mock.patch("terok_shield.core.mode_hook.has_global_hooks", return_value=True)
 def test_pre_start_with_denied_ips_includes_deny_elements(
     _has_hooks: mock.Mock,
@@ -1268,29 +1244,6 @@ def test_pre_start_does_not_inspect_container(
     assert not state.container_id_path(config.state_dir).exists()
 
 
-def test_shield_up_interactive_uses_interactive_ruleset(
-    make_hook_mode: HookModeHarnessFactory,
-    make_config: ConfigFactory,
-) -> None:
-    """shield_up() uses interactive=True when the interactive marker is set."""
-    config = make_config()
-    harness = make_hook_mode(config=config)
-    # Bypass DNS reading
-    harness.mode._container_ruleset = lambda _c: harness.ruleset
-    harness.runner.nft_via_nsenter.return_value = ""
-    harness.ruleset.build_hook.return_value = "hook ruleset"
-    harness.ruleset.verify_hook.return_value = []
-    harness.ruleset.add_elements_dual.return_value = ""
-    harness.ruleset.verify_bypass.return_value = ["not bypass"]
-
-    # Write the interactive marker
-    state.interactive_path(config.state_dir).write_text("nflog\n")
-
-    harness.mode.shield_up("test-ctr")
-
-    harness.ruleset.build_hook.assert_called_with(interactive=True)
-
-
 def test_shield_up_repopulates_deny_sets(
     make_hook_mode: HookModeHarnessFactory,
     make_config: ConfigFactory,
@@ -1313,32 +1266,3 @@ def test_shield_up_repopulates_deny_sets(
     # Verify deny elements were sent via nsenter
     deny_calls = [c for c in harness.runner.nft_via_nsenter.call_args_list if c.kwargs.get("stdin")]
     assert any(TEST_IP1 in (c.kwargs.get("stdin", "") or "") for c in deny_calls)
-
-
-def test_shield_state_detects_interactive_up(
-    make_hook_mode: HookModeHarnessFactory,
-) -> None:
-    """shield_state() returns UP for an interactive hook ruleset."""
-    harness = make_hook_mode()
-    harness.runner.nft_via_nsenter.return_value = "some ruleset"
-    # First verify_bypass fails, first verify_hook (strict) fails,
-    # second verify_hook (interactive=True) succeeds.
-    harness.ruleset.verify_bypass.return_value = ["not bypass"]
-    harness.ruleset.verify_hook.side_effect = [["not strict"], []]
-
-    assert harness.mode.shield_state("test") == ShieldState.UP
-
-
-def test_preview_interactive_delegates(
-    make_hook_mode: HookModeHarnessFactory,
-    make_config: ConfigFactory,
-) -> None:
-    """preview() passes interactive=True when config has interactive enabled."""
-    config = make_config(interactive=True)
-    harness = make_hook_mode(config=config)
-    harness.ruleset.build_hook.return_value = "interactive ruleset"
-
-    result = harness.mode.preview()
-
-    harness.ruleset.build_hook.assert_called_with(interactive=True)
-    assert result == "interactive ruleset"

--- a/tests/unit/test_interactive.py
+++ b/tests/unit/test_interactive.py
@@ -530,29 +530,14 @@ class TestReadStdin:
 class TestRunInteractive:
     """Tests for the run_interactive entry point."""
 
-    def test_exits_if_not_interactive(self, tmp_path: Path) -> None:
-        """run_interactive exits with code 1 if interactive tier is not configured."""
-        with pytest.raises(SystemExit) as ctx:
-            run_interactive(tmp_path, _CONTAINER)
-        assert ctx.value.code == 1
-
-    def test_exits_if_unsupported_tier(self, tmp_path: Path) -> None:
-        """run_interactive exits with code 1 for an unsupported tier marker."""
-        state.interactive_path(tmp_path).write_text("unsupported\n")
-        with pytest.raises(SystemExit) as ctx:
-            run_interactive(tmp_path, _CONTAINER)
-        assert ctx.value.code == 1
-
     def test_nsenter_reexec_when_not_in_netns(self, tmp_path: Path) -> None:
         """run_interactive calls nsenter reexec when not inside the container netns."""
-        state.interactive_path(tmp_path).write_text("nflog\n")
         with mock.patch("terok_shield.cli.interactive._nsenter_reexec") as mock_reexec:
             run_interactive(tmp_path, _CONTAINER)
         mock_reexec.assert_called_once_with(tmp_path, _CONTAINER, raw=False)
 
     def test_dispatches_to_session_inside_netns(self, tmp_path: Path) -> None:
         """run_interactive creates a session when already inside the container netns."""
-        state.interactive_path(tmp_path).write_text("nflog\n")
         with (
             mock.patch.dict("os.environ", {_NSENTER_ENV: "1"}),
             mock.patch("terok_shield.cli.interactive.SubprocessRunner") as mock_runner_cls,
@@ -1074,7 +1059,7 @@ class TestRawFlagPropagation:
 
     def test_run_interactive_raw_false_uses_cli_io(self, tmp_path: Path) -> None:
         """run_interactive defaults to CliSessionIO."""
-        state.interactive_path(tmp_path).write_text("nflog\n")
+
         with (
             mock.patch.dict("os.environ", {_NSENTER_ENV: "1"}),
             mock.patch("terok_shield.cli.interactive.SubprocessRunner"),
@@ -1086,7 +1071,7 @@ class TestRawFlagPropagation:
 
     def test_run_interactive_raw_true_uses_json_io(self, tmp_path: Path) -> None:
         """run_interactive with raw=True uses JsonSessionIO."""
-        state.interactive_path(tmp_path).write_text("nflog\n")
+
         with (
             mock.patch.dict("os.environ", {_NSENTER_ENV: "1"}),
             mock.patch("terok_shield.cli.interactive.SubprocessRunner"),
@@ -1328,7 +1313,7 @@ class TestEagerDomainRefresh:
 
     def test_run_interactive_passes_raw_to_nsenter(self, tmp_path: Path) -> None:
         """run_interactive forwards raw=True to _nsenter_reexec."""
-        state.interactive_path(tmp_path).write_text("nflog\n")
+
         with mock.patch("terok_shield.cli.interactive._nsenter_reexec") as mock_reexec:
             run_interactive(tmp_path, _CONTAINER, raw=True)
         mock_reexec.assert_called_once_with(tmp_path, _CONTAINER, raw=True)

--- a/tests/unit/test_nft.py
+++ b/tests/unit/test_nft.py
@@ -248,6 +248,8 @@ def test_hook_ruleset_terminal_rule_is_standalone_log_reject() -> None:
 def test_hook_ruleset_deny_sets_use_denied_prefix() -> None:
     """Deny set rules use the DENIED prefix (not BLOCKED)."""
     ruleset = hook_ruleset()
+    assert "@deny_v4" in ruleset, "deny_v4 set rule missing from ruleset"
+    assert "@deny_v6" in ruleset, "deny_v6 set rule missing from ruleset"
     # Deny set rules have a daddr selector + DENIED prefix
     lines = [ln for ln in ruleset.splitlines() if "@deny_v4" in ln or "@deny_v6" in ln]
     assert all(_DENY_LOG_PREFIX in ln for ln in lines)

--- a/tests/unit/test_nft.py
+++ b/tests/unit/test_nft.py
@@ -56,7 +56,7 @@ _DENY_V4_SET = "set deny_v4 { type ipv4_addr; flags interval; }"
 _DENY_V6_SET = "set deny_v6 { type ipv6_addr; flags interval; }"
 _ALLOW_LOG_PREFIX = "TEROK_SHIELD_ALLOWED"
 _DENY_LOG_PREFIX = "TEROK_SHIELD_DENIED"
-_QUEUED_LOG_PREFIX = "TEROK_SHIELD_QUEUED"
+_BLOCKED_LOG_PREFIX = "TEROK_SHIELD_BLOCKED"
 _ADMIN_PROHIBITED = "admin-prohibited"
 _INPUT_CHAIN = "chain input"
 _OUTPUT_CHAIN = "chain output"
@@ -225,71 +225,45 @@ def test_hook_ruleset_places_deny_sets_between_allow_and_private() -> None:
     assert allow_pos < deny_pos < private_pos
 
 
-# ── Interactive mode ────────────────────────────────────
+# ── Terminal deny rule (BLOCKED prefix) ───────────────
 
 
-def test_hook_ruleset_interactive_uses_queued_prefix() -> None:
-    """Interactive mode replaces the deny-all rule with a QUEUED prefix rule."""
-    ruleset = hook_ruleset(interactive=True)
-    assert _QUEUED_LOG_PREFIX in ruleset
+def test_hook_ruleset_uses_blocked_prefix() -> None:
+    """Terminal deny rule uses the BLOCKED prefix for unclassified connections."""
+    ruleset = hook_ruleset()
+    assert _BLOCKED_LOG_PREFIX in ruleset
 
 
-def test_hook_ruleset_interactive_does_not_have_deny_terminal_rule() -> None:
-    """Interactive mode must not include the terminal DENIED log line."""
-    ruleset = hook_ruleset(interactive=True)
-    # The deny sets still reference DENIED prefix -- but the terminal rule should use QUEUED.
-    # Split by lines: the terminal deny-all rule in non-interactive has a standalone
-    # DENIED line; interactive replaces it with QUEUED.
-    lines = ruleset.splitlines()
-    terminal_deny_lines = [
-        line.strip()
-        for line in lines
-        if line.strip().startswith("log group") and _DENY_LOG_PREFIX in line and "reject" in line
+def test_hook_ruleset_terminal_rule_is_standalone_log_reject() -> None:
+    """Terminal deny rule is a standalone log+reject (no daddr selector)."""
+    lines = hook_ruleset().splitlines()
+    terminal = [
+        ln.strip()
+        for ln in lines
+        if ln.strip().startswith("log group") and _BLOCKED_LOG_PREFIX in ln and "reject" in ln
     ]
-    assert terminal_deny_lines == [], "Terminal deny-all rule should not appear in interactive mode"
+    assert len(terminal) == 1, "Exactly one terminal BLOCKED rule expected"
 
 
-def test_hook_ruleset_interactive_still_contains_deny_sets() -> None:
-    """Interactive mode still declares deny_v4 and deny_v6 sets."""
-    ruleset = hook_ruleset(interactive=True)
-    assert _DENY_V4_SET in ruleset
-    assert _DENY_V6_SET in ruleset
+def test_hook_ruleset_deny_sets_use_denied_prefix() -> None:
+    """Deny set rules use the DENIED prefix (not BLOCKED)."""
+    ruleset = hook_ruleset()
+    # Deny set rules have a daddr selector + DENIED prefix
+    lines = [ln for ln in ruleset.splitlines() if "@deny_v4" in ln or "@deny_v6" in ln]
+    assert all(_DENY_LOG_PREFIX in ln for ln in lines)
+    assert not any(_BLOCKED_LOG_PREFIX in ln for ln in lines)
 
 
-def test_hook_ruleset_non_interactive_has_no_queued_prefix() -> None:
-    """Non-interactive (default) hook mode must not contain the QUEUED log prefix."""
-    ruleset = hook_ruleset(interactive=False)
-    assert _QUEUED_LOG_PREFIX not in ruleset
-
-
-def test_verify_ruleset_accepts_interactive_hook_ruleset() -> None:
-    """verify_ruleset() with interactive=True accepts the interactive hook ruleset."""
-    assert verify_ruleset(hook_ruleset(interactive=True), interactive=True) == []
-
-
-def test_verify_ruleset_interactive_rejects_non_interactive_ruleset() -> None:
-    """verify_ruleset() with interactive=True rejects a non-interactive ruleset."""
-    errors = verify_ruleset(hook_ruleset(interactive=False), interactive=True)
-    assert any("queued nflog prefix" in error for error in errors)
-
-
-def test_verify_ruleset_interactive_mode_cross_validates() -> None:
-    """Interactive ruleset passes interactive verify but not non-interactive, and vice versa."""
-    interactive_rs = hook_ruleset(interactive=True)
-    non_interactive_rs = hook_ruleset(interactive=False)
-    # Interactive ruleset passes interactive verify
-    assert verify_ruleset(interactive_rs, interactive=True) == []
-    # Non-interactive ruleset passes non-interactive verify
-    assert verify_ruleset(non_interactive_rs, interactive=False) == []
-    # Interactive verify rejects non-interactive (missing QUEUED prefix)
-    errors = verify_ruleset(non_interactive_rs, interactive=True)
-    assert any("queued nflog prefix" in e for e in errors)
+def test_hook_ruleset_has_no_queued_prefix() -> None:
+    """Hook ruleset must not contain the legacy QUEUED log prefix."""
+    assert "QUEUED" not in hook_ruleset()
 
 
 def test_verify_ruleset_checks_deny_sets() -> None:
-    """verify_ruleset() requires deny_v4 and deny_v6 sets in both modes."""
+    """verify_ruleset() requires deny_v4 and deny_v6 sets."""
     minimal = (
-        f"policy drop {_ADMIN_PROHIBITED} {_DENY_LOG_PREFIX} "
+        f"policy drop {_ADMIN_PROHIBITED} "
+        f'log group 100 prefix "{_BLOCKED_LOG_PREFIX}" '
         f"allow_v4 allow_v6 {_OUTPUT_CHAIN} {_INPUT_CHAIN}\n"
         f"{_private_reject_rules()}"
     )

--- a/tests/unit/test_watch.py
+++ b/tests/unit/test_watch.py
@@ -24,11 +24,11 @@ from terok_shield.cli.watch import (
 from terok_shield.common.config import DnsTier
 from terok_shield.core.nft_constants import (
     ALLOWED_LOG_PREFIX,
+    BLOCKED_LOG_PREFIX,
     BYPASS_LOG_PREFIX,
     DENIED_LOG_PREFIX,
     NFLOG_GROUP,
     PRIVATE_LOG_PREFIX,
-    QUEUED_LOG_PREFIX,
 )
 from terok_shield.lib.watchers import (
     AuditLogWatcher,
@@ -698,10 +698,10 @@ class TestNflogWatcherParsing:
         assert events[0].port == 53
         assert events[0].proto == 17
 
-    def test_queued_packet_produces_queued_connection(self) -> None:
-        """NFLOG message with QUEUED prefix yields queued_connection event."""
+    def test_blocked_packet_produces_queued_connection(self) -> None:
+        """NFLOG message with BLOCKED prefix yields queued_connection event."""
         watcher = self._make_watcher()
-        data = _make_nflog_packet(f"{QUEUED_LOG_PREFIX}: ", "192.0.2.1", 6, 443)
+        data = _make_nflog_packet(f"{BLOCKED_LOG_PREFIX}: ", "192.0.2.1", 6, 443)
         events = watcher._parse_messages(data)
         assert len(events) == 1
         assert events[0].action == "queued_connection"


### PR DESCRIPTION
## Summary

- Remove the `interactive` config flag — NFLOG is fire-and-forget, the rule generator shouldn't know whether a listener exists
- Single terminal deny rule always uses `BLOCKED` prefix (was conditional `QUEUED`/`DENIED`)
- Three semantically correct log prefixes: `BLOCKED` (unclassified), `DENIED` (explicit deny set), `ALLOWED` (unchanged)
- `deny_ip()` always persists to deny.list (operator decisions stick across restarts)
- Net -244 lines across 16 files

Closes #199
Related: terok-ai/terok#616

## Test plan

- [x] `make check` passes (984 tests, lint, tach, docstrings, deadcode, REUSE)
- [ ] Dev-host integration: `shield dbus-bridge` works without `--interactive` flag
- [ ] Dev-host integration: `shield interactive` works without marker file
- [ ] Verify `shield watch` shows BLOCKED prefix for terminal deny events

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Removed Features**
  * Removed the CLI --interactive flag from prepare/run.
  * Removed interactive mode configuration from config files and runtime.

* **Changes**
  * Deny decisions now always persist to deny.list and survive restarts.
  * Terminal deny packets consistently log with the BLOCKED prefix to NFLOG group 100; interactive approval mode is no longer used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->