### PR TITLE
fix: harden nft ruleset verification and remove redundant sport 53 rules

### DIFF
--- a/src/terok_shield/hooks/mode.py
+++ b/src/terok_shield/hooks/mode.py
@@ -44,6 +44,7 @@ from ..dns import dnsmasq
 from ..nft.constants import (
     NFT_SET_TIMEOUT_DNSMASQ,
     NFT_TABLE,
+    NFT_TABLE_NAME,
     PASTA_DNS,
     PASTA_HOST_LOOPBACK_MAP,
     SLIRP4NETNS_DNS,
@@ -474,7 +475,13 @@ class HookMode:
             if deny_cmd:
                 self._runner.nft_via_nsenter(container, stdin=deny_cmd)
 
-        output = self._runner.nft_via_nsenter(container, "list", "ruleset")
+        output = self._runner.nft_via_nsenter(
+            container,
+            "list",
+            "table",
+            "inet",
+            NFT_TABLE_NAME,
+        )
         errors = ruleset.verify_bypass(output, allow_all=allow_all)
         if errors:
             raise RuntimeError(f"Shield-down ruleset verification failed: {'; '.join(errors)}")
@@ -486,7 +493,13 @@ class HookMode:
         current = self.shield_state(container)
         stdin = rs if current == ShieldState.INACTIVE else f"delete table {NFT_TABLE}\n{rs}"
         self._runner.nft_via_nsenter(container, stdin=stdin)
-        output = self._runner.nft_via_nsenter(container, "list", "ruleset")
+        output = self._runner.nft_via_nsenter(
+            container,
+            "list",
+            "table",
+            "inet",
+            NFT_TABLE_NAME,
+        )
         errors = ruleset.verify_block(output)
         if errors:
             raise RuntimeError(f"Block ruleset verification failed: {'; '.join(errors)}")
@@ -520,7 +533,13 @@ class HookMode:
 
         # Gateway addresses are baked into the ruleset — no repopulation needed.
 
-        output = self._runner.nft_via_nsenter(container, "list", "ruleset")
+        output = self._runner.nft_via_nsenter(
+            container,
+            "list",
+            "table",
+            "inet",
+            NFT_TABLE_NAME,
+        )
         errors = ruleset.verify_hook(output)
         if errors:
             raise RuntimeError(f"Ruleset verification failed: {'; '.join(errors)}")

--- a/src/terok_shield/nft/rules.py
+++ b/src/terok_shield/nft/rules.py
@@ -37,8 +37,6 @@ _INPUT_CHAIN = """\
                 type filter hook input priority filter; policy drop;
                 iifname "lo" accept
                 ct state established,related accept
-                udp sport 53 accept
-                tcp sport 53 accept
                 drop
             }"""
 
@@ -197,7 +195,11 @@ class RulesetBuilder:
     def verify_hook(self, nft_output: str) -> list[str]:
         """Check applied hook ruleset invariants.  Returns errors (empty = OK).
 
+        Expects output from ``nft list table inet terok_shield`` (scoped to the
+        managed table), not ``nft list ruleset``.
+
         Verifies:
+        - Managed table header is present
         - Default policy is drop
         - Both output and input chains exist
         - Reject type is present
@@ -207,6 +209,8 @@ class RulesetBuilder:
         - Terminal deny-all rule with BLOCKED prefix present
         """
         errors: list[str] = []
+        if f"table {NFT_TABLE}" not in nft_output:
+            errors.append(f"managed table '{NFT_TABLE}' not found in output")
         if "policy drop" not in nft_output:
             errors.append("policy is not drop")
         for chain in ("output", "input"):
@@ -236,7 +240,11 @@ class RulesetBuilder:
     def verify_bypass(self, nft_output: str, *, allow_all: bool = False) -> list[str]:
         """Check applied bypass ruleset invariants.  Returns errors (empty = OK).
 
+        Expects output from ``nft list table inet terok_shield`` (scoped to the
+        managed table), not ``nft list ruleset``.
+
         Verifies:
+        - Managed table header is present
         - Output chain has policy accept
         - Input chain has policy drop
         - Bypass nflog prefix is present
@@ -244,6 +252,8 @@ class RulesetBuilder:
         - Private-range reject rules present (unless *allow_all*)
         """
         errors: list[str] = []
+        if f"table {NFT_TABLE}" not in nft_output:
+            errors.append(f"managed table '{NFT_TABLE}' not found in output")
         if "policy accept" not in nft_output:
             errors.append("output policy is not accept")
         if "policy drop" not in nft_output:
@@ -264,12 +274,18 @@ class RulesetBuilder:
     def verify_block(nft_output: str) -> list[str]:
         """Check applied block ruleset invariants.  Returns errors (empty = OK).
 
+        Expects output from ``nft list table inet terok_shield`` (scoped to the
+        managed table), not ``nft list ruleset``.
+
         Verifies:
+        - Managed table header is present
         - Both chains present with policy drop
         - Blocked log prefix present
         - No allow sets (total blackout means no allowlists)
         """
         errors: list[str] = []
+        if f"table {NFT_TABLE}" not in nft_output:
+            errors.append(f"managed table '{NFT_TABLE}' not found in output")
         if "policy drop" not in nft_output:
             errors.append("policy is not drop")
         for chain in ("output", "input"):

--- a/tests/integration/allow_deny/test_traffic.py
+++ b/tests/integration/allow_deny/test_traffic.py
@@ -90,8 +90,10 @@ class TestRFC1918Allow:
         """RFC1918 addresses in the allow set bypass the RFC1918 reject rules."""
         from terok_shield.nft.constants import RFC1918
 
-        nsenter_nft(container_pid, stdin=RulesetBuilder().build_hook())
-        nsenter_nft(container_pid, stdin=add_elements("allow_v4", [RFC1918_HOST]))
+        applied = nsenter_nft(container_pid, stdin=RulesetBuilder().build_hook())
+        assert applied.returncode == 0, f"Ruleset apply failed: {applied.stderr}"
+        added = nsenter_nft(container_pid, stdin=add_elements("allow_v4", [RFC1918_HOST]))
+        assert added.returncode == 0, f"Add elements failed: {added.stderr}"
 
         # Structural: allow set evaluates before RFC1918 reject
         listed = nsenter_nft(container_pid, "list", "ruleset")


### PR DESCRIPTION
## Summary

- **#237**: Remove unconditional `udp/tcp sport 53 accept` rules from `_INPUT_CHAIN` — `ct state established,related accept` already handles DNS replies via conntrack; the explicit rules widened the container ingress surface to any unsolicited packet with source port 53
- **#239**: Scope post-apply ruleset verification in `shield_down`, `shield_block`, and `shield_up` to `nft list table inet terok_shield` instead of `nft list ruleset`, preventing false passes from string matches in unrelated tables (CWE-697). All three `verify_*` methods now also check for the managed table header
- **#238**: Assert `nsenter_nft()` return codes in `test_rfc1918_allowed_when_whitelisted` so silent failures in ruleset application or element insertion don't produce false-positive test results

Closes #237, closes #238, closes #239.

## Test plan

- [x] All 1009 unit tests pass
- [ ] Integration tests (`make test-integration-podman`) — needs podman environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced firewall verification process to explicitly check for managed table presence during shield lifecycle operations, improving validation reliability.

* **Changes**
  * Removed incoming DNS port accept rules from firewall input chain configuration.

* **Tests**
  * Improved integration tests with enhanced error reporting and return code validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->