### PR TITLE
fix: use colon separator for list-valued OCI annotations

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -124,10 +124,10 @@ These annotations are set automatically by `terok-shield run` (or
 
 | Annotation | Value | Purpose |
 |------------|-------|---------|
-| `terok.shield.profiles` | Comma-separated names | Which profiles to apply |
+| `terok.shield.profiles` | Colon-separated names | Which profiles to apply |
 | `terok.shield.name` | Container name | Audit log identification |
 | `terok.shield.state_dir` | Absolute path | Where the hook finds its state bundle |
-| `terok.shield.loopback_ports` | Comma-separated ints | Ports for ruleset generation |
+| `terok.shield.loopback_ports` | Colon-separated ints | Ports for ruleset generation |
 | `terok.shield.version` | Integer | Bundle version (hard-fail on mismatch) |
 | `terok.shield.audit_enabled` | `true` / `false` | Whether to write audit logs |
 | `terok.shield.upstream_dns` | IP address | Upstream DNS forwarder for dnsmasq |

--- a/src/terok_shield/config.py
+++ b/src/terok_shield/config.py
@@ -19,8 +19,9 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 # ── OCI annotation keys ─────────────────────────────────
 
 # Delimiter for list-valued annotations (profiles, loopback_ports).
-# Podman 4.x registers --annotation as StringSliceVar (pflag), which splits
-# values on commas.  Colons are safe across both Podman 4.x and 5.x.
+# Podman ≤4.9.x registers --annotation as StringSliceVar (pflag), which
+# splits values on commas.  Fixed in 5.0.0 (containers/podman#20945).
+# Colons are safe across all versions.
 ANNOTATION_LIST_SEP = ":"
 
 ANNOTATION_KEY = "terok.shield.profiles"

--- a/src/terok_shield/config.py
+++ b/src/terok_shield/config.py
@@ -18,6 +18,10 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 # ── OCI annotation keys ─────────────────────────────────
 
+# Delimiter for list-valued annotations (profiles, loopback_ports).
+# Colons instead of commas — some Podman builds (e.g. Nvidia's Ubuntu 24.04)
+# treat commas in annotation values as key=value pair separators.
+ANNOTATION_LIST_SEP = ":"
 
 ANNOTATION_KEY = "terok.shield.profiles"
 ANNOTATION_NAME_KEY = "terok.shield.name"

--- a/src/terok_shield/config.py
+++ b/src/terok_shield/config.py
@@ -19,8 +19,8 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 # ── OCI annotation keys ─────────────────────────────────
 
 # Delimiter for list-valued annotations (profiles, loopback_ports).
-# Colons instead of commas — some Podman builds (e.g. Nvidia's Ubuntu 24.04)
-# treat commas in annotation values as key=value pair separators.
+# Podman 4.x registers --annotation as StringSliceVar (pflag), which splits
+# values on commas.  Colons are safe across both Podman 4.x and 5.x.
 ANNOTATION_LIST_SEP = ":"
 
 ANNOTATION_KEY = "terok.shield.profiles"

--- a/src/terok_shield/hooks/mode.py
+++ b/src/terok_shield/hooks/mode.py
@@ -29,6 +29,7 @@ from ..config import (
     ANNOTATION_AUDIT_ENABLED_KEY,
     ANNOTATION_DNS_TIER_KEY,
     ANNOTATION_KEY,
+    ANNOTATION_LIST_SEP,
     ANNOTATION_LOOPBACK_PORTS_KEY,
     ANNOTATION_NAME_KEY,
     ANNOTATION_STATE_DIR_KEY,
@@ -155,10 +156,10 @@ class HookMode:
             args += ["--volume", f"{state.resolv_conf_path(sd)}:/etc/resolv.conf:ro,Z"]
 
         # Annotations: profiles, name, state_dir, loopback_ports, version, dns
-        ports_str = ",".join(str(p) for p in self._config.loopback_ports)
+        ports_str = ANNOTATION_LIST_SEP.join(str(p) for p in self._config.loopback_ports)
         args += [
             "--annotation",
-            f"{ANNOTATION_KEY}={','.join(profiles)}",
+            f"{ANNOTATION_KEY}={ANNOTATION_LIST_SEP.join(profiles)}",
             "--annotation",
             f"{ANNOTATION_NAME_KEY}={container}",
             "--annotation",


### PR DESCRIPTION
## Summary

- Switch `profiles` and `loopback_ports` annotation delimiters from `,` to `:`
- Add `ANNOTATION_LIST_SEP` constant in `config.py` documenting the reason
- Update docs to reflect "colon-separated" format

## Context

Podman ≤4.9.x registers `--annotation` as `StringSliceVar` (pflag), which
splits values on commas. So `--annotation key=a,b,c` is parsed as three
separate entries (`key=a`, `b`, `c`), and the bare tokens fail with
*"annotations must be in form key=value"*.

[containers/podman#20945](https://github.com/containers/podman/pull/20945)
switched `--annotation` to `StringArrayVar` (no comma splitting), merged
Dec 2023 — first released in **Podman 5.0.0**. Never backported to 4.x.

We must support Podman 4.x (e.g. 4.9.3 on Nvidia DGX Spark / Ubuntu 24.04).
Colons are safe across all versions.

## Test plan

- [x] All 1013 unit tests pass
- [x] `ruff check` clean
- [x] `tach check` clean
- [ ] Manual verification on Podman 4.9.3 (Nvidia DGX Spark)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated OCI annotation configuration documentation to specify colon-separated format for list-valued annotations such as profiles and loopback port settings.

* **Bug Fixes**
  * Corrected annotation processing to consistently parse and construct list-valued OCI annotations using colon-separated delimiters instead of comma-separated format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->