### PR TITLE
refactor: absorb free functions into RulesetBuilder class

### DIFF
--- a/src/terok_shield/hooks/mode.py
+++ b/src/terok_shield/hooks/mode.py
@@ -43,13 +43,13 @@ from ..config import (
 from ..dns import dnsmasq
 from ..nft.constants import (
     NFT_SET_TIMEOUT_DNSMASQ,
+    NFT_TABLE,
     PASTA_DNS,
     PASTA_HOST_LOOPBACK_MAP,
     SLIRP4NETNS_DNS,
     SLIRP4NETNS_GATEWAY_V6,
 )
 from ..nft.rules import (
-    NFT_TABLE,
     RulesetBuilder,
     add_deny_elements_dual,
     delete_deny_elements_dual,

--- a/src/terok_shield/nft/rules.py
+++ b/src/terok_shield/nft/rules.py
@@ -32,6 +32,16 @@ from .constants import (
 _SAFE_TIMEOUT_RE = re.compile(r"^\d+[smhd]$")
 _SAFE_IDENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
+_INPUT_CHAIN = """\
+            chain input {
+                type filter hook input priority filter; policy drop;
+                iifname "lo" accept
+                ct state established,related accept
+                udp sport 53 accept
+                tcp sport 53 accept
+                drop
+            }"""
+
 
 # ── RulesetBuilder ──────────────────────────────────────
 
@@ -75,42 +85,205 @@ class RulesetBuilder:
         self._gateway_v6 = _safe_ipv6(gateway_v6) if gateway_v6 else ""
         self._set_timeout = set_timeout
 
+    # ── Ruleset generation ─────────────────────────────
+
     def build_hook(self) -> str:
-        """Generate the hook-mode (deny-all) nftables ruleset."""
-        return hook_ruleset(
-            dns=self._dns,
-            loopback_ports=self._loopback_ports,
-            gateway_v4=self._gateway_v4,
-            gateway_v6=self._gateway_v6,
-            set_timeout=self._set_timeout,
-        )
+        """Generate the hook-mode (deny-all) nftables ruleset.
+
+        Applied by the OCI hook into the container's own netns.
+        Dual-stack: both IPv4 and IPv6 use deny-all + allowlist.
+
+        Gateway addresses are baked directly into the ruleset as literal
+        accept rules -- no dynamic sets or runtime discovery needed.
+
+        Chain order (output):
+            loopback -> established -> DNS -> gateway ports -> loopback ports
+            -> allow sets -> deny sets -> private-range reject -> terminal deny
+        """
+        dns_af, dns, infra_block, set_v4, set_v6, set_deny_v4, set_deny_v6 = self._preamble()
+        allow_rules = RulesetBuilder._audit_allow_rules()
+        deny_rules = RulesetBuilder._deny_set_rules()
+        private_rules = RulesetBuilder._private_range_rules()
+        terminal_rule = RulesetBuilder._terminal_deny_rule()
+        return textwrap.dedent(f"""\
+            table {NFT_TABLE} {{
+                {set_v4}
+                {set_v6}
+                {set_deny_v4}
+                {set_deny_v6}
+
+                chain output {{
+                    type filter hook output priority filter; policy drop;
+                    oifname "lo" accept
+                    ct state established,related accept
+                    udp dport 53 {dns_af} daddr {dns} accept
+                    tcp dport 53 {dns_af} daddr {dns} accept{infra_block}\
+            {allow_rules}
+            {deny_rules}
+            {private_rules}
+            {terminal_rule}
+                }}
+
+    {_INPUT_CHAIN}
+            }}
+        """)
 
     def build_bypass(self, *, allow_all: bool = False) -> str:
-        """Generate the bypass-mode (accept-all + log) ruleset."""
-        return bypass_ruleset(
-            dns=self._dns,
-            loopback_ports=self._loopback_ports,
-            gateway_v4=self._gateway_v4,
-            gateway_v6=self._gateway_v6,
-            allow_all=allow_all,
-            set_timeout=self._set_timeout,
+        """Generate the bypass-mode (accept-all + log) ruleset.
+
+        Same structure as ``build_hook()`` but output chain policy is accept,
+        new connections are logged with the bypass prefix, and deny sets are
+        enforced so ``deny.list`` entries still block traffic.
+
+        Args:
+            allow_all: If True, remove private-range reject rules.
+        """
+        dns_af, dns, infra_block, set_v4, set_v6, set_deny_v4, set_deny_v6 = self._preamble()
+        deny_rules = RulesetBuilder._deny_set_rules()
+        private_rules = RulesetBuilder._private_range_rules()
+        private_block = "" if allow_all else f"\n{private_rules}"
+        bypass_log = (
+            f'        ct state new log group {NFLOG_GROUP} prefix "{BYPASS_LOG_PREFIX}: " counter'
         )
+        return textwrap.dedent(f"""\
+            table {NFT_TABLE} {{
+                {set_v4}
+                {set_v6}
+                {set_deny_v4}
+                {set_deny_v6}
+
+                chain output {{
+                    type filter hook output priority filter; policy accept;
+                    oifname "lo" accept
+                    ct state established,related accept
+                    udp dport 53 {dns_af} daddr {dns} accept
+                    tcp dport 53 {dns_af} daddr {dns} accept{infra_block}\
+            {deny_rules}
+            {bypass_log}{private_block}
+                }}
+
+    {_INPUT_CHAIN}
+            }}
+        """)
+
+    @staticmethod
+    def build_block() -> str:
+        """Generate the block-mode (total blackout) ruleset.
+
+        Drops all traffic except loopback and established connections.
+        No DNS, no allowlists, no gateway ports.  Forensic logging only.
+        """
+        blocked_log = f'        log group {NFLOG_GROUP} prefix "{BLOCKED_LOG_PREFIX}: " drop'
+        return textwrap.dedent(f"""\
+            table {NFT_TABLE} {{
+                chain output {{
+                    type filter hook output priority filter; policy drop;
+                    oifname "lo" accept
+                    ct state established,related accept
+            {blocked_log}
+                }}
+
+                chain input {{
+                    type filter hook input priority filter; policy drop;
+                    iifname "lo" accept
+                    ct state established,related accept
+                    drop
+                }}
+            }}
+        """)
+
+    # ── Verification ───────────────────────────────────
 
     def verify_hook(self, nft_output: str) -> list[str]:
-        """Check applied hook ruleset invariants.  Returns errors (empty = OK)."""
-        return verify_ruleset(nft_output)
+        """Check applied hook ruleset invariants.  Returns errors (empty = OK).
 
-    def build_block(self) -> str:
-        """Generate the block-mode (total blackout) ruleset."""
-        return block_ruleset()
-
-    def verify_block(self, nft_output: str) -> list[str]:
-        """Check applied block ruleset invariants.  Returns errors (empty = OK)."""
-        return verify_block_ruleset(nft_output)
+        Verifies:
+        - Default policy is drop
+        - Both output and input chains exist
+        - Reject type is present
+        - Dual-stack allow sets are declared
+        - Dual-stack deny sets are declared
+        - All private ranges are present (RFC 1918 + RFC 4193/4291)
+        - Terminal deny-all rule with BLOCKED prefix present
+        """
+        errors: list[str] = []
+        if "policy drop" not in nft_output:
+            errors.append("policy is not drop")
+        for chain in ("output", "input"):
+            if f"chain {chain}" not in nft_output:
+                errors.append(f"{chain} chain missing")
+        if "admin-prohibited" not in nft_output:
+            errors.append("reject type missing")
+        if "allow_v4" not in nft_output:
+            errors.append("allow_v4 set missing")
+        if "allow_v6" not in nft_output:
+            errors.append("allow_v6 set missing")
+        if "deny_v4" not in nft_output:
+            errors.append("deny_v4 set missing")
+        if "deny_v6" not in nft_output:
+            errors.append("deny_v6 set missing")
+        # Verify the terminal deny-all rule -- a standalone log+reject with the
+        # BLOCKED prefix (no daddr selector, unlike deny-set rules).
+        terminal_deny_re = re.compile(
+            rf'^\s*log\s+.*prefix\s+"{re.escape(BLOCKED_LOG_PREFIX)}',
+            re.MULTILINE,
+        )
+        if not terminal_deny_re.search(nft_output):
+            errors.append("terminal deny-all rule missing")
+        errors.extend(RulesetBuilder._verify_private_blocks(nft_output))
+        return errors
 
     def verify_bypass(self, nft_output: str, *, allow_all: bool = False) -> list[str]:
-        """Check applied bypass ruleset invariants.  Returns errors (empty = OK)."""
-        return verify_bypass_ruleset(nft_output, allow_all=allow_all)
+        """Check applied bypass ruleset invariants.  Returns errors (empty = OK).
+
+        Verifies:
+        - Output chain has policy accept
+        - Input chain has policy drop
+        - Bypass nflog prefix is present
+        - Dual-stack allow sets are declared
+        - Private-range reject rules present (unless *allow_all*)
+        """
+        errors: list[str] = []
+        if "policy accept" not in nft_output:
+            errors.append("output policy is not accept")
+        if "policy drop" not in nft_output:
+            errors.append("input policy is not drop")
+        for chain in ("output", "input"):
+            if f"chain {chain}" not in nft_output:
+                errors.append(f"{chain} chain missing")
+        if BYPASS_LOG_PREFIX not in nft_output:
+            errors.append("bypass nflog prefix missing")
+        for sname in ("allow_v4", "allow_v6", "deny_v4", "deny_v6"):
+            if sname not in nft_output:
+                errors.append(f"{sname} set missing")
+        if not allow_all:
+            errors.extend(RulesetBuilder._verify_private_blocks(nft_output))
+        return errors
+
+    @staticmethod
+    def verify_block(nft_output: str) -> list[str]:
+        """Check applied block ruleset invariants.  Returns errors (empty = OK).
+
+        Verifies:
+        - Both chains present with policy drop
+        - Blocked log prefix present
+        - No allow sets (total blackout means no allowlists)
+        """
+        errors: list[str] = []
+        if "policy drop" not in nft_output:
+            errors.append("policy is not drop")
+        for chain in ("output", "input"):
+            if f"chain {chain}" not in nft_output:
+                errors.append(f"{chain} chain missing")
+        if BLOCKED_LOG_PREFIX not in nft_output:
+            errors.append("blocked nflog prefix missing")
+        if "allow_v4" in nft_output:
+            errors.append("allow_v4 set present in block mode")
+        if "allow_v6" in nft_output:
+            errors.append("allow_v6 set present in block mode")
+        return errors
+
+    # ── Set operations (instance) ──────────────────────
 
     def add_elements_dual(self, ips: list[str]) -> str:
         """Classify IPs by family and generate add-element commands for both sets.
@@ -121,237 +294,159 @@ class RulesetBuilder:
         """
         return add_elements_dual(ips, permanent=bool(self._set_timeout))
 
+    # ── Private helpers ────────────────────────────────
 
-# ── Ruleset generation ──────────────────────────────────
+    def _preamble(self) -> tuple[str, str, str, str, str, str, str]:
+        """Validate inputs and build the shared fragments for both rulesets.
 
+        Returns ``(dns_af, dns, infra_block, set_v4, set_v6, set_deny_v4, set_deny_v6)``.
+        """
+        dns = safe_ip(self._dns)
+        if self._set_timeout:
+            _safe_timeout(self._set_timeout)
+        for p in self._loopback_ports:
+            _safe_port(p)
+        port_rules = RulesetBuilder._loopback_port_rules(self._loopback_ports)
+        gw_rules = RulesetBuilder._gateway_port_rules(
+            self._loopback_ports, self._gateway_v4, self._gateway_v6
+        )
+        infra_block = ""
+        if gw_rules:
+            infra_block += f"\n{gw_rules}"
+        if port_rules:
+            infra_block += f"\n{port_rules}"
+        infra_block += "\n"
+        dns_af = "ip" if _is_v4(dns) else "ip6"
+        return (
+            dns_af,
+            dns,
+            infra_block,
+            RulesetBuilder._set_declaration("allow_v4", "ipv4_addr", self._set_timeout),
+            RulesetBuilder._set_declaration("allow_v6", "ipv6_addr", self._set_timeout),
+            RulesetBuilder._set_declaration("deny_v4", "ipv4_addr"),
+            RulesetBuilder._set_declaration("deny_v6", "ipv6_addr"),
+        )
 
-def _ruleset_preamble(
-    dns: str,
-    loopback_ports: tuple[int, ...],
-    gateway_v4: str,
-    gateway_v6: str,
-    set_timeout: str,
-) -> tuple[str, str, str, str, str, str, str]:
-    """Validate inputs and build the shared fragments for both rulesets.
+    @staticmethod
+    def _set_declaration(name: str, family: str, set_timeout: str = "") -> str:
+        """Generate an nft set declaration with optional timeout.
 
-    Returns ``(dns_af, dns, infra_block, set_v4, set_v6, set_deny_v4, set_deny_v6)``.
-    """
-    dns = safe_ip(dns)
-    if set_timeout:
-        _safe_timeout(set_timeout)
-    for p in loopback_ports:
-        _safe_port(p)
-    port_rules = _loopback_port_rules(loopback_ports)
-    gw_rules = _gateway_port_rules(loopback_ports, gateway_v4, gateway_v6)
-    infra_block = ""
-    if gw_rules:
-        infra_block += f"\n{gw_rules}"
-    if port_rules:
-        infra_block += f"\n{port_rules}"
-    infra_block += "\n"
-    dns_af = "ip" if _is_v4(dns) else "ip6"
-    return (
-        dns_af,
-        dns,
-        infra_block,
-        _set_declaration("allow_v4", "ipv4_addr", set_timeout),
-        _set_declaration("allow_v6", "ipv6_addr", set_timeout),
-        _set_declaration("deny_v4", "ipv4_addr"),
-        _set_declaration("deny_v6", "ipv6_addr"),
-    )
+        Args:
+            name: Set name (e.g. ``allow_v4``).
+            family: Address type (``ipv4_addr`` or ``ipv6_addr``).
+            set_timeout: Element timeout (e.g. ``30m``).  When set, adds
+                ``timeout`` flag so elements auto-expire.
+        """
+        if set_timeout:
+            return (
+                f"set {name} {{ type {family}; flags interval, timeout; timeout {set_timeout}; }}"
+            )
+        return f"set {name} {{ type {family}; flags interval; }}"
 
+    @staticmethod
+    def _audit_allow_rules() -> str:
+        """Generate audit rules for allowed traffic (IPv4 + IPv6).
 
-_INPUT_CHAIN = """\
-            chain input {
-                type filter hook input priority filter; policy drop;
-                iifname "lo" accept
-                ct state established,related accept
-                udp sport 53 accept
-                tcp sport 53 accept
-                drop
-            }"""
+        No rate limit -- only new connections reach these rules because
+        ``ct state established,related accept`` is earlier in the chain.
+        """
+        return (
+            f'        ip daddr @allow_v4 log group {NFLOG_GROUP} prefix "{ALLOWED_LOG_PREFIX}: " counter accept\n'
+            f'        ip6 daddr @allow_v6 log group {NFLOG_GROUP} prefix "{ALLOWED_LOG_PREFIX}: " counter accept'
+        )
 
+    @staticmethod
+    def _terminal_deny_rule() -> str:
+        """Generate the terminal default-deny rule with NFLOG audit.
 
-def hook_ruleset(
-    dns: str = PASTA_DNS,
-    loopback_ports: tuple[int, ...] = (),
-    gateway_v4: str = "",
-    gateway_v6: str = "",
-    set_timeout: str = "",
-) -> str:
-    """Generate a per-container nftables ruleset for hook mode.
+        Unclassified packets (not in any allow or deny set) are rejected and
+        logged with the ``BLOCKED`` prefix.  NFLOG is fire-and-forget: if a
+        clearance handler subscribes it can prompt the operator; otherwise
+        events are silently dropped by the kernel.
 
-    Applied by the OCI hook into the container's own netns.
-    Dual-stack: both IPv4 and IPv6 use deny-all + allowlist.
+        Uses ``icmpx`` for cross-family reject in ``inet`` tables --
+        auto-selects ICMP (IPv4) or ICMPv6 (IPv6).
+        """
+        return (
+            f'        log group {NFLOG_GROUP} prefix "{BLOCKED_LOG_PREFIX}: " '
+            f"counter reject with icmpx admin-prohibited"
+        )
 
-    Gateway addresses are baked directly into the ruleset as literal
-    accept rules — no dynamic sets or runtime discovery needed.
+    @staticmethod
+    def _deny_set_rules() -> str:
+        """Generate deny-set match rules (IPv4 + IPv6).
 
-    Chain order (output):
-        loopback -> established -> DNS -> gateway ports -> loopback ports
-        -> allow sets -> deny sets -> private-range reject -> terminal deny
+        Packets matching the deny sets are immediately rejected with an ICMP error.
+        Placed after allow-set rules, before private-range reject.
+        """
+        return (
+            f'        ip daddr @deny_v4 log group {NFLOG_GROUP} prefix "{DENIED_LOG_PREFIX}: " counter reject with icmpx admin-prohibited\n'
+            f'        ip6 daddr @deny_v6 log group {NFLOG_GROUP} prefix "{DENIED_LOG_PREFIX}: " counter reject with icmpx admin-prohibited'
+        )
 
-    Args:
-        dns: DNS server address (pasta default forwarder).
-        loopback_ports: TCP ports to allow on the loopback interface.
-        gateway_v4: IPv4 gateway for host-service port rules.
-        gateway_v6: IPv6 gateway for host-service port rules.
-        set_timeout: nft set element timeout (e.g. ``30m``).
-    """
-    dns_af, dns, infra_block, set_v4, set_v6, set_deny_v4, set_deny_v6 = _ruleset_preamble(
-        dns,
-        loopback_ports,
-        gateway_v4,
-        gateway_v6,
-        set_timeout,
-    )
-    allow_rules = _audit_allow_rules()
-    deny_rules = _deny_set_rules()
-    private_rules = _private_range_rules()
-    terminal_rule = _terminal_deny_rule()
-    return textwrap.dedent(f"""\
-        table {NFT_TABLE} {{
-            {set_v4}
-            {set_v6}
-            {set_deny_v4}
-            {set_deny_v6}
+    @staticmethod
+    def _private_range_rules() -> str:
+        """Generate private-range reject rules (RFC 1918 + RFC 4193/4291).
 
-            chain output {{
-                type filter hook output priority filter; policy drop;
-                oifname "lo" accept
-                ct state established,related accept
-                udp dport 53 {dns_af} daddr {dns} accept
-                tcp dport 53 {dns_af} daddr {dns} accept{infra_block}\
-        {allow_rules}
-        {deny_rules}
-        {private_rules}
-        {terminal_rule}
-            }}
+        Auto-detects address family for the ``daddr`` selector and uses
+        cross-family ``icmpx`` reject for all ranges.
+        """
+        return "\n".join(
+            f"        {'ip' if _is_v4(net) else 'ip6'} daddr {net}"
+            f' log group {NFLOG_GROUP} prefix "{PRIVATE_LOG_PREFIX}: " reject with icmpx admin-prohibited'
+            for net in PRIVATE_RANGES
+        )
 
-{_INPUT_CHAIN}
-        }}
-    """)
+    @staticmethod
+    def _loopback_port_rules(ports: tuple[int, ...]) -> str:
+        """Generate nft accept rules for host-loopback-proxy ports.
 
+        Traffic to ``PASTA_HOST_LOOPBACK_MAP`` (169.254.1.2) goes via pasta's
+        virtual interface, not ``lo``.  pasta's ``--map-host-loopback`` translates
+        this address to ``127.0.0.1`` on the host, enabling container->host
+        loopback access without the pasta 2.x "two loopbacks" splice bug.
+        These rules are placed before the private-range reject block so that
+        link-local traffic to 169.254.1.2 is accepted for the allowed ports.
+        """
+        return "\n".join(
+            f"            tcp dport {p} ip daddr {PASTA_HOST_LOOPBACK_MAP} accept" for p in ports
+        )
 
-def bypass_ruleset(
-    dns: str = PASTA_DNS,
-    loopback_ports: tuple[int, ...] = (),
-    gateway_v4: str = "",
-    gateway_v6: str = "",
-    *,
-    allow_all: bool = False,
-    set_timeout: str = "",
-) -> str:
-    """Generate a shield-down (accept-all + log) nftables ruleset.
+    @staticmethod
+    def _gateway_port_rules(
+        ports: tuple[int, ...], gateway_v4: str = "", gateway_v6: str = ""
+    ) -> str:
+        """Generate nft accept rules for gateway (slirp4netns) host-service ports.
 
-    Same structure as ``hook_ruleset()`` but output chain policy is accept,
-    new connections are logged with the bypass prefix, and deny sets are
-    enforced so ``deny.list`` entries still block traffic.
+        Uses literal gateway IPs baked into the ruleset at generation time --
+        no dynamic sets or runtime discovery needed.  Placed before the
+        private-range reject block so RFC 1918 traffic to the gateway is accepted.
+        """
+        if not ports or not (gateway_v4 or gateway_v6):
+            return ""
+        lines = []
+        for p in ports:
+            if gateway_v4:
+                lines.append(f"        tcp dport {p} ip daddr {safe_ip(gateway_v4)} accept")
+            if gateway_v6:
+                lines.append(f"        tcp dport {p} ip6 daddr {safe_ip(gateway_v6)} accept")
+        return "\n".join(lines)
 
-    Args:
-        dns: DNS server address (pasta default forwarder).
-        loopback_ports: TCP ports to allow on the loopback interface.
-        gateway_v4: IPv4 gateway for host-service port rules.
-        gateway_v6: IPv6 gateway for host-service port rules.
-        allow_all: If True, remove private-range reject rules.
-        set_timeout: nft set element timeout (e.g. ``30m``).
-    """
-    dns_af, dns, infra_block, set_v4, set_v6, set_deny_v4, set_deny_v6 = _ruleset_preamble(
-        dns,
-        loopback_ports,
-        gateway_v4,
-        gateway_v6,
-        set_timeout,
-    )
-    deny_rules = _deny_set_rules()
-    private_rules = _private_range_rules()
-    private_block = "" if allow_all else f"\n{private_rules}"
-    bypass_log = (
-        f'        ct state new log group {NFLOG_GROUP} prefix "{BYPASS_LOG_PREFIX}: " counter'
-    )
-    return textwrap.dedent(f"""\
-        table {NFT_TABLE} {{
-            {set_v4}
-            {set_v6}
-            {set_deny_v4}
-            {set_deny_v6}
+    @staticmethod
+    def _verify_private_blocks(nft_output: str) -> list[str]:
+        """Check private-range reject rules (RFC 1918 + RFC 4193/4291) are present.
 
-            chain output {{
-                type filter hook output priority filter; policy accept;
-                oifname "lo" accept
-                ct state established,related accept
-                udp dport 53 {dns_af} daddr {dns} accept
-                tcp dport 53 {dns_af} daddr {dns} accept{infra_block}\
-        {deny_rules}
-        {bypass_log}{private_block}
-            }}
-
-{_INPUT_CHAIN}
-        }}
-    """)
-
-
-def block_ruleset() -> str:
-    """Generate a total-blackout nftables ruleset for panic scenarios.
-
-    Drops all traffic except loopback and established connections.
-    No DNS, no allowlists, no gateway ports.  Forensic logging only.
-    """
-    blocked_log = f'        log group {NFLOG_GROUP} prefix "{BLOCKED_LOG_PREFIX}: " drop'
-    return textwrap.dedent(f"""\
-        table {NFT_TABLE} {{
-            chain output {{
-                type filter hook output priority filter; policy drop;
-                oifname "lo" accept
-                ct state established,related accept
-        {blocked_log}
-            }}
-
-            chain input {{
-                type filter hook input priority filter; policy drop;
-                iifname "lo" accept
-                ct state established,related accept
-                drop
-            }}
-        }}
-    """)
-
-
-def verify_block_ruleset(nft_output: str) -> list[str]:
-    """Check applied block ruleset invariants.  Returns errors (empty = OK).
-
-    Verifies:
-    - Both chains present with policy drop
-    - Blocked log prefix present
-    - No allow sets (total blackout means no allowlists)
-    """
-    errors: list[str] = []
-    if "policy drop" not in nft_output:
-        errors.append("policy is not drop")
-    for chain in ("output", "input"):
-        if f"chain {chain}" not in nft_output:
-            errors.append(f"{chain} chain missing")
-    if BLOCKED_LOG_PREFIX not in nft_output:
-        errors.append("blocked nflog prefix missing")
-    if "allow_v4" in nft_output:
-        errors.append("allow_v4 set present in block mode")
-    if "allow_v6" in nft_output:
-        errors.append("allow_v6 set present in block mode")
-    return errors
-
-
-def _set_declaration(name: str, family: str, set_timeout: str = "") -> str:
-    """Generate an nft set declaration with optional timeout.
-
-    Args:
-        name: Set name (e.g. ``allow_v4``).
-        family: Address type (``ipv4_addr`` or ``ipv6_addr``).
-        set_timeout: Element timeout (e.g. ``30m``).  When set, adds
-            ``timeout`` flag so elements auto-expire.
-    """
-    if set_timeout:
-        return f"set {name} {{ type {family}; flags interval, timeout; timeout {set_timeout}; }}"
-    return f"set {name} {{ type {family}; flags interval; }}"
+        Uses a regex to match reject rule context (``ip[6] daddr <net> ... reject``)
+        rather than bare CIDR presence, so set elements don't produce false passes.
+        Auto-detects address family from the CIDR.
+        """
+        errors: list[str] = []
+        for net in PRIVATE_RANGES:
+            selector = "ip" if _is_v4(net) else "ip6"
+            pattern = rf"{selector} daddr {re.escape(net)}.*reject"
+            if not re.search(pattern, nft_output):
+                errors.append(f"Private-range reject rule for {net} missing")
+        return errors
 
 
 # ── Set operations ──────────────────────────────────────
@@ -474,183 +569,6 @@ def delete_elements(set_name: str, ips: list[str], table: str = NFT_TABLE) -> st
         return ""
     elements = ", ".join(valid)
     return f"delete element {table} {set_name} {{ {elements} }}\n"
-
-
-# ── Verification ────────────────────────────────────────
-
-
-def verify_ruleset(nft_output: str) -> list[str]:
-    """Check applied ruleset invariants.  Returns errors (empty = OK).
-
-    Verifies:
-    - Default policy is drop
-    - Both output and input chains exist
-    - Reject type is present
-    - Dual-stack allow sets are declared
-    - Dual-stack deny sets are declared
-    - All private ranges are present (RFC 1918 + RFC 4193/4291)
-    - Terminal deny-all rule with BLOCKED prefix present
-    """
-    errors: list[str] = []
-    if "policy drop" not in nft_output:
-        errors.append("policy is not drop")
-    for chain in ("output", "input"):
-        if f"chain {chain}" not in nft_output:
-            errors.append(f"{chain} chain missing")
-    if "admin-prohibited" not in nft_output:
-        errors.append("reject type missing")
-    if "allow_v4" not in nft_output:
-        errors.append("allow_v4 set missing")
-    if "allow_v6" not in nft_output:
-        errors.append("allow_v6 set missing")
-    if "deny_v4" not in nft_output:
-        errors.append("deny_v4 set missing")
-    if "deny_v6" not in nft_output:
-        errors.append("deny_v6 set missing")
-    # Verify the terminal deny-all rule — a standalone log+reject with the
-    # BLOCKED prefix (no daddr selector, unlike deny-set rules).
-    _terminal_deny_re = re.compile(
-        rf'^\s*log\s+.*prefix\s+"{re.escape(BLOCKED_LOG_PREFIX)}',
-        re.MULTILINE,
-    )
-    if not _terminal_deny_re.search(nft_output):
-        errors.append("terminal deny-all rule missing")
-    errors.extend(_verify_private_blocks(nft_output))
-    return errors
-
-
-def verify_bypass_ruleset(nft_output: str, *, allow_all: bool = False) -> list[str]:
-    """Check applied bypass ruleset invariants.  Returns errors (empty = OK).
-
-    Verifies:
-    - Output chain has policy accept
-    - Input chain has policy drop
-    - Bypass nflog prefix is present
-    - Dual-stack allow sets are declared
-    - Private-range reject rules present (unless *allow_all*)
-    """
-    errors: list[str] = []
-    if "policy accept" not in nft_output:
-        errors.append("output policy is not accept")
-    if "policy drop" not in nft_output:
-        errors.append("input policy is not drop")
-    for chain in ("output", "input"):
-        if f"chain {chain}" not in nft_output:
-            errors.append(f"{chain} chain missing")
-    if BYPASS_LOG_PREFIX not in nft_output:
-        errors.append("bypass nflog prefix missing")
-    for sname in ("allow_v4", "allow_v6", "deny_v4", "deny_v6"):
-        if sname not in nft_output:
-            errors.append(f"{sname} set missing")
-    if not allow_all:
-        errors.extend(_verify_private_blocks(nft_output))
-    return errors
-
-
-def _verify_private_blocks(nft_output: str) -> list[str]:
-    """Check private-range reject rules (RFC 1918 + RFC 4193/4291) are present.
-
-    Uses a regex to match reject rule context (``ip[6] daddr <net> ... reject``)
-    rather than bare CIDR presence, so set elements don't produce false passes.
-    Auto-detects address family from the CIDR.
-    """
-    errors: list[str] = []
-    for net in PRIVATE_RANGES:
-        selector = "ip" if _is_v4(net) else "ip6"
-        pattern = rf"{selector} daddr {re.escape(net)}.*reject"
-        if not re.search(pattern, nft_output):
-            errors.append(f"Private-range reject rule for {net} missing")
-    return errors
-
-
-# ── Rule fragment generators ────────────────────────────
-
-
-def _audit_allow_rules() -> str:
-    """Generate audit rules for allowed traffic (IPv4 + IPv6).
-
-    No rate limit -- only new connections reach these rules because
-    ``ct state established,related accept`` is earlier in the chain.
-    """
-    return (
-        f'        ip daddr @allow_v4 log group {NFLOG_GROUP} prefix "{ALLOWED_LOG_PREFIX}: " counter accept\n'
-        f'        ip6 daddr @allow_v6 log group {NFLOG_GROUP} prefix "{ALLOWED_LOG_PREFIX}: " counter accept'
-    )
-
-
-def _terminal_deny_rule() -> str:
-    """Generate the terminal default-deny rule with NFLOG audit.
-
-    Unclassified packets (not in any allow or deny set) are rejected and
-    logged with the ``BLOCKED`` prefix.  NFLOG is fire-and-forget: if a
-    clearance handler subscribes it can prompt the operator; otherwise
-    events are silently dropped by the kernel.
-
-    Uses ``icmpx`` for cross-family reject in ``inet`` tables —
-    auto-selects ICMP (IPv4) or ICMPv6 (IPv6).
-    """
-    return (
-        f'        log group {NFLOG_GROUP} prefix "{BLOCKED_LOG_PREFIX}: " '
-        f"counter reject with icmpx admin-prohibited"
-    )
-
-
-def _deny_set_rules() -> str:
-    """Generate deny-set match rules (IPv4 + IPv6).
-
-    Packets matching the deny sets are immediately rejected with an ICMP error.
-    Placed after allow-set rules, before private-range reject.
-    """
-    return (
-        f'        ip daddr @deny_v4 log group {NFLOG_GROUP} prefix "{DENIED_LOG_PREFIX}: " counter reject with icmpx admin-prohibited\n'
-        f'        ip6 daddr @deny_v6 log group {NFLOG_GROUP} prefix "{DENIED_LOG_PREFIX}: " counter reject with icmpx admin-prohibited'
-    )
-
-
-def _private_range_rules() -> str:
-    """Generate private-range reject rules (RFC 1918 + RFC 4193/4291).
-
-    Auto-detects address family for the ``daddr`` selector and uses
-    cross-family ``icmpx`` reject for all ranges.
-    """
-    return "\n".join(
-        f"        {'ip' if _is_v4(net) else 'ip6'} daddr {net}"
-        f' log group {NFLOG_GROUP} prefix "{PRIVATE_LOG_PREFIX}: " reject with icmpx admin-prohibited'
-        for net in PRIVATE_RANGES
-    )
-
-
-def _loopback_port_rules(ports: tuple[int, ...]) -> str:
-    """Generate nft accept rules for host-loopback-proxy ports.
-
-    Traffic to ``PASTA_HOST_LOOPBACK_MAP`` (169.254.1.2) goes via pasta's
-    virtual interface, not ``lo``.  pasta's ``--map-host-loopback`` translates
-    this address to ``127.0.0.1`` on the host, enabling container→host
-    loopback access without the pasta 2.x "two loopbacks" splice bug.
-    These rules are placed before the private-range reject block so that
-    link-local traffic to 169.254.1.2 is accepted for the allowed ports.
-    """
-    return "\n".join(
-        f"            tcp dport {p} ip daddr {PASTA_HOST_LOOPBACK_MAP} accept" for p in ports
-    )
-
-
-def _gateway_port_rules(ports: tuple[int, ...], gateway_v4: str = "", gateway_v6: str = "") -> str:
-    """Generate nft accept rules for gateway (slirp4netns) host-service ports.
-
-    Uses literal gateway IPs baked into the ruleset at generation time —
-    no dynamic sets or runtime discovery needed.  Placed before the
-    private-range reject block so RFC 1918 traffic to the gateway is accepted.
-    """
-    if not ports or not (gateway_v4 or gateway_v6):
-        return ""
-    lines = []
-    for p in ports:
-        if gateway_v4:
-            lines.append(f"        tcp dport {p} ip daddr {safe_ip(gateway_v4)} accept")
-        if gateway_v6:
-            lines.append(f"        tcp dport {p} ip6 daddr {safe_ip(gateway_v6)} accept")
-    return "\n".join(lines)
 
 
 # ── Validation ──────────────────────────────────────────

--- a/tests/integration/allow_deny/test_elements.py
+++ b/tests/integration/allow_deny/test_elements.py
@@ -5,7 +5,7 @@
 
 import pytest
 
-from terok_shield.nft.rules import add_elements, hook_ruleset
+from terok_shield.nft.rules import RulesetBuilder, add_elements
 from tests.testnet import ALLOWED_TARGET_IPS, GOOGLE_DNS_IP, QUAD9_DNS_IP, TEST_IP1
 
 from ..conftest import nft_missing, nsenter_nft, podman_missing
@@ -21,7 +21,7 @@ class TestAddElementsLive:
 
     def test_elements_appear_in_set(self, container: str, container_pid: str) -> None:
         """IPs added via add_elements appear in 'nft list set'."""
-        r = nsenter_nft(container_pid, stdin=hook_ruleset())
+        r = nsenter_nft(container_pid, stdin=RulesetBuilder().build_hook())
         assert r.returncode == 0, f"Ruleset apply failed: {r.stderr}"
         r = nsenter_nft(container_pid, stdin=add_elements("allow_v4", [TEST_IP1]))
         assert r.returncode == 0, f"Add elements failed: {r.stderr}"
@@ -33,7 +33,7 @@ class TestAddElementsLive:
     def test_multiple_elements(self, container: str, container_pid: str) -> None:
         """Multiple IPs can be added to the set."""
         ips = [*ALLOWED_TARGET_IPS, GOOGLE_DNS_IP, QUAD9_DNS_IP]
-        r = nsenter_nft(container_pid, stdin=hook_ruleset())
+        r = nsenter_nft(container_pid, stdin=RulesetBuilder().build_hook())
         assert r.returncode == 0, f"Ruleset apply failed: {r.stderr}"
         r = nsenter_nft(container_pid, stdin=add_elements("allow_v4", ips))
         assert r.returncode == 0, f"Add elements failed: {r.stderr}"

--- a/tests/integration/allow_deny/test_traffic.py
+++ b/tests/integration/allow_deny/test_traffic.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import pytest
 
 from terok_shield import Shield, ShieldConfig
-from terok_shield.nft.rules import add_elements, hook_ruleset
+from terok_shield.nft.rules import RulesetBuilder, add_elements
 from tests.testnet import (
     ALLOWED_TARGET_HTTP,
     ALLOWED_TARGET_HTTPS,
@@ -34,7 +34,7 @@ class TestFirewallAllowing:
 
     def test_allowed_ip_reachable_http(self, container: str, container_pid: str) -> None:
         """HTTP traffic to an allowed IP is permitted."""
-        r = nsenter_nft(container_pid, stdin=hook_ruleset())
+        r = nsenter_nft(container_pid, stdin=RulesetBuilder().build_hook())
         assert r.returncode == 0, f"Ruleset apply failed: {r.stderr}"
         r = nsenter_nft(container_pid, stdin=add_elements("allow_v4", ALLOWED_TARGET_IPS))
         assert r.returncode == 0, f"Add elements failed: {r.stderr}"
@@ -44,7 +44,7 @@ class TestFirewallAllowing:
 
     def test_allowed_ip_reachable_https(self, container: str, container_pid: str) -> None:
         """HTTPS traffic to an allowed IP is permitted."""
-        r = nsenter_nft(container_pid, stdin=hook_ruleset())
+        r = nsenter_nft(container_pid, stdin=RulesetBuilder().build_hook())
         assert r.returncode == 0, f"Ruleset apply failed: {r.stderr}"
         r = nsenter_nft(container_pid, stdin=add_elements("allow_v4", ALLOWED_TARGET_IPS))
         assert r.returncode == 0, f"Add elements failed: {r.stderr}"
@@ -54,7 +54,7 @@ class TestFirewallAllowing:
 
     def test_non_allowed_ip_still_blocked(self, container: str, container_pid: str) -> None:
         """IPs not in the allow set remain blocked after adding others."""
-        r = nsenter_nft(container_pid, stdin=hook_ruleset())
+        r = nsenter_nft(container_pid, stdin=RulesetBuilder().build_hook())
         assert r.returncode == 0, f"Ruleset apply failed: {r.stderr}"
         r = nsenter_nft(container_pid, stdin=add_elements("allow_v4", ALLOWED_TARGET_IPS))
         assert r.returncode == 0, f"Add elements failed: {r.stderr}"
@@ -64,7 +64,7 @@ class TestFirewallAllowing:
 
     def test_allow_then_block_different_targets(self, container: str, container_pid: str) -> None:
         """One IP allowed, another blocked — in the same container."""
-        r = nsenter_nft(container_pid, stdin=hook_ruleset())
+        r = nsenter_nft(container_pid, stdin=RulesetBuilder().build_hook())
         assert r.returncode == 0, f"Ruleset apply failed: {r.stderr}"
         r = nsenter_nft(container_pid, stdin=add_elements("allow_v4", ALLOWED_TARGET_IPS))
         assert r.returncode == 0, f"Add elements failed: {r.stderr}"
@@ -90,7 +90,7 @@ class TestRFC1918Allow:
         """RFC1918 addresses in the allow set bypass the RFC1918 reject rules."""
         from terok_shield.nft.constants import RFC1918
 
-        nsenter_nft(container_pid, stdin=hook_ruleset())
+        nsenter_nft(container_pid, stdin=RulesetBuilder().build_hook())
         nsenter_nft(container_pid, stdin=add_elements("allow_v4", [RFC1918_HOST]))
 
         # Structural: allow set evaluates before RFC1918 reject

--- a/tests/integration/blocking/test_default_deny.py
+++ b/tests/integration/blocking/test_default_deny.py
@@ -18,7 +18,7 @@ import time
 import pytest
 
 from terok_shield.nft.constants import IPV6_PRIVATE, RFC1918
-from terok_shield.nft.rules import hook_ruleset
+from terok_shield.nft.rules import RulesetBuilder
 from tests.testnet import (
     ALLOWED_TARGET_HTTP,
     ALLOWED_TARGET_HTTPS,
@@ -76,7 +76,7 @@ class TestFirewallBlocking:
         """Outbound HTTP to an external IP is rejected after applying the ruleset."""
         _preflight_wget(container, ALLOWED_TARGET_HTTP)
 
-        r = nsenter_nft(container_pid, stdin=hook_ruleset())
+        r = nsenter_nft(container_pid, stdin=RulesetBuilder().build_hook())
         assert r.returncode == 0, f"Ruleset apply failed: {r.stderr}"
 
         post = _wget(container, ALLOWED_TARGET_HTTP, timeout=10)
@@ -86,7 +86,7 @@ class TestFirewallBlocking:
         """Outbound HTTPS is rejected after applying the ruleset."""
         _preflight_wget(container, ALLOWED_TARGET_HTTPS)
 
-        r = nsenter_nft(container_pid, stdin=hook_ruleset())
+        r = nsenter_nft(container_pid, stdin=RulesetBuilder().build_hook())
         assert r.returncode == 0, f"Ruleset apply failed: {r.stderr}"
 
         post = _wget(container, ALLOWED_TARGET_HTTPS, timeout=10)
@@ -103,7 +103,7 @@ class TestFirewallBlocking:
         """
         _preflight_tcp(container, BLOCKED_TARGET_IP, BLOCKED_TARGET_DNS_PORT)
 
-        r = nsenter_nft(container_pid, stdin=hook_ruleset())
+        r = nsenter_nft(container_pid, stdin=RulesetBuilder().build_hook())
         assert r.returncode == 0, f"Ruleset apply failed: {r.stderr}"
 
         wget_timeout = 10
@@ -121,7 +121,7 @@ class TestFirewallBlocking:
         self, container: str, container_pid: str
     ) -> None:
         """RFC1918 addresses are rejected when not in the allow set."""
-        nsenter_nft(container_pid, stdin=hook_ruleset())
+        nsenter_nft(container_pid, stdin=RulesetBuilder().build_hook())
 
         # Structural: all RFC1918 reject rules present
         listed = nsenter_nft(container_pid, "list", "ruleset")
@@ -148,7 +148,7 @@ class TestFirewallBlockingIPv6:
 
     def test_ipv6_ruleset_has_dual_stack_sets(self, container: str, container_pid: str) -> None:
         """Applied ruleset contains allow_v6 set and IPv6 private reject rules."""
-        nsenter_nft(container_pid, stdin=hook_ruleset())
+        nsenter_nft(container_pid, stdin=RulesetBuilder().build_hook())
         listed = nsenter_nft(container_pid, "list", "ruleset")
         assert listed.returncode == 0, listed.stderr
         output = listed.stdout
@@ -160,7 +160,7 @@ class TestFirewallBlockingIPv6:
         """ICMPv6 ping to non-allowed IPv6 addresses is blocked."""
         _skip_unless_ipv6(container)
 
-        nsenter_nft(container_pid, stdin=hook_ruleset())
+        nsenter_nft(container_pid, stdin=RulesetBuilder().build_hook())
 
         for ip, label in [(IPV6_CLOUDFLARE, "Cloudflare"), (IPV6_GOOGLE, "Google")]:
             r = _exec(container, "ping", "-6", "-c1", "-W2", ip, timeout=5)
@@ -174,7 +174,7 @@ class TestFirewallBlockingIPv6:
         if pre.returncode != 0:
             pytest.skip("IPv6 DNS (port 53) not reachable pre-firewall")
 
-        nsenter_nft(container_pid, stdin=hook_ruleset())
+        nsenter_nft(container_pid, stdin=RulesetBuilder().build_hook())
 
         post = _exec(container, "nc", "-z", "-w", "3", IPV6_CLOUDFLARE, "53", timeout=8)
         assert post.returncode != 0, "IPv6 DNS (port 53) should be blocked"
@@ -187,7 +187,7 @@ class TestFirewallBlockingIPv6:
         if pre.returncode != 0:
             pytest.skip("IPv6 HTTP not reachable pre-firewall")
 
-        nsenter_nft(container_pid, stdin=hook_ruleset())
+        nsenter_nft(container_pid, stdin=RulesetBuilder().build_hook())
 
         post = _wget(container, IPV6_HTTP_URL, timeout=5)
         assert post.returncode != 0, "HTTP over IPv6 should be blocked"
@@ -200,7 +200,7 @@ class TestFirewallBlockingIPv6:
         if pre.returncode != 0:
             pytest.skip("IPv6 HTTPS (port 443) not reachable pre-firewall")
 
-        nsenter_nft(container_pid, stdin=hook_ruleset())
+        nsenter_nft(container_pid, stdin=RulesetBuilder().build_hook())
 
         post = _exec(container, "nc", "-z", "-w", "3", IPV6_CLOUDFLARE, "443", timeout=8)
         assert post.returncode != 0, "IPv6 HTTPS (port 443) should be blocked"

--- a/tests/integration/blocking/test_probe.py
+++ b/tests/integration/blocking/test_probe.py
@@ -10,7 +10,7 @@ import unittest
 
 import pytest
 
-from terok_shield.nft.rules import hook_ruleset
+from terok_shield.nft.rules import RulesetBuilder
 from terok_shield.resources.shield_probe import probe
 from tests.testnet import ALLOWED_TARGET_IPS, BLOCKED_TARGET_IP
 
@@ -78,7 +78,7 @@ class TestShieldProbe:
             text=True,
             timeout=10,
         ).stdout.strip()
-        r = nsenter_nft(pid, stdin=hook_ruleset())
+        r = nsenter_nft(pid, stdin=RulesetBuilder().build_hook())
         assert r.returncode == 0, f"Ruleset apply failed: {r.stderr}"
 
         result = self._run_probe(probe_container, BLOCKED_TARGET_IP)

--- a/tests/integration/launch/test_nft_apply.py
+++ b/tests/integration/launch/test_nft_apply.py
@@ -7,14 +7,14 @@ import subprocess
 
 import pytest
 
-from terok_shield.nft.rules import hook_ruleset, verify_ruleset
+from terok_shield.nft.rules import RulesetBuilder
 
 from ..conftest import nsenter_nft
 
 
 def _apply(pid: str) -> None:
     """Apply hook ruleset and assert success."""
-    result = nsenter_nft(pid, stdin=hook_ruleset())
+    result = nsenter_nft(pid, stdin=RulesetBuilder().build_hook())
     assert result.returncode == 0, f"nft apply failed: {result.stderr}"
 
 
@@ -40,7 +40,7 @@ class TestHookApply:
         """Apply hook ruleset and run verify_ruleset against the output."""
         _apply(container_pid)
         listed = _list(container_pid)
-        errors = verify_ruleset(listed.stdout)
+        errors = RulesetBuilder().verify_hook(listed.stdout)
         assert errors == [], f"Verification errors: {errors}"
 
     def test_policy_drop_enforced(self, container_pid: str) -> None:

--- a/tests/unit/test_hook_mode_class.py
+++ b/tests/unit/test_hook_mode_class.py
@@ -21,7 +21,7 @@ from terok_shield.config import (
 from terok_shield.hooks.install import install_hooks
 from terok_shield.hooks.mode import HookMode
 from terok_shield.nft.constants import PASTA_HOST_LOOPBACK_MAP
-from terok_shield.nft.rules import bypass_ruleset, hook_ruleset
+from terok_shield.nft.rules import RulesetBuilder
 from terok_shield.run import ExecError
 
 from ..testfs import BIN_DIR_NAME, HOOK_ENTRYPOINT_NAME, HOOKS_DIR_NAME
@@ -454,8 +454,8 @@ def test_shield_up_reapplies_hook_ruleset(
     ("nft_output", "verify_bypass", "verify_hook", "expected"),
     [
         pytest.param("", None, None, ShieldState.INACTIVE, id="inactive"),
-        pytest.param(hook_ruleset(), ["not bypass"], [], ShieldState.UP, id="up"),
-        pytest.param(bypass_ruleset(), [], None, ShieldState.DOWN, id="down"),
+        pytest.param(RulesetBuilder().build_hook(), ["not bypass"], [], ShieldState.UP, id="up"),
+        pytest.param(RulesetBuilder().build_bypass(), [], None, ShieldState.DOWN, id="down"),
         pytest.param(
             "random nft stuff", ["not bypass"], ["not hook"], ShieldState.ERROR, id="error"
         ),

--- a/tests/unit/test_nft.py
+++ b/tests/unit/test_nft.py
@@ -9,8 +9,6 @@ the asserted invariant clearer; they should never hide rule ordering,
 allow-vs-deny semantics, or input-validation guarantees.
 """
 
-from collections.abc import Callable
-
 import pytest
 
 from terok_shield.nft.constants import (
@@ -29,14 +27,8 @@ from terok_shield.nft.rules import (
     add_deny_elements_dual,
     add_elements,
     add_elements_dual,
-    block_ruleset,
-    bypass_ruleset,
     delete_deny_elements_dual,
-    hook_ruleset,
     safe_ip,
-    verify_block_ruleset,
-    verify_bypass_ruleset,
-    verify_ruleset,
 )
 
 from ..testnet import (
@@ -137,7 +129,7 @@ def test_is_v4_returns_false_for_garbage() -> None:
     assert _is_v4("not-an-ip") is False
 
 
-# ── hook_ruleset() ----------------------------------------------------
+# ── build_hook() ------------------------------------------------------
 
 
 @pytest.mark.parametrize(
@@ -158,19 +150,19 @@ def test_is_v4_returns_false_for_garbage() -> None:
 )
 def test_hook_ruleset_contains_required_fragments(fragment: str) -> None:
     """The enforcing ruleset contains the expected top-level invariants."""
-    assert fragment in hook_ruleset()
+    assert fragment in RulesetBuilder().build_hook()
 
 
 def test_hook_ruleset_blocks_all_private_ranges() -> None:
     """Every RFC1918 and IPv6 private/link-local range must be rejected in enforce mode."""
-    rs = hook_ruleset()
+    rs = RulesetBuilder().build_hook()
     for net in PRIVATE_RANGES:
         assert net in rs, f"Private range {net!r} missing from hook ruleset"
 
 
 def test_hook_ruleset_accepts_dns_to_the_configured_forwarder() -> None:
     """Only the configured DNS forwarder is granted the DNS exception."""
-    ruleset = hook_ruleset(dns=LINK_LOCAL_DNS)
+    ruleset = RulesetBuilder(dns=LINK_LOCAL_DNS).build_hook()
     assert _dns_accept_rules(ruleset) == {
         f"udp dport 53 ip daddr {LINK_LOCAL_DNS} accept",
         f"tcp dport 53 ip daddr {LINK_LOCAL_DNS} accept",
@@ -179,7 +171,9 @@ def test_hook_ruleset_accepts_dns_to_the_configured_forwarder() -> None:
 
 def test_hook_ruleset_default_tcp_rules_are_dns_only() -> None:
     """Without loopback ports, TCP port rules must be limited to DNS."""
-    tcp_rules = [line.strip() for line in hook_ruleset().splitlines() if "tcp dport" in line]
+    tcp_rules = [
+        line.strip() for line in RulesetBuilder().build_hook().splitlines() if "tcp dport" in line
+    ]
     assert tcp_rules
     assert all(line.startswith("tcp dport 53 ") for line in tcp_rules)
 
@@ -207,7 +201,7 @@ def test_hook_ruleset_emits_one_rule_per_loopback_port(
     expected_rules: list[str],
 ) -> None:
     """Each configured loopback port gets its own accept rule before private-range reject."""
-    ruleset = hook_ruleset(loopback_ports=ports)
+    ruleset = RulesetBuilder(loopback_ports=ports).build_hook()
     for rule in expected_rules:
         assert rule in ruleset
         # Loopback port rules must fire before the 169.254.0.0/16 private-range reject
@@ -216,13 +210,13 @@ def test_hook_ruleset_emits_one_rule_per_loopback_port(
 
 def test_hook_ruleset_places_allow_sets_before_private_range_rejects() -> None:
     """Allow-set accepts must precede the private-range reject rules."""
-    ruleset = hook_ruleset()
+    ruleset = RulesetBuilder().build_hook()
     assert ruleset.index("@allow_v4") < ruleset.index(RFC1918[0])
 
 
 def test_hook_ruleset_places_deny_sets_between_allow_and_private() -> None:
     """Deny-set reject rules appear after allow-set accepts and before private-range rejects."""
-    ruleset = hook_ruleset()
+    ruleset = RulesetBuilder().build_hook()
     allow_pos = ruleset.index("@allow_v4")
     deny_pos = ruleset.index("@deny_v4")
     private_pos = ruleset.index(RFC1918[0])
@@ -234,13 +228,13 @@ def test_hook_ruleset_places_deny_sets_between_allow_and_private() -> None:
 
 def test_hook_ruleset_uses_blocked_prefix() -> None:
     """Terminal deny rule uses the BLOCKED prefix for unclassified connections."""
-    ruleset = hook_ruleset()
+    ruleset = RulesetBuilder().build_hook()
     assert _BLOCKED_LOG_PREFIX in ruleset
 
 
 def test_hook_ruleset_terminal_rule_is_standalone_log_reject() -> None:
     """Terminal deny rule is a standalone log+reject (no daddr selector)."""
-    lines = hook_ruleset().splitlines()
+    lines = RulesetBuilder().build_hook().splitlines()
     terminal = [
         ln.strip()
         for ln in lines
@@ -251,7 +245,7 @@ def test_hook_ruleset_terminal_rule_is_standalone_log_reject() -> None:
 
 def test_hook_ruleset_deny_sets_use_denied_prefix() -> None:
     """Deny set rules use the DENIED prefix (not BLOCKED)."""
-    ruleset = hook_ruleset()
+    ruleset = RulesetBuilder().build_hook()
     assert "@deny_v4" in ruleset, "deny_v4 set rule missing from ruleset"
     assert "@deny_v6" in ruleset, "deny_v6 set rule missing from ruleset"
     # Deny set rules have a daddr selector + DENIED prefix
@@ -262,7 +256,7 @@ def test_hook_ruleset_deny_sets_use_denied_prefix() -> None:
 
 def test_hook_ruleset_has_no_queued_prefix() -> None:
     """Hook ruleset must not contain the legacy QUEUED log prefix."""
-    assert "QUEUED" not in hook_ruleset()
+    assert "QUEUED" not in RulesetBuilder().build_hook()
 
 
 def test_verify_ruleset_checks_deny_sets() -> None:
@@ -273,39 +267,31 @@ def test_verify_ruleset_checks_deny_sets() -> None:
         f"allow_v4 allow_v6 {_OUTPUT_CHAIN} {_INPUT_CHAIN}\n"
         f"{_private_reject_rules()}"
     )
-    errors = verify_ruleset(minimal)
+    errors = RulesetBuilder().verify_hook(minimal)
     assert "deny_v4 set missing" in errors
     assert "deny_v6 set missing" in errors
 
 
-@pytest.mark.parametrize(
-    "builder",
-    [pytest.param(hook_ruleset, id="hook"), pytest.param(bypass_ruleset, id="bypass")],
-)
-def test_ruleset_builders_reject_invalid_dns(builder: Callable[..., str]) -> None:
-    """Both ruleset builders reject non-IP DNS values before interpolation."""
+def test_ruleset_builder_rejects_invalid_dns() -> None:
+    """RulesetBuilder rejects non-IP DNS values before interpolation."""
     with pytest.raises(ValueError):
-        builder(dns="not-an-ip")
+        RulesetBuilder(dns="not-an-ip")
 
 
 @pytest.mark.parametrize(
-    ("builder", "ports"),
+    "ports",
     [
-        pytest.param(hook_ruleset, (0,), id="hook-port-too-low"),
-        pytest.param(hook_ruleset, (99999,), id="hook-port-too-high"),
-        pytest.param(hook_ruleset, (True,), id="hook-bool-port"),
-        pytest.param(bypass_ruleset, (0,), id="bypass-port-too-low"),
-        pytest.param(bypass_ruleset, (99999,), id="bypass-port-too-high"),
-        pytest.param(bypass_ruleset, (True,), id="bypass-bool-port"),
+        pytest.param((0,), id="port-too-low"),
+        pytest.param((99999,), id="port-too-high"),
+        pytest.param((True,), id="bool-port"),
     ],
 )
-def test_ruleset_builders_reject_invalid_loopback_ports(
-    builder: Callable[..., str],
+def test_ruleset_builder_rejects_invalid_loopback_ports(
     ports: tuple[int, ...],
 ) -> None:
-    """Both ruleset builders reject out-of-range and boolean loopback ports."""
+    """RulesetBuilder rejects out-of-range and boolean loopback ports."""
     with pytest.raises(ValueError):
-        builder(loopback_ports=ports)
+        RulesetBuilder(loopback_ports=ports)
 
 
 # ── add_elements() / add_elements_dual() ------------------------------
@@ -494,12 +480,14 @@ def test_delete_deny_elements_dual_returns_empty_when_no_valid_ips(ips: list[str
     assert delete_deny_elements_dual(ips) == ""
 
 
-# ── verify_ruleset() --------------------------------------------------
+# ── verify_hook() -----------------------------------------------------
+
+_builder = RulesetBuilder()
 
 
-def test_verify_ruleset_accepts_the_generated_hook_ruleset() -> None:
-    """verify_ruleset() accepts the enforcing ruleset generated by nft.py."""
-    assert verify_ruleset(hook_ruleset()) == []
+def test_verify_hook_accepts_the_generated_hook_ruleset() -> None:
+    """verify_hook() accepts the enforcing ruleset generated by RulesetBuilder."""
+    assert _builder.verify_hook(_builder.build_hook()) == []
 
 
 @pytest.mark.parametrize(
@@ -532,26 +520,26 @@ def test_verify_ruleset_accepts_the_generated_hook_ruleset() -> None:
         ),
     ],
 )
-def test_verify_ruleset_reports_missing_top_level_invariants(
+def test_verify_hook_reports_missing_top_level_invariants(
     nft_output: str,
     expected_error: str,
 ) -> None:
-    """verify_ruleset() names the missing high-level enforce-mode invariant."""
-    assert expected_error in verify_ruleset(nft_output)
+    """verify_hook() names the missing high-level enforce-mode invariant."""
+    assert expected_error in _builder.verify_hook(nft_output)
 
 
-def test_verify_ruleset_reports_each_missing_private_range_rule() -> None:
+def test_verify_hook_reports_each_missing_private_range_rule() -> None:
     """Every missing private-range reject rule should produce its own error."""
-    errors = verify_ruleset(
+    errors = _builder.verify_hook(
         f"policy drop {_ADMIN_PROHIBITED} {_DENY_LOG_PREFIX} allow_v4 allow_v6 {_OUTPUT_CHAIN} {_INPUT_CHAIN}"
     )
     range_errors = [error for error in errors if "Private-range" in error]
     assert len(range_errors) == len(PRIVATE_RANGES)
 
 
-def test_verify_ruleset_reports_missing_ipv6_private_ranges_independently() -> None:
+def test_verify_hook_reports_missing_ipv6_private_ranges_independently() -> None:
     """Missing IPv6 private-range rejects are reported separately from IPv4 ones."""
-    errors = verify_ruleset(
+    errors = _builder.verify_hook(
         "chain output { type filter hook output priority filter; policy drop;\n"
         "chain input { policy drop;\n"
         f"{_DENY_LOG_PREFIX} {_ADMIN_PROHIBITED} allow_v4 allow_v6\n{_private_reject_rules(RFC1918)}\n@allow_v4 }}"
@@ -560,46 +548,46 @@ def test_verify_ruleset_reports_missing_ipv6_private_ranges_independently() -> N
     assert len(ipv6_errors) == len(IPV6_PRIVATE)
 
 
-def test_verify_ruleset_rejects_a_bypass_ruleset() -> None:
+def test_verify_hook_rejects_a_bypass_ruleset() -> None:
     """Bypass mode must not satisfy enforce-mode verification."""
-    errors = verify_ruleset(bypass_ruleset())
+    errors = _builder.verify_hook(_builder.build_bypass())
     assert errors
     assert any("terminal deny-all rule" in error for error in errors)
 
 
-def test_verify_ruleset_accepts_prefix_before_group_ordering() -> None:
-    """verify_ruleset() handles nft output where prefix appears before group.
+def test_verify_hook_accepts_prefix_before_group_ordering() -> None:
+    """verify_hook() handles nft output where prefix appears before group.
 
     Newer nft versions reorder log statement attributes: ``log prefix "..." group N``
     instead of ``log group N prefix "..."``.  The terminal deny-all check must
     accept both orderings.
     """
-    ruleset = hook_ruleset()
+    ruleset = _builder.build_hook()
     # Simulate newer nft output ordering: swap group/prefix in log lines
     reordered = ruleset.replace(
         f'log group 100 prefix "{_DENY_LOG_PREFIX}',
         f'log prefix "{_DENY_LOG_PREFIX}: " group 100',
     )
     assert reordered != ruleset  # sanity: replacement happened
-    assert verify_ruleset(reordered) == []
+    assert _builder.verify_hook(reordered) == []
 
 
-def test_verify_ruleset_checks_private_ranges_by_rule_not_by_position() -> None:
+def test_verify_hook_checks_private_ranges_by_rule_not_by_position() -> None:
     """Private-range rejects pass verification even if moved after the allow-set match."""
     ruleset = (
         f"policy drop {_ADMIN_PROHIBITED} {_DENY_LOG_PREFIX} @allow_v4 accept allow_v6\n"
         f"{_private_reject_rules()}"
     )
-    range_errors = [error for error in verify_ruleset(ruleset) if "Private-range" in error]
+    range_errors = [error for error in _builder.verify_hook(ruleset) if "Private-range" in error]
     assert range_errors == []
 
 
-def test_verify_ruleset_reports_errors_for_empty_input() -> None:
+def test_verify_hook_reports_errors_for_empty_input() -> None:
     """Empty nft output should fail enforce-mode verification."""
-    assert verify_ruleset("")
+    assert _builder.verify_hook("")
 
 
-# ── bypass_ruleset() --------------------------------------------------
+# ── build_bypass() ----------------------------------------------------
 
 
 @pytest.mark.parametrize(
@@ -615,26 +603,26 @@ def test_verify_ruleset_reports_errors_for_empty_input() -> None:
 )
 def test_bypass_ruleset_contains_required_fragments(fragment: str) -> None:
     """The bypass ruleset preserves the expected top-level invariants."""
-    assert fragment in bypass_ruleset()
+    assert fragment in RulesetBuilder().build_bypass()
 
 
 def test_bypass_ruleset_blocks_all_private_ranges_by_default() -> None:
     """Bypass mode still rejects all private-range traffic unless allow_all=True."""
-    rs = bypass_ruleset()
+    rs = RulesetBuilder().build_bypass()
     for net in PRIVATE_RANGES:
         assert net in rs, f"Private range {net!r} missing from bypass ruleset"
 
 
 def test_bypass_ruleset_allow_all_removes_all_private_range_rejects() -> None:
     """allow_all=True removes every RFC1918 and IPv6 private-range reject rule."""
-    rs = bypass_ruleset(allow_all=True)
+    rs = RulesetBuilder().build_bypass(allow_all=True)
     for net in PRIVATE_RANGES:
         assert net not in rs, f"Private range {net!r} should be absent when allow_all=True"
 
 
 def test_bypass_ruleset_includes_deny_sets() -> None:
     """Shield-down ruleset includes deny sets so deny.list is enforced."""
-    rs = bypass_ruleset()
+    rs = RulesetBuilder().build_bypass()
     assert "deny_v4" in rs
     assert "deny_v6" in rs
     assert _DENY_LOG_PREFIX in rs
@@ -642,7 +630,7 @@ def test_bypass_ruleset_includes_deny_sets() -> None:
 
 def test_bypass_ruleset_emits_loopback_port_rules() -> None:
     """Host-loopback-proxy port exceptions survive in bypass mode, before private-range reject."""
-    ruleset = bypass_ruleset(loopback_ports=(9418,))
+    ruleset = RulesetBuilder(loopback_ports=(9418,)).build_bypass()
     accept_rule = f"tcp dport 9418 ip daddr {PASTA_HOST_LOOPBACK_MAP} accept"
     assert accept_rule in ruleset
     assert ruleset.index(accept_rule) < ruleset.index("169.254.0.0/16")
@@ -650,28 +638,26 @@ def test_bypass_ruleset_emits_loopback_port_rules() -> None:
 
 def test_bypass_ruleset_accepts_dns_to_the_configured_forwarder() -> None:
     """Bypass mode retains the explicit DNS exception for the configured forwarder."""
-    ruleset = bypass_ruleset(dns=LINK_LOCAL_DNS)
+    ruleset = RulesetBuilder(dns=LINK_LOCAL_DNS).build_bypass()
     assert _dns_accept_rules(ruleset) == {
         f"udp dport 53 ip daddr {LINK_LOCAL_DNS} accept",
         f"tcp dport 53 ip daddr {LINK_LOCAL_DNS} accept",
     }
 
 
-# ── verify_bypass_ruleset() ------------------------------------------
+# ── verify_bypass() ---------------------------------------------------
 
 
 @pytest.mark.parametrize(
     ("ruleset", "allow_all"),
     [
-        pytest.param(bypass_ruleset(), False, id="default-bypass"),
-        pytest.param(bypass_ruleset(allow_all=True), True, id="allow-all-bypass"),
+        pytest.param(_builder.build_bypass(), False, id="default-bypass"),
+        pytest.param(_builder.build_bypass(allow_all=True), True, id="allow-all-bypass"),
     ],
 )
-def test_verify_bypass_ruleset_accepts_generated_bypass_rulesets(
-    ruleset: str, allow_all: bool
-) -> None:
-    """verify_bypass_ruleset() accepts bypass rulesets produced by nft.py."""
-    assert verify_bypass_ruleset(ruleset, allow_all=allow_all) == []
+def test_verify_bypass_accepts_generated_bypass_rulesets(ruleset: str, allow_all: bool) -> None:
+    """verify_bypass() accepts bypass rulesets produced by RulesetBuilder."""
+    assert _builder.verify_bypass(ruleset, allow_all=allow_all) == []
 
 
 @pytest.mark.parametrize(
@@ -712,26 +698,26 @@ def test_verify_bypass_ruleset_accepts_generated_bypass_rulesets(
         ),
     ],
 )
-def test_verify_bypass_ruleset_reports_missing_top_level_invariants(
+def test_verify_bypass_reports_missing_top_level_invariants(
     nft_output: str,
     expected_error: str,
 ) -> None:
-    """verify_bypass_ruleset() names the missing high-level bypass invariant."""
-    assert expected_error in verify_bypass_ruleset(nft_output)
+    """verify_bypass() names the missing high-level bypass invariant."""
+    assert expected_error in _builder.verify_bypass(nft_output)
 
 
-def test_verify_bypass_ruleset_reports_private_ranges_when_allow_all_is_false() -> None:
+def test_verify_bypass_reports_private_ranges_when_allow_all_is_false() -> None:
     """Private-range reject rules remain mandatory in default bypass mode."""
-    errors = verify_bypass_ruleset(
+    errors = _builder.verify_bypass(
         f"{_OUTPUT_CHAIN} policy accept {_INPUT_CHAIN} policy drop {BYPASS_LOG_PREFIX} allow_v4 allow_v6"
     )
     range_errors = [error for error in errors if "Private-range" in error]
     assert len(range_errors) == len(PRIVATE_RANGES)
 
 
-def test_verify_bypass_ruleset_skips_private_range_checks_in_allow_all_mode() -> None:
+def test_verify_bypass_skips_private_range_checks_in_allow_all_mode() -> None:
     """allow_all=True disables private-range verification in bypass mode."""
-    errors = verify_bypass_ruleset(
+    errors = _builder.verify_bypass(
         f"{_OUTPUT_CHAIN} policy accept {_INPUT_CHAIN} policy drop {BYPASS_LOG_PREFIX} allow_v4 allow_v6",
         allow_all=True,
     )
@@ -739,19 +725,19 @@ def test_verify_bypass_ruleset_skips_private_range_checks_in_allow_all_mode() ->
     assert range_errors == []
 
 
-def test_verify_bypass_ruleset_rejects_an_enforcing_hook_ruleset() -> None:
+def test_verify_bypass_rejects_an_enforcing_hook_ruleset() -> None:
     """Enforce mode must not satisfy bypass-mode verification."""
-    errors = verify_bypass_ruleset(hook_ruleset())
+    errors = _builder.verify_bypass(_builder.build_hook())
     assert errors
     assert any("accept" in error for error in errors)
 
 
-def test_verify_bypass_ruleset_reports_errors_for_empty_input() -> None:
+def test_verify_bypass_reports_errors_for_empty_input() -> None:
     """Empty nft output should fail bypass-mode verification."""
-    assert verify_bypass_ruleset("")
+    assert _builder.verify_bypass("")
 
 
-# ── block_ruleset() ──────────────────────────────────────
+# ── build_block() ─────────────────────────────────────────
 
 
 @pytest.mark.parametrize(
@@ -767,82 +753,82 @@ def test_verify_bypass_ruleset_reports_errors_for_empty_input() -> None:
 )
 def test_block_ruleset_contains_required_fragments(fragment: str) -> None:
     """The block ruleset preserves the expected security invariants."""
-    assert fragment in block_ruleset()
+    assert fragment in RulesetBuilder.build_block()
 
 
 def test_block_ruleset_has_no_allow_sets() -> None:
-    """Block mode must have no allowlists — total blackout."""
-    rs = block_ruleset()
+    """Block mode must have no allowlists -- total blackout."""
+    rs = RulesetBuilder.build_block()
     assert "allow_v4" not in rs
     assert "allow_v6" not in rs
 
 
 def test_block_ruleset_has_no_deny_sets() -> None:
-    """Block mode needs no deny sets — everything is dropped anyway."""
-    rs = block_ruleset()
+    """Block mode needs no deny sets -- everything is dropped anyway."""
+    rs = RulesetBuilder.build_block()
     assert "deny_v4" not in rs
     assert "deny_v6" not in rs
 
 
 def test_block_ruleset_has_no_dns_rules() -> None:
-    """Block mode drops DNS — no external resolution allowed."""
-    rs = block_ruleset()
+    """Block mode drops DNS -- no external resolution allowed."""
+    rs = RulesetBuilder.build_block()
     assert "dport 53" not in rs
 
 
 def test_block_ruleset_has_no_port_accept_rules() -> None:
-    """Block mode allows only loopback + established — no port-specific accepts."""
-    rs = block_ruleset()
+    """Block mode allows only loopback + established -- no port-specific accepts."""
+    rs = RulesetBuilder.build_block()
     assert "tcp dport" not in rs
 
 
 def test_block_ruleset_does_not_include_bypass_or_deny_prefixes() -> None:
     """Block mode uses only the BLOCKED prefix, not BYPASS or DENIED."""
-    rs = block_ruleset()
+    rs = RulesetBuilder.build_block()
     assert _DENY_LOG_PREFIX not in rs
     assert BYPASS_LOG_PREFIX not in rs
 
 
-# ── verify_block_ruleset() ────────────────────────────────
+# ── verify_block() ─────────────────────────────────────────
 
 
-def test_verify_block_ruleset_accepts_generated_block_ruleset() -> None:
-    """verify_block_ruleset() returns no errors for a valid block ruleset."""
-    assert verify_block_ruleset(block_ruleset()) == []
+def test_verify_block_accepts_generated_block_ruleset() -> None:
+    """verify_block() returns no errors for a valid block ruleset."""
+    assert RulesetBuilder.verify_block(RulesetBuilder.build_block()) == []
 
 
-def test_verify_block_ruleset_rejects_hook_ruleset() -> None:
+def test_verify_block_rejects_hook_ruleset() -> None:
     """Hook (deny-all with allowlists) must not satisfy block verification."""
-    errors = verify_block_ruleset(hook_ruleset())
+    errors = RulesetBuilder.verify_block(_builder.build_hook())
     assert errors
     assert any("allow_v4" in e for e in errors)
 
 
-def test_verify_block_ruleset_rejects_bypass_ruleset() -> None:
+def test_verify_block_rejects_bypass_ruleset() -> None:
     """Bypass (accept-all) must not satisfy block verification."""
-    errors = verify_block_ruleset(bypass_ruleset())
+    errors = RulesetBuilder.verify_block(_builder.build_bypass())
     assert errors
 
 
-def test_verify_block_ruleset_reports_missing_chain() -> None:
+def test_verify_block_reports_missing_chain() -> None:
     """Missing chains are reported."""
     minimal = f"table {NFT_TABLE} {{ chain output {{ policy drop; {BLOCKED_LOG_PREFIX} }} }}"
-    errors = verify_block_ruleset(minimal)
+    errors = RulesetBuilder.verify_block(minimal)
     assert "input chain missing" in errors
 
 
-def test_verify_block_ruleset_reports_missing_prefix() -> None:
+def test_verify_block_reports_missing_prefix() -> None:
     """Missing blocked log prefix is reported."""
     minimal = (
         f"table {NFT_TABLE} {{ chain output {{ policy drop; }} chain input {{ policy drop; }} }}"
     )
-    errors = verify_block_ruleset(minimal)
+    errors = RulesetBuilder.verify_block(minimal)
     assert "blocked nflog prefix missing" in errors
 
 
-def test_verify_block_ruleset_reports_errors_for_empty_input() -> None:
+def test_verify_block_reports_errors_for_empty_input() -> None:
     """Empty nft output should fail block-mode verification."""
-    assert verify_block_ruleset("")
+    assert RulesetBuilder.verify_block("")
 
 
 # ── Gateway sets and port rules ──────────────────────────
@@ -854,56 +840,45 @@ class TestGatewayPortRules:
     _GW_V4 = SLIRP4NETNS_DNS.replace(".3", ".2")  # 10.0.2.2
     _GW_V6 = "fd00::2"
 
-    def test_hook_ruleset_contains_literal_gateway_ips(self) -> None:
-        """hook_ruleset() with gateway params contains literal IP accept rules."""
-        rs = hook_ruleset(
+    def _gw_builder(self, *, ports: tuple[int, ...] = (9418,)) -> RulesetBuilder:
+        """Create a RulesetBuilder with gateway config."""
+        return RulesetBuilder(
             dns=SLIRP4NETNS_DNS,
-            loopback_ports=(9418,),
+            loopback_ports=ports,
             gateway_v4=self._GW_V4,
             gateway_v6=self._GW_V6,
         )
+
+    def test_hook_ruleset_contains_literal_gateway_ips(self) -> None:
+        """build_hook() with gateway params contains literal IP accept rules."""
+        rs = self._gw_builder().build_hook()
         assert f"tcp dport 9418 ip daddr {self._GW_V4} accept" in rs
         assert f"tcp dport 9418 ip6 daddr {self._GW_V6} accept" in rs
 
     def test_bypass_ruleset_contains_literal_gateway_ips(self) -> None:
-        """bypass_ruleset() with gateway params contains literal IP accept rules."""
-        rs = bypass_ruleset(
-            dns=SLIRP4NETNS_DNS,
-            loopback_ports=(9418,),
-            gateway_v4=self._GW_V4,
-            gateway_v6=self._GW_V6,
-        )
+        """build_bypass() with gateway params contains literal IP accept rules."""
+        rs = self._gw_builder().build_bypass()
         assert f"tcp dport 9418 ip daddr {self._GW_V4} accept" in rs
         assert f"tcp dport 9418 ip6 daddr {self._GW_V6} accept" in rs
 
     def test_gateway_rules_before_private_range(self) -> None:
         """Gateway accept rules appear before private-range reject rules."""
-        rs = hook_ruleset(
-            dns=SLIRP4NETNS_DNS,
-            loopback_ports=(9418,),
-            gateway_v4=self._GW_V4,
-            gateway_v6=self._GW_V6,
-        )
+        rs = self._gw_builder().build_hook()
         gw_pos = rs.index(f"ip daddr {self._GW_V4} accept")
         private_pos = rs.index(RFC1918[0])
         assert gw_pos < private_pos
 
     def test_gateway_multiple_ports(self) -> None:
         """Literal gateway IP rules are generated for each loopback port."""
-        rs = hook_ruleset(
-            dns=SLIRP4NETNS_DNS,
-            loopback_ports=(9418, 8080),
-            gateway_v4=self._GW_V4,
-            gateway_v6=self._GW_V6,
-        )
+        rs = self._gw_builder(ports=(9418, 8080)).build_hook()
         assert f"tcp dport 9418 ip daddr {self._GW_V4} accept" in rs
         assert f"tcp dport 8080 ip daddr {self._GW_V4} accept" in rs
         assert f"tcp dport 9418 ip6 daddr {self._GW_V6} accept" in rs
         assert f"tcp dport 8080 ip6 daddr {self._GW_V6} accept" in rs
 
     def test_no_gateway_rules_without_ports(self) -> None:
-        """hook_ruleset() with no loopback_ports produces no gateway rules."""
-        rs = hook_ruleset(dns=SLIRP4NETNS_DNS, loopback_ports=())
+        """build_hook() with no loopback_ports produces no gateway rules."""
+        rs = RulesetBuilder(dns=SLIRP4NETNS_DNS, loopback_ports=()).build_hook()
         assert f"ip daddr {self._GW_V4} accept" not in rs
 
     def test_swapped_gateway_families_rejected(self) -> None:
@@ -958,26 +933,21 @@ class TestSetTimeout:
 
     def test_hook_ruleset_without_timeout(self) -> None:
         """Default rulesets have no timeout in set declarations."""
-        rs = hook_ruleset()
+        rs = RulesetBuilder().build_hook()
         assert "flags interval;" in rs
         assert "timeout" not in rs
 
     def test_hook_ruleset_with_timeout(self) -> None:
         """With set_timeout, sets get interval+timeout flags."""
-        rs = hook_ruleset(set_timeout="30m")
+        rs = RulesetBuilder(set_timeout="30m").build_hook()
         assert "flags interval, timeout; timeout 30m;" in rs
 
     def test_bypass_ruleset_with_timeout(self) -> None:
         """Bypass rulesets also support set_timeout."""
-        rs = bypass_ruleset(set_timeout="1h")
+        rs = RulesetBuilder(set_timeout="1h").build_bypass()
         assert "flags interval, timeout; timeout 1h;" in rs
 
-    def test_hook_ruleset_rejects_invalid_timeout(self) -> None:
-        """Invalid timeout in hook_ruleset is rejected."""
+    def test_builder_rejects_invalid_timeout(self) -> None:
+        """Invalid set_timeout in RulesetBuilder is rejected."""
         with pytest.raises(ValueError):
-            hook_ruleset(set_timeout="bad")
-
-    def test_bypass_ruleset_rejects_invalid_timeout(self) -> None:
-        """Invalid timeout in bypass_ruleset is rejected by _safe_timeout."""
-        with pytest.raises(ValueError):
-            bypass_ruleset(set_timeout="bad")
+            RulesetBuilder(set_timeout="bad")


### PR DESCRIPTION
## Summary

- **nft/rules.py**: 15 module-level free functions absorbed into the existing `RulesetBuilder` class — eliminates the delegation pattern where methods just called free functions
  - Ruleset generators (`hook_ruleset`, `bypass_ruleset`, `block_ruleset`) merged into `build_hook`/`build_bypass`/`build_block`
  - Verification functions merged into `verify_hook`/`verify_bypass`/`verify_block`
  - 8 private helpers become `@staticmethod` methods on the class
- **hooks/mode.py**: fix `NFT_TABLE` import to come from `nft.constants` (where it's defined) instead of `nft.rules`
- Standalone set operations (`add_elements`, `delete_elements`, `*_dual` variants) and all validators (`safe_ip`, `_safe_port`, etc.) remain as module-level functions — they are stateless and used independently
- 7 test files updated to use `RulesetBuilder` instances instead of free functions

## Test plan

- [x] `ruff check` + `ruff format` clean
- [x] All 1009 unit tests pass (1 pre-existing skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal restructuring of ruleset generation and verification systems to improve code organization, reduce duplication, and enhance long-term maintainability.

* **Tests**
  * Comprehensive updates to integration and unit tests to align with internal API changes and ensure continued functionality.

**Note:** This release contains no user-visible features or bug fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->