### PR TITLE
fix: treat unreadable hook version as stale

### DIFF
--- a/src/terok_shield/__init__.py
+++ b/src/terok_shield/__init__.py
@@ -256,7 +256,7 @@ class Shield:
                 health = "ok"
                 # Check hook version matches current package
                 hook_ver = _read_installed_hook_version(hooks_dirs)
-                if hook_ver is not None and hook_ver != state.BUNDLE_VERSION:
+                if hook_ver != state.BUNDLE_VERSION:
                     health = "stale-hooks"
                     issues.append(
                         f"Installed hook version {hook_ver} != expected {state.BUNDLE_VERSION}. "

--- a/tests/unit/test_shield_facade.py
+++ b/tests/unit/test_shield_facade.py
@@ -11,8 +11,7 @@ from unittest import mock
 
 import pytest
 
-from terok_shield import ExecError, Shield, ShieldConfig, ShieldState
-from terok_shield import state
+from terok_shield import ExecError, Shield, ShieldConfig, ShieldState, state
 
 from ..testfs import NFT_BINARY
 from ..testnet import TEST_DOMAIN, TEST_IP1, TEST_IP2

--- a/tests/unit/test_shield_facade.py
+++ b/tests/unit/test_shield_facade.py
@@ -12,6 +12,7 @@ from unittest import mock
 import pytest
 
 from terok_shield import ExecError, Shield, ShieldConfig, ShieldState
+from terok_shield import state
 
 from ..testfs import NFT_BINARY
 from ..testnet import TEST_DOMAIN, TEST_IP1, TEST_IP2
@@ -461,6 +462,7 @@ class TestCheckEnvironment:
         assert env.health == "stale-hooks"
         assert any("Stale" in i for i in env.issues)
 
+    @mock.patch("terok_shield._read_installed_hook_version", return_value=state.BUNDLE_VERSION)
     @mock.patch("terok_shield.find_hooks_dirs", return_value=[Path("/fake/hooks")])
     @mock.patch("terok_shield.has_global_hooks", return_value=True)
     @mock.patch("terok_shield.system_hooks_dir", return_value=Path("/fake/hooks"))
@@ -469,6 +471,7 @@ class TestCheckEnvironment:
         _sys_dir: mock.Mock,
         _has_hooks: mock.Mock,
         _find_dirs: mock.Mock,
+        _hook_ver: mock.Mock,
         make_shield: ShieldHarnessFactory,
     ) -> None:
         """System global hooks → ok/global-system."""
@@ -479,12 +482,14 @@ class TestCheckEnvironment:
         assert env.health == "ok"
         assert env.hooks == "global-system"
 
+    @mock.patch("terok_shield._read_installed_hook_version", return_value=state.BUNDLE_VERSION)
     @mock.patch("terok_shield.find_hooks_dirs", return_value=[Path("/user/hooks")])
     @mock.patch("terok_shield.system_hooks_dir", return_value=Path("/nonexistent"))
     def test_global_user_hooks(
         self,
         _sys_dir: mock.Mock,
         _find_dirs: mock.Mock,
+        _hook_ver: mock.Mock,
         make_shield: ShieldHarnessFactory,
     ) -> None:
         """User global hooks (not system) → ok/global-user."""
@@ -514,6 +519,29 @@ class TestCheckEnvironment:
         hooks_dir = tmp_path / "hooks.d"
         hooks_dir.mkdir()
         (hooks_dir / "terok-shield-hook").write_text("_BUNDLE_VERSION = 1\n")
+        _find_dirs.return_value = [hooks_dir]
+
+        harness = make_shield()
+        harness.runner.run.side_effect = _run_side_effect("5.8.0")
+        env = harness.shield.check_environment()
+        assert env.health == "stale-hooks"
+        assert any("version" in i.lower() for i in env.issues)
+
+    @mock.patch("terok_shield.find_hooks_dirs")
+    @mock.patch("terok_shield.has_global_hooks", return_value=True)
+    @mock.patch("terok_shield.system_hooks_dir", return_value=Path("/fake/hooks"))
+    def test_unreadable_hook_version_treated_as_stale(
+        self,
+        _sys_dir: mock.Mock,
+        _has_hooks: mock.Mock,
+        _find_dirs: mock.Mock,
+        make_shield: ShieldHarnessFactory,
+        tmp_path: Path,
+    ) -> None:
+        """Hook file without _BUNDLE_VERSION line → stale-hooks (not silently ok)."""
+        hooks_dir = tmp_path / "hooks.d"
+        hooks_dir.mkdir()
+        (hooks_dir / "terok-shield-hook").write_text("#!/bin/sh\necho old hook\n")
         _find_dirs.return_value = [hooks_dir]
 
         harness = make_shield()


### PR DESCRIPTION
## Summary
- When `_read_installed_hook_version()` returns `None` (hook file predates `_BUNDLE_VERSION` line), the staleness check was silently skipped due to `if hook_ver is not None and ...`
- Removed the `is not None` guard so `None != BUNDLE_VERSION` correctly triggers "stale-hooks" health status
- Added test for the None-version case; updated happy-path tests to mock a matching version

## Context
Found during fresh-install testing: upgrading terok-shield left old hook scripts that were reported as healthy because they had no version line to compare.

## Test plan
- [x] `make lint` passes
- [x] `make test-unit` — 39 tests pass including new `test_unreadable_hook_version_treated_as_stale`
- [ ] Manual: install old hook (no `_BUNDLE_VERSION`), run `check_environment()`, verify "stale-hooks"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Environment validation now treats missing or unreadable hook version information as stale-hooks. Any hook version that does not match the expected bundle version—including absent or unreadable values—is correctly flagged, preventing silent acceptance of incompatible hooks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->