### PR TITLE
Propagate sys.path for creation of Python subprocesses

### DIFF
--- a/src/terok_shield/cli/interactive.py
+++ b/src/terok_shield/cli/interactive.py
@@ -663,11 +663,13 @@ def _propagate_pythonpath(env: dict[str, str]) -> None:
     ``python -m terok_shield.cli.interactive`` resolves regardless
     of installation method.
     """
+    env["PYTHONPATH"] = os.pathsep.join(sys.path)
     # terok_shield/ is two levels up from cli/interactive.py; site-packages is three.
     site = str(Path(__file__).resolve().parent.parent.parent)
     existing = env.get("PYTHONPATH", "")
     if site not in existing.split(os.pathsep):
-        env["PYTHONPATH"] = f"{site}{os.pathsep}{existing}" if existing else site
+        sitepath = f"{site}{os.pathsep}{existing}" if existing else site
+        env["PYTHONPATH"] = sitepath + env["PYTHONPATH"]
 
 
 # ── Helpers ──────────────────────────────────────────────

--- a/src/terok_shield/cli/interactive.py
+++ b/src/terok_shield/cli/interactive.py
@@ -668,6 +668,7 @@ def _propagate_pythonpath(env: dict[str, str]) -> None:
     paths = sys.path if site in sys.path else [site, *sys.path]
     env["PYTHONPATH"] = os.pathsep.join(paths)
 
+
 # ── Helpers ──────────────────────────────────────────────
 
 # Module-level stop flag, set by signal handler.

--- a/src/terok_shield/cli/interactive.py
+++ b/src/terok_shield/cli/interactive.py
@@ -663,14 +663,10 @@ def _propagate_pythonpath(env: dict[str, str]) -> None:
     ``python -m terok_shield.cli.interactive`` resolves regardless
     of installation method.
     """
-    env["PYTHONPATH"] = os.pathsep.join(sys.path)
     # terok_shield/ is two levels up from cli/interactive.py; site-packages is three.
     site = str(Path(__file__).resolve().parent.parent.parent)
-    existing = env.get("PYTHONPATH", "")
-    if site not in existing.split(os.pathsep):
-        sitepath = f"{site}{os.pathsep}{existing}" if existing else site
-        env["PYTHONPATH"] = sitepath + env["PYTHONPATH"]
-
+    paths = sys.path if site in sys.path else [site, *sys.path]
+    env["PYTHONPATH"] = os.pathsep.join(paths)
 
 # ── Helpers ──────────────────────────────────────────────
 

--- a/src/terok_shield/dbus_bridge.py
+++ b/src/terok_shield/dbus_bridge.py
@@ -55,11 +55,13 @@ def _propagate_pythonpath(env: dict[str, str]) -> None:
     Mirrors :func:`terok_shield.cli.interactive._propagate_pythonpath` —
     duplicated because tach layer boundaries prevent support->cli imports.
     """
+    env["PYTHONPATH"] = os.pathsep.join(sys.path)
     # terok_shield/ is one level up from this file; site-packages is two.
     site = str(Path(__file__).resolve().parent.parent)
     existing = env.get("PYTHONPATH", "")
     if site not in existing.split(os.pathsep):
-        env["PYTHONPATH"] = f"{site}{os.pathsep}{existing}" if existing else site
+        sitepath = f"{site}{os.pathsep}{existing}" if existing else site
+        env["PYTHONPATH"] = sitepath + env["PYTHONPATH"]
 
 
 def bus_name_for_container(short_id: str) -> str:

--- a/src/terok_shield/dbus_bridge.py
+++ b/src/terok_shield/dbus_bridge.py
@@ -60,6 +60,7 @@ def _propagate_pythonpath(env: dict[str, str]) -> None:
     paths = sys.path if site in sys.path else [site, *sys.path]
     env["PYTHONPATH"] = os.pathsep.join(paths)
 
+
 def bus_name_for_container(short_id: str) -> str:
     """Derive the per-container well-known bus name.
 

--- a/src/terok_shield/dbus_bridge.py
+++ b/src/terok_shield/dbus_bridge.py
@@ -55,14 +55,10 @@ def _propagate_pythonpath(env: dict[str, str]) -> None:
     Mirrors :func:`terok_shield.cli.interactive._propagate_pythonpath` —
     duplicated because tach layer boundaries prevent support->cli imports.
     """
-    env["PYTHONPATH"] = os.pathsep.join(sys.path)
     # terok_shield/ is one level up from this file; site-packages is two.
     site = str(Path(__file__).resolve().parent.parent)
-    existing = env.get("PYTHONPATH", "")
-    if site not in existing.split(os.pathsep):
-        sitepath = f"{site}{os.pathsep}{existing}" if existing else site
-        env["PYTHONPATH"] = sitepath + env["PYTHONPATH"]
-
+    paths = sys.path if site in sys.path else [site, *sys.path]
+    env["PYTHONPATH"] = os.pathsep.join(paths)
 
 def bus_name_for_container(short_id: str) -> str:
     """Derive the per-container well-known bus name.


### PR DESCRIPTION
This is basically the same fix as in https://github.com/terok-ai/terok/pull/717. This ensures that any launched Python subprocess has the same Python Path as the parent.
In some setups, the `PYTHONPATH` environment variable may not be enough for this purpose, as the Python Path might have been modified inside the running Python process using `import site`. So instead, this uses `sys.path` to get the Python path currently in use.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Revised how runtime search paths are assembled so they are built from the interpreter’s canonical paths rather than merging pre-existing settings.
  * Results in more consistent and predictable module resolution, reduced duplicate entries, and improved reliability of command-line tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->