### PR TITLE
refactor: import SLIRP4NETNS_CIDR instead of duplicating

### DIFF
--- a/src/terok_shield/podman_info.py
+++ b/src/terok_shield/podman_info.py
@@ -16,9 +16,7 @@ import tomllib
 from dataclasses import dataclass
 from pathlib import Path
 
-# Duplicated from nft.constants to avoid a cross-boundary import
-# (tach: podman_info → nft.constants is disallowed).  Keep in sync.
-_DEFAULT_SLIRP4NETNS_CIDR = "10.0.2.0/24"
+from .nft.constants import SLIRP4NETNS_CIDR as _DEFAULT_SLIRP4NETNS_CIDR
 
 # Well-known system hooks directories (containers-common standard).
 # Used as fallback when containers.conf doesn't specify hooks_dir.

--- a/tach.toml
+++ b/tach.toml
@@ -45,7 +45,9 @@ depends_on = []
 [[modules]]
 path = "terok_shield.podman_info"
 layer = "foundation"
-depends_on = []
+depends_on = [
+    "terok_shield.nft.constants",
+]
 
 # Per-container state bundle layout — zero internal deps
 [[modules]]


### PR DESCRIPTION
## Summary
- `podman_info.py` duplicated `SLIRP4NETNS_CIDR` from `nft.constants` with a "keep in sync" comment — a drift risk
- Both modules are foundation-layer with zero deps; adding the tach dependency is safe and eliminates the duplication
- Same pattern as terok-sandbox#122 (shared `HEALTH_PATH` constant)

## Test plan
- [x] `make check` passes (1013 tests, lint, tach, security, docstrings, deadcode, reuse)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization by consolidating duplicate constant definitions and clarifying module dependencies. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->