### PR TITLE
fix: use CamelCase for Verdict method name on D-Bus wire

### DIFF
--- a/src/terok_shield/dbus_bridge.py
+++ b/src/terok_shield/dbus_bridge.py
@@ -114,7 +114,7 @@ class _ShieldInterface(ServiceInterface):
         """Emit after a verdict has been applied to the nft ruleset."""
         return [container, dest, request_id, action, ok]
 
-    @method()
+    @method(name="Verdict")
     async def verdict(self, request_id: "s", action: "s") -> "b":
         """Route an operator verdict to the subprocess stdin."""
         return await self._bridge.submit_verdict(request_id, action)

--- a/tests/unit/test_dbus_bridge.py
+++ b/tests/unit/test_dbus_bridge.py
@@ -363,6 +363,11 @@ def test_signal_wire_names_are_camelcase() -> None:
     assert "connection_blocked" not in signal_names
     assert "verdict_applied" not in signal_names
 
+    # Methods must also be CamelCase
+    method_names = {m.name for m in introspection.methods}
+    assert "Verdict" in method_names
+    assert "verdict" not in method_names
+
 
 def test_verdict_method_delegates() -> None:
     """The verdict method body awaits bridge.submit_verdict."""


### PR DESCRIPTION
## Summary

- Same root cause as #215 — `@method()` without `name=` exports as lowercase `verdict`, but `EventSubscriber` sends `member='Verdict'` (CamelCase per D-Bus spec)
- The method call silently failed to match, breaking Allow/Deny verdict delivery from the TUI clearance screen
- Extends the wire-name regression test from #215 to also cover methods

## Test plan

- [x] All 1064 unit tests pass
- [x] `test_signal_wire_names_are_camelcase` now also asserts `Verdict` in method names
- [ ] TUI clearance screen Allow/Deny buttons deliver verdicts to the bridge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized D-Bus interface method naming convention to CamelCase format, ensuring consistency across exported methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->