### PR TITLE
fix: revert -U flag — podman unshare IS the owning userns

### DIFF
--- a/src/terok_shield/cli/interactive.py
+++ b/src/terok_shield/cli/interactive.py
@@ -159,8 +159,8 @@ class InteractiveSession:
             print(
                 "Error: could not create NFLOG watcher.\n"
                 "  NFLOG requires CAP_NET_ADMIN in the user namespace that owns\n"
-                "  the container's network namespace.  Re-run with\n"
-                "  TEROK_LOG_LEVEL=DEBUG for detailed diagnostics.",
+                "  the container's network namespace.  Ensure this process runs\n"
+                "  inside 'podman unshare' (not the container's inner userns).",
                 file=sys.stderr,
             )
             raise SystemExit(1)
@@ -603,13 +603,16 @@ def _nsenter_reexec(state_dir: Path, container: str, *, raw: bool) -> None:
 
     NFLOG messages are delivered per-netns — the watcher must be inside the
     container's netns to receive packets logged by its nft rules.  Uses
-    ``podman unshare nsenter`` to enter the netns, then runs this module as
-    ``__main__``.
+    ``podman unshare nsenter -t PID -n`` to enter the netns, then runs this
+    module as ``__main__``.
 
-    The nsenter invocation enters both the user namespace (``-U``) and network
-    namespace (``-n``) of the container process.  ``-U`` must precede ``-n``
-    so the kernel checks ``CAP_NET_ADMIN`` after joining the owning user
-    namespace — see :data:`WORKAROUND(nsenter-userns)` below.
+    ``podman unshare`` enters the persistent rootless user namespace that
+    Podman created for the container — the same userns that *owns* the
+    container's network namespace.  This gives us ``CAP_NET_ADMIN`` over
+    the netns, which NFLOG subscription requires.  Do **not** add ``-U``
+    to nsenter: that would enter the container's *inner* userns (a child
+    of the owning userns), where the kernel denies ``CAP_NET_ADMIN`` over
+    parent-owned resources.
 
     Args:
         state_dir: Per-container state directory.
@@ -621,27 +624,12 @@ def _nsenter_reexec(state_dir: Path, container: str, *, raw: bool) -> None:
     runner = SubprocessRunner()
     pid = runner.podman_inspect(container, "{{.State.Pid}}")
 
-    # WORKAROUND(nsenter-userns): ``podman unshare`` creates a *new* user
-    # namespace that is a sibling of the container's owning userns.  NFLOG
-    # bind requires CAP_NET_ADMIN relative to the userns that *owns* the
-    # network namespace.  A sibling userns cannot satisfy this — only the
-    # owning userns or an ancestor can.  Adding ``-U --preserve-credentials``
-    # enters the container's owning userns (which grants CAP_NET_ADMIN over
-    # its netns) while keeping UID 0 and mapped capabilities from
-    # ``podman unshare``.  ``-U`` must precede ``-n`` because the kernel
-    # validates capabilities at netns-entry time.
-    # Short-lived ``nft`` commands (nft_via_nsenter) are unaffected because
-    # they do not subscribe to NFLOG.
-    # Removal: if a future Podman version provides a direct ``--userns=container``
-    # flag or an alternative NFLOG subscription path, this workaround can be dropped.
     cmd = [
         "podman",
         "unshare",
         "nsenter",
         "-t",
         pid,
-        "-U",
-        "--preserve-credentials",
         "-n",
         sys.executable,
         "-m",

--- a/tests/unit/test_interactive.py
+++ b/tests/unit/test_interactive.py
@@ -593,9 +593,9 @@ class TestNsenterReexec:
     def test_builds_nsenter_command(self, tmp_path: Path) -> None:
         """_nsenter_reexec invokes podman unshare nsenter with correct args.
 
-        Verifies WORKAROUND(nsenter-userns): ``-U --preserve-credentials``
-        must appear before ``-n`` so the kernel checks CAP_NET_ADMIN after
-        entering the container's owning user namespace.
+        Must NOT use ``-U`` — ``podman unshare`` already enters the owning
+        userns of the container's netns; adding ``-U`` would descend into
+        the container's inner userns where CAP_NET_ADMIN is denied.
         """
         from terok_shield.cli.interactive import _nsenter_reexec
 
@@ -609,11 +609,8 @@ class TestNsenterReexec:
         cmd = mock_run.call_args[0][0]
         assert cmd[:3] == ["podman", "unshare", "nsenter"]
         assert "-t" in cmd and "12345" in cmd
-        # WORKAROUND(nsenter-userns): -U must precede -n
-        assert "-U" in cmd and "--preserve-credentials" in cmd
-        u_idx = cmd.index("-U")
-        n_idx = cmd.index("-n")
-        assert u_idx < n_idx, "-U must precede -n for CAP_NET_ADMIN in owning userns"
+        assert "-n" in cmd
+        assert "-U" not in cmd, "-U enters inner userns, breaks NFLOG CAP_NET_ADMIN"
         assert str(tmp_path) in cmd
         assert _CONTAINER in cmd
         env = mock_run.call_args[1]["env"]


### PR DESCRIPTION
## Summary

- Revert the `-U --preserve-credentials` nsenter flag from #211 — diagnostic testing confirmed it breaks NFLOG bind
- Keep PYTHONPATH propagation and improved error messages from #211

## Root cause

`podman unshare` enters the persistent rootless userns that **owns** the container's netns. NFLOG bind from that userns succeeds (confirmed via diagnostic script).

Adding `-U` to `nsenter` entered the container's **inner** userns (a child of the owning userns). The kernel's `ns_capable()` check denies `CAP_NET_ADMIN` from a descendant userns over parent-owned resources → EPERM.

## Diagnostic evidence

```
Test A (-U --preserve-credentials): userns:4026538796 → NFLOG errno 1 (EPERM)
Test B (-U only):                   userns:4026531837 → NFLOG errno 1 (EPERM)
Test C (no -U, original):           userns:4026536492 → NFLOG ok ✓
```

## Test plan

- [x] `make check` — 1013 passed, lint/tach/docstrings/security/REUSE clean
- [ ] `terok shield dbus-bridge <project> <task>` + curl from container

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined NFLOG capability error messaging with updated instructions for end-users.
  * Enhanced namespace handling in the CLI for improved reliability.

* **Tests**
  * Updated unit tests to verify the revised namespace command implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->