### PR TITLE
feat: enforce deny.list when shield is down

### DIFF
--- a/src/terok_shield/hooks/mode.py
+++ b/src/terok_shield/hooks/mode.py
@@ -456,7 +456,8 @@ class HookMode:
     # ── State transitions ───────────────────────────────
 
     def shield_down(self, container: str, *, allow_all: bool = False) -> None:
-        """Switch a running container to bypass mode."""
+        """Switch a running container to shield-down (accept-all + deny.list)."""
+        sd = self._config.state_dir.resolve()
         ruleset = self._container_ruleset(container)
         rs = ruleset.build_bypass(allow_all=allow_all)
         current = self.shield_state(container)
@@ -465,10 +466,18 @@ class HookMode:
         else:
             stdin = f"delete table {NFT_TABLE}\n{rs}"
         self._runner.nft_via_nsenter(container, stdin=stdin)
+
+        # Repopulate deny sets so deny.list is enforced even when shield is down.
+        denied_ips = list(state.read_denied_ips(sd))
+        if denied_ips:
+            deny_cmd = add_deny_elements_dual(denied_ips)
+            if deny_cmd:
+                self._runner.nft_via_nsenter(container, stdin=deny_cmd)
+
         output = self._runner.nft_via_nsenter(container, "list", "ruleset")
         errors = ruleset.verify_bypass(output, allow_all=allow_all)
         if errors:
-            raise RuntimeError(f"Bypass ruleset verification failed: {'; '.join(errors)}")
+            raise RuntimeError(f"Shield-down ruleset verification failed: {'; '.join(errors)}")
 
     def shield_block(self, container: str) -> None:
         """Total network blackout — drop all traffic, log for forensics."""

--- a/src/terok_shield/nft/rules.py
+++ b/src/terok_shield/nft/rules.py
@@ -125,6 +125,53 @@ class RulesetBuilder:
 # ── Ruleset generation ──────────────────────────────────
 
 
