### PR TITLE
chore: skip CodeRabbit on automated release PRs

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,4 @@
+reviews:
+  auto_review:
+    labels:
+      - "!automated-release"


### PR DESCRIPTION
Add `.coderabbit.yaml` to skip reviews on PRs labelled `automated-release`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated review automation configuration to exclude issues labeled "automated-release" from the auto-review process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->