### PR TITLE
fix: retry gateway discovery in OCI hook to survive slirp4netns race

### DIFF
--- a/src/terok_shield/resources/hook_entrypoint.py
+++ b/src/terok_shield/resources/hook_entrypoint.py
@@ -29,6 +29,7 @@ import socket
 import struct
 import subprocess  # nosec B404
 import sys
+import time
 from pathlib import Path
 
 # These constants are intentionally duplicated from src/terok_shield/state.py
@@ -293,33 +294,32 @@ def _nsenter(pid: str, *cmd: str, stdin: str | None = None) -> None:
 # ── Gateway discovery ──────────────────────────────────
 
 
-def _read_gateway(pid: str) -> str:
-    """Read the default IPv4 gateway from the container's routing table.
+_GATEWAY_POLL_INTERVAL = 0.05  # 50 ms between retries
+_GATEWAY_POLL_TIMEOUT = 5.0  # give up after 5 s
 
-    Parses ``/proc/{pid}/net/route`` (the kernel routing table for the
-    container's network namespace).  Returns an empty string when no default
-    route is present (e.g. pasta mode) or when parsing fails — fail-closed:
-    the nft ruleset is still applied, gateway sets stay empty.
+
+def _parse_gateway_v4(pid: str) -> str:
+    """Parse the default IPv4 gateway from ``/proc/{pid}/net/route``.
+
+    Returns empty string when no default route is present or parsing fails.
     """
     try:
         for line in Path(f"/proc/{pid}/net/route").read_text().splitlines()[1:]:
             fields = line.split()
             if len(fields) >= 3 and fields[1] == "00000000":
                 gw = socket.inet_ntoa(struct.pack("=I", int(fields[2], 16)))
-                ipaddress.ip_address(gw)  # validate — raises ValueError if malformed
+                if ipaddress.ip_address(gw).is_unspecified:
+                    continue  # 0.0.0.0 = connected route, not a real gateway
                 return gw
     except (OSError, ValueError, struct.error):
         pass
     return ""
 
 
-def _read_gateway_v6(pid: str) -> str:
-    """Read the default IPv6 gateway from the container's routing table.
+def _parse_gateway_v6(pid: str) -> str:
+    """Parse the default IPv6 gateway from ``/proc/{pid}/net/ipv6_route``.
 
-    Parses ``/proc/{pid}/net/ipv6_route``.  Each line has 10 space-separated
-    hex fields; the default route has dest_net=32 zeros and prefix_len=00.
-    The nexthop (field index 4) is a 128-bit address stored as 32 hex chars.
-    Returns an empty string when no default route is present or parsing fails.
+    Returns empty string when no default route is present or parsing fails.
     """
     try:
         for line in Path(f"/proc/{pid}/net/ipv6_route").read_text().splitlines():
@@ -331,6 +331,38 @@ def _read_gateway_v6(pid: str) -> str:
     except (OSError, ValueError):
         pass
     return ""
+
+
+def _read_gateway(pid: str) -> str:
+    """Read the default IPv4 gateway, retrying until the route appears.
+
+    On rootless Podman the network backend (slirp4netns / pasta) may not
+    have populated the routing table yet when the ``createRuntime`` OCI
+    hook fires.  Poll briefly so the gateway set is populated before the
+    container process starts.
+
+    Raises ``RuntimeError`` after the timeout — a container without a
+    gateway cannot reach host services (gate, credential proxy).
+    """
+    deadline = time.monotonic() + _GATEWAY_POLL_TIMEOUT
+    while True:
+        if gw := _parse_gateway_v4(pid):
+            return gw
+        if time.monotonic() >= deadline:
+            raise RuntimeError(
+                f"no default IPv4 route in /proc/{pid}/net/route after "
+                f"{_GATEWAY_POLL_TIMEOUT:.0f} s — network backend not ready"
+            )
+        time.sleep(_GATEWAY_POLL_INTERVAL)
+
+
+def _read_gateway_v6(pid: str) -> str:
+    """Read the default IPv6 gateway (best-effort, no retry).
+
+    IPv6 is optional — many setups are v4-only.  Returns empty string
+    when no default route is present.
+    """
+    return _parse_gateway_v6(pid)
 
 
 # ── Process identity ───────────────────────────────────