+def _ruleset_preamble(
+    dns: str,
+    loopback_ports: tuple[int, ...],
+    gateway_v4: str,
+    gateway_v6: str,
+    set_timeout: str,
+) -> tuple[str, str, str, str, str, str, str]:
+    """Validate inputs and build the shared fragments for both rulesets.
+
+    Returns ``(dns_af, dns, infra_block, set_v4, set_v6, set_deny_v4, set_deny_v6)``.
+    """
+    dns = safe_ip(dns)
+    if set_timeout:
+        _safe_timeout(set_timeout)
+    for p in loopback_ports:
+        _safe_port(p)
+    port_rules = _loopback_port_rules(loopback_ports)
+    gw_rules = _gateway_port_rules(loopback_ports, gateway_v4, gateway_v6)
+    infra_block = ""
+    if gw_rules:
+        infra_block += f"\n{gw_rules}"
+    if port_rules:
+        infra_block += f"\n{port_rules}"
+    infra_block += "\n"
+    dns_af = "ip" if _is_v4(dns) else "ip6"
+    return (
+        dns_af,
+        dns,
+        infra_block,
+        _set_declaration("allow_v4", "ipv4_addr", set_timeout),
+        _set_declaration("allow_v6", "ipv6_addr", set_timeout),
+        _set_declaration("deny_v4", "ipv4_addr"),
+        _set_declaration("deny_v6", "ipv6_addr"),
+    )
+
+
+_INPUT_CHAIN = """\
+            chain input {
+                type filter hook input priority filter; policy drop;
+                iifname "lo" accept
+                ct state established,related accept
+                udp sport 53 accept
+                tcp sport 53 accept
+                drop
+            }"""
+
+
 def hook_ruleset(
     dns: str = PASTA_DNS,
     loopback_ports: tuple[int, ...] = (),
@@ -151,24 +198,13 @@ def hook_ruleset(
         gateway_v6: IPv6 gateway for host-service port rules.
         set_timeout: nft set element timeout (e.g. ``30m``).
     """
-    dns = safe_ip(dns)
-    if set_timeout:
-        _safe_timeout(set_timeout)
-    for p in loopback_ports:
-        _safe_port(p)
-    port_rules = _loopback_port_rules(loopback_ports)
-    gw_rules = _gateway_port_rules(loopback_ports, gateway_v4, gateway_v6)
-    infra_block = ""
-    if gw_rules:
-        infra_block += f"\n{gw_rules}"
-    if port_rules:
-        infra_block += f"\n{port_rules}"
-    infra_block += "\n"
-    dns_af = "ip" if _is_v4(dns) else "ip6"
-    set_v4 = _set_declaration("allow_v4", "ipv4_addr", set_timeout)
-    set_v6 = _set_declaration("allow_v6", "ipv6_addr", set_timeout)
-    set_deny_v4 = _set_declaration("deny_v4", "ipv4_addr")
-    set_deny_v6 = _set_declaration("deny_v6", "ipv6_addr")
+    dns_af, dns, infra_block, set_v4, set_v6, set_deny_v4, set_deny_v6 = _ruleset_preamble(
+        dns,
+        loopback_ports,
+        gateway_v4,
+        gateway_v6,
+        set_timeout,
+    )
     allow_rules = _audit_allow_rules()
     deny_rules = _deny_set_rules()
     private_rules = _private_range_rules()
@@ -192,14 +228,7 @@ def hook_ruleset(
         {terminal_rule}
             }}
 
-            chain input {{
-                type filter hook input priority filter; policy drop;
-                iifname "lo" accept
-                ct state established,related accept
-                udp sport 53 accept
-                tcp sport 53 accept
-                drop
-            }}
+{_INPUT_CHAIN}
         }}
     """)
 
@@ -213,10 +242,11 @@ def bypass_ruleset(
     allow_all: bool = False,
     set_timeout: str = "",
 ) -> str:
-    """Generate a bypass (accept-all + log) nftables ruleset.
+    """Generate a shield-down (accept-all + log) nftables ruleset.
 
-    Same structure as ``hook_ruleset()`` but output chain policy is accept
-    and new connections are logged with the bypass prefix.
+    Same structure as ``hook_ruleset()`` but output chain policy is accept,
+    new connections are logged with the bypass prefix, and deny sets are
+    enforced so ``deny.list`` entries still block traffic.
 
     Args:
         dns: DNS server address (pasta default forwarder).
@@ -226,24 +256,13 @@ def bypass_ruleset(
         allow_all: If True, remove private-range reject rules.
         set_timeout: nft set element timeout (e.g. ``30m``).
     """
-    dns = safe_ip(dns)
-    if set_timeout:
-        _safe_timeout(set_timeout)
-    for p in loopback_ports:
-        _safe_port(p)
-    port_rules = _loopback_port_rules(loopback_ports)
-    gw_rules = _gateway_port_rules(loopback_ports, gateway_v4, gateway_v6)
-    infra_block = ""
-    if gw_rules:
-        infra_block += f"\n{gw_rules}"
-    if port_rules:
-        infra_block += f"\n{port_rules}"
-    infra_block += "\n"
-    dns_af = "ip" if _is_v4(dns) else "ip6"
-    set_v4 = _set_declaration("allow_v4", "ipv4_addr", set_timeout)
-    set_v6 = _set_declaration("allow_v6", "ipv6_addr", set_timeout)
-    set_deny_v4 = _set_declaration("deny_v4", "ipv4_addr")
-    set_deny_v6 = _set_declaration("deny_v6", "ipv6_addr")
+    dns_af, dns, infra_block, set_v4, set_v6, set_deny_v4, set_deny_v6 = _ruleset_preamble(
+        dns,
+        loopback_ports,
+        gateway_v4,
+        gateway_v6,
+        set_timeout,
+    )
     deny_rules = _deny_set_rules()
     private_rules = _private_range_rules()
     private_block = "" if allow_all else f"\n{private_rules}"
@@ -267,14 +286,7 @@ def bypass_ruleset(
         {bypass_log}{private_block}
             }}
 
-            chain input {{
-                type filter hook input priority filter; policy drop;
-                iifname "lo" accept
-                ct state established,related accept
-                udp sport 53 accept
-                tcp sport 53 accept
-                drop
-            }}
+{_INPUT_CHAIN}
         }}
     """)
 

--- a/src/terok_shield/nft/rules.py
+++ b/src/terok_shield/nft/rules.py
@@ -242,6 +242,9 @@ def bypass_ruleset(
     dns_af = "ip" if _is_v4(dns) else "ip6"
     set_v4 = _set_declaration("allow_v4", "ipv4_addr", set_timeout)
     set_v6 = _set_declaration("allow_v6", "ipv6_addr", set_timeout)
+    set_deny_v4 = _set_declaration("deny_v4", "ipv4_addr")
+    set_deny_v6 = _set_declaration("deny_v6", "ipv6_addr")
+    deny_rules = _deny_set_rules()
     private_rules = _private_range_rules()
     private_block = "" if allow_all else f"\n{private_rules}"
     bypass_log = (
@@ -251,6 +254,8 @@ def bypass_ruleset(
         table {NFT_TABLE} {{
             {set_v4}
             {set_v6}
+            {set_deny_v4}
+            {set_deny_v6}
 
             chain output {{
                 type filter hook output priority filter; policy accept;
@@ -258,6 +263,7 @@ def bypass_ruleset(
                 ct state established,related accept
                 udp dport 53 {dns_af} daddr {dns} accept
                 tcp dport 53 {dns_af} daddr {dns} accept{infra_block}\
+        {deny_rules}
         {bypass_log}{private_block}
             }}
 
@@ -521,10 +527,9 @@ def verify_bypass_ruleset(nft_output: str, *, allow_all: bool = False) -> list[s
             errors.append(f"{chain} chain missing")
     if BYPASS_LOG_PREFIX not in nft_output:
         errors.append("bypass nflog prefix missing")
-    if "allow_v4" not in nft_output:
-        errors.append("allow_v4 set missing")
-    if "allow_v6" not in nft_output:
-        errors.append("allow_v6 set missing")
+    for sname in ("allow_v4", "allow_v6", "deny_v4", "deny_v6"):
+        if sname not in nft_output:
+            errors.append(f"{sname} set missing")
     if not allow_all:
         errors.extend(_verify_private_blocks(nft_output))
     return errors

--- a/tests/unit/test_hook_mode_class.py
+++ b/tests/unit/test_hook_mode_class.py
@@ -1285,3 +1285,25 @@ def test_shield_up_repopulates_deny_sets(
     # Verify deny elements were sent via nsenter
     deny_calls = [c for c in harness.runner.nft_via_nsenter.call_args_list if c.kwargs.get("stdin")]
     assert any(TEST_IP1 in (c.kwargs.get("stdin", "") or "") for c in deny_calls)
+
+
+def test_shield_down_repopulates_deny_sets(
+    make_hook_mode: HookModeHarnessFactory,
+    make_config: ConfigFactory,
+) -> None:
+    """shield_down() repopulates deny sets from deny.list so denies survive shield-down."""
+    config = make_config()
+    harness = make_hook_mode(config=config)
+    harness.mode._container_ruleset = lambda _c: harness.ruleset
+    harness.runner.nft_via_nsenter.return_value = ""
+    harness.ruleset.build_bypass.return_value = "bypass ruleset"
+    harness.ruleset.verify_bypass.return_value = []
+
+    # Write a deny.list before going down
+    state.deny_path(config.state_dir).write_text(f"{TEST_IP1}\n")
+
+    harness.mode.shield_down("test-ctr", allow_all=False)
+
+    # Verify deny elements were sent via nsenter
+    deny_calls = [c for c in harness.runner.nft_via_nsenter.call_args_list if c.kwargs.get("stdin")]
+    assert any(TEST_IP1 in (c.kwargs.get("stdin", "") or "") for c in deny_calls)

--- a/tests/unit/test_nft.py
+++ b/tests/unit/test_nft.py
@@ -632,9 +632,12 @@ def test_bypass_ruleset_allow_all_removes_all_private_range_rejects() -> None:
         assert net not in rs, f"Private range {net!r} should be absent when allow_all=True"
 
 
-def test_bypass_ruleset_does_not_include_the_enforce_deny_rule() -> None:
-    """Bypass mode must log new flows without appending the enforce-mode deny rule."""
-    assert _DENY_LOG_PREFIX not in bypass_ruleset()
+def test_bypass_ruleset_includes_deny_sets() -> None:
+    """Shield-down ruleset includes deny sets so deny.list is enforced."""
+    rs = bypass_ruleset()
+    assert "deny_v4" in rs
+    assert "deny_v6" in rs
+    assert _DENY_LOG_PREFIX in rs
 
 
 def test_bypass_ruleset_emits_loopback_port_rules() -> None:


### PR DESCRIPTION
## Summary

- Shield-down (bypass) ruleset now includes `deny_v4`/`deny_v6` nft sets with explicit reject rules, matching the shield-up (hook) ruleset
- `shield_down()` repopulates deny sets from `deny.list` after applying the ruleset, so operator deny decisions are enforced regardless of shield state
- `verify_bypass_ruleset()` now checks for deny set presence

Previously, `shield.down()` replaced the nft table with a `policy accept` ruleset that had no deny mechanism — `deny.list` entries were silently ignored. This meant `shield.deny("api.anthropic.com")` had no effect when the shield was down.

Motivated by terok-ai/terok#567 (Claude OAuth workaround): the credential proxy needs to block `api.anthropic.com` even when the shield starts down (the default).

## Test plan

- [x] Existing unit tests pass (1013 passed)
- [x] Updated `test_bypass_ruleset_does_not_include_the_enforce_deny_rule` → `test_bypass_ruleset_includes_deny_sets`
- [x] `make check` passes (lint, test, tach, docstrings, security, reuse)
- [ ] Integration test: deny IP → shield down → verify IP still blocked (needs podman)
- [ ] Integration test: shield down → deny → verify blocked (needs podman)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Deny lists are now consistently enforced across all shield modes, including shield-down and bypass modes. Blocked IP addresses remain blocked even when the shield is temporarily disabled or in bypass mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->