--- a/tests/unit/test_hook_entrypoint.py
+++ b/tests/unit/test_hook_entrypoint.py
@@ -39,6 +39,12 @@ _ROUTE_NO_DEFAULT = (
     "eth0\t0A000000\t00000000\t0001\t0\t0\t100\t00FFFFFF\t0\t0\t0\n"
 )
 
+# Default route with zero gateway (connected route, not a real gateway)
+_ROUTE_ZERO_GATEWAY = (
+    "Iface\tDestination\tGateway\tFlags\tRefCnt\tUse\tMetric\tMask\tMTU\tWindow\tIRTT\n"
+    "eth0\t00000000\t00000000\t0003\t0\t0\t100\t00000000\t0\t0\t0\n"
+)
+
 
 def _oci_json(
     pid: int = 42,
@@ -162,41 +168,73 @@ def test_find_binary_uses_which_or_falls_back(
 # ── _read_gateway ─────────────────────────────────────────────────────────────
 
 
-def test_read_gateway_returns_ip_for_default_route() -> None:
-    """_read_gateway() parses the default gateway from a slirp4netns routing table."""
+def test_parse_gateway_v4_returns_ip_for_default_route() -> None:
+    """_parse_gateway_v4() parses the default gateway from a slirp4netns routing table."""
     with mock.patch("terok_shield.resources.hook_entrypoint.Path") as mock_path_cls:
         mock_path_cls.return_value.read_text.return_value = _ROUTE_WITH_DEFAULT
-        gw = hook_entrypoint._read_gateway("42")
-
-    assert gw == "10.0.2.2"
+        assert hook_entrypoint._parse_gateway_v4("42") == "10.0.2.2"
 
 
-def test_read_gateway_returns_empty_when_no_default_route() -> None:
-    """_read_gateway() returns '' when there is no default (00000000 destination) route."""
+def test_parse_gateway_v4_returns_empty_when_no_default_route() -> None:
+    """_parse_gateway_v4() returns '' when no default route exists."""
     with mock.patch("terok_shield.resources.hook_entrypoint.Path") as mock_path_cls:
         mock_path_cls.return_value.read_text.return_value = _ROUTE_NO_DEFAULT
-        gw = hook_entrypoint._read_gateway("42")
-
-    assert gw == ""
+        assert hook_entrypoint._parse_gateway_v4("42") == ""
 
 
-def test_read_gateway_returns_empty_on_oserror() -> None:
-    """_read_gateway() returns '' when /proc/{pid}/net/route is unreadable."""
+def test_parse_gateway_v4_returns_empty_on_oserror() -> None:
+    """_parse_gateway_v4() returns '' when /proc/{pid}/net/route is unreadable."""
     with mock.patch("terok_shield.resources.hook_entrypoint.Path") as mock_path_cls:
         mock_path_cls.return_value.read_text.side_effect = OSError("no file")
-        gw = hook_entrypoint._read_gateway("42")
-
-    assert gw == ""
+        assert hook_entrypoint._parse_gateway_v4("42") == ""
 
 
-def test_read_gateway_returns_empty_on_malformed_hex() -> None:
-    """_read_gateway() returns '' when the gateway hex is malformed."""
+def test_parse_gateway_v4_returns_empty_on_malformed_hex() -> None:
+    """_parse_gateway_v4() returns '' when the gateway hex is malformed."""
     malformed = "Iface\tDestination\tGateway\neth0\t00000000\tZZZZZZZZ\n"
     with mock.patch("terok_shield.resources.hook_entrypoint.Path") as mock_path_cls:
         mock_path_cls.return_value.read_text.return_value = malformed
-        gw = hook_entrypoint._read_gateway("42")
+        assert hook_entrypoint._parse_gateway_v4("42") == ""
 
-    assert gw == ""
+
+def test_parse_gateway_v4_skips_zero_gateway() -> None:
+    """_parse_gateway_v4() returns '' for a connected route with gateway 0.0.0.0."""
+    with mock.patch("terok_shield.resources.hook_entrypoint.Path") as mock_path_cls:
+        mock_path_cls.return_value.read_text.return_value = _ROUTE_ZERO_GATEWAY
+        assert hook_entrypoint._parse_gateway_v4("42") == ""
+
+
+def test_read_gateway_retries_until_route_appears() -> None:
+    """_read_gateway() polls until slirp4netns populates the routing table."""
+    call_count = 0
+
+    def _delayed_route(*_a: object, **_kw: object) -> str:
+        nonlocal call_count
+        call_count += 1
+        return _ROUTE_WITH_DEFAULT if call_count >= 3 else _ROUTE_NO_DEFAULT
+
+    with (
+        mock.patch("terok_shield.resources.hook_entrypoint.Path") as mock_path_cls,
+        mock.patch("terok_shield.resources.hook_entrypoint.time.sleep"),
+    ):
+        mock_path_cls.return_value.read_text.side_effect = _delayed_route
+        assert hook_entrypoint._read_gateway("42") == "10.0.2.2"
+    assert call_count == 3
+
+
+def test_read_gateway_raises_on_timeout() -> None:
+    """_read_gateway() raises RuntimeError when no route appears within the timeout."""
+    with (
+        mock.patch("terok_shield.resources.hook_entrypoint.Path") as mock_path_cls,
+        mock.patch(
+            "terok_shield.resources.hook_entrypoint.time.monotonic",
+            side_effect=[0.0, 0.0, 6.0],  # start, first check, expired
+        ),
+        mock.patch("terok_shield.resources.hook_entrypoint.time.sleep"),
+        pytest.raises(RuntimeError, match="no default IPv4 route"),
+    ):
+        mock_path_cls.return_value.read_text.return_value = _ROUTE_NO_DEFAULT
+        hook_entrypoint._read_gateway("42")
 
 
 # ── _read_gateway_v6 ─────────────────────────────────────────────────────────

--- a/tests/unit/test_hook_entrypoint_isolation.py
+++ b/tests/unit/test_hook_entrypoint_isolation.py
@@ -38,6 +38,7 @@ class TestHookEntrypointImportIsolation:
             "struct",
             "subprocess",
             "sys",
+            "time",
         }
         for node in ast.walk(tree):
             if isinstance(node, ast.Import):


### PR DESCRIPTION
## Summary

- On rootless Podman (tested with 4.9.3), the `createRuntime` OCI hook fires before slirp4netns populates the container routing table
- `_read_gateway()` found an empty `/proc/{pid}/net/route`, leaving `@gateway_v4` unpopulated
- Loopback port rules (gate server, credential proxy) matched nothing — traffic to `10.0.2.2:9418` fell through to the `10.0.0.0/8` private-range reject rule
- Result: immediate connection refused (0 ms) when cloning from the git gate

**Fix:** poll `/proc/{pid}/net/route` at 50 ms intervals (up to 5 s timeout). Raise `RuntimeError` on timeout — a container without a gateway cannot reach host services. IPv6 stays best-effort (no retry).

Confirmed with debug instrumentation: at `createRuntime` time the route table contained only the header line with no data rows. After the container started, routes were present.

## Test plan

- [x] Unit tests updated: `_parse_gateway_v4` (renamed single-attempt parser), retry-succeeds, timeout-raises
- [x] Import isolation test updated for `time` module
- [x] `make check` passes (lint + test-unit + tach + security + docstrings + deadcode + reuse)
- [ ] Manual: re-run `terok-sandbox shield setup --user` on the affected Ubuntu machine, then `terok task start` should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable IPv4 gateway detection: the system now polls for a default IPv4 route (up to 5s) and fails fast with a clear error if none appears, avoiding silent misconfiguration.
  * IPv6 gateway handling remains non-fatal when absent.

* **Tests**
  * Unit tests expanded to cover polling, timeout, and edge cases for gateway detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->