### PR TITLE
feat(reader): drop ff02::/16 noise + dedupe at domain grain

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.poetry]
 name = "terok-shield"
-version = "0.6.22"
+version = "0.6.23"
 description = "nftables-based egress firewalling for Podman containers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/terok_shield/resources/nflog_reader.py
+++ b/src/terok_shield/resources/nflog_reader.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import argparse
 import contextlib
+import ipaddress
 import json
 import logging
 import os
@@ -213,6 +214,21 @@ def _resolve_binary(name: str) -> str:
 
 # ── Session ───────────────────────────────────────────────────────────
 
+#: IPv6 link-local multicast — MLD, router / neighbor discovery, mDNS.
+#: The kernel and systemd emit these routinely; the shield correctly
+#: blocks them but the operator has no useful decision to make, so the
+#: reader drops them before dedup / emit.  See polish backlog.
+_IPV6_LINK_LOCAL_MULTICAST = ipaddress.IPv6Network("ff02::/16")
+
+
+def _is_noise_dest(dest: str) -> bool:
+    """Return True for traffic the clearance flow should silently drop."""
+    try:
+        addr = ipaddress.ip_address(dest)
+    except ValueError:
+        return False
+    return isinstance(addr, ipaddress.IPv6Address) and addr in _IPV6_LINK_LOCAL_MULTICAST
+
 
 class ReaderSession:
     """Orchestrates the container's block-event stream for the clearance flow.
@@ -220,8 +236,15 @@ class ReaderSession:
     Owns the NFLOG socket, a rolling dedup window, the domain cache, and the
     signal handler.  Lives for the container's lifetime: emits
     ``ContainerStarted`` on open, streams ``ConnectionBlocked`` for each
-    unique-destination block within a dedup window, and emits
-    ``ContainerExited`` on SIGTERM or NFLOG close.
+    unique block within a dedup window, and emits ``ContainerExited`` on
+    SIGTERM or NFLOG close.
+
+    The dedup key is the *domain* when the reader has one cached from the
+    per-container dnsmasq log, otherwise the raw destination IP.  That means
+    a multi-A-record name like ``example.com → 1.1.1.1 + 1.0.0.1`` collapses
+    to one prompt rather than two — which matches the operator's mental
+    model ("do I allow example.com?"), not the kernel's ("two distinct
+    packets went to two IPs").
 
     The dedup window rate-limits retries within a single application's
     attempt (TCP SYN retransmits, wget's own retries, etc.) without
@@ -230,10 +253,10 @@ class ReaderSession:
     (replacing still-visible notifications) belongs to the notifier.
     """
 
-    #: Seconds for which a dest stays muted after one emission.  Short enough
-    #: that the operator can re-trigger a block and get a fresh notification
-    #: when the previous one auto-dismissed; long enough that a single wget
-    #: retry burst doesn't produce a pile of duplicate signals.
+    #: Seconds for which a dedup key stays muted after one emission.  Short
+    #: enough that the operator can re-trigger a block and get a fresh
+    #: notification when the previous one auto-dismissed; long enough that a
+    #: single wget retry burst doesn't produce a pile of duplicate signals.
     _DEDUP_WINDOW_S = 30.0
 
     def __init__(self, *, state_dir: Path, container: str, emitter: EventEmitter) -> None:
@@ -273,18 +296,30 @@ class ReaderSession:
                 continue
             now = time.monotonic()
             for event in _drain(sock):
-                last = self._last_emit.get(event.dest)
-                if last is not None and now - last < self._DEDUP_WINDOW_S:
-                    continue
-                self._last_emit[event.dest] = now
-                self._emit_connection_blocked(event)
+                self._maybe_emit(event, now)
 
-    def _emit_connection_blocked(self, event: _RawBlockEvent) -> None:
-        """Enrich an NFLOG event with domain + request-id and publish it."""
-        domain = self._domain_cache.lookup(event.dest)
+    def _maybe_emit(self, event: _RawBlockEvent, now: float) -> None:
+        """Filter noise, dedupe by domain-or-dest, emit if fresh."""
+        if _is_noise_dest(event.dest):
+            return
+        domain = self._resolve_domain(event.dest)
+        dedup_key = domain or event.dest
+        last = self._last_emit.get(dedup_key)
+        if last is not None and now - last < self._DEDUP_WINDOW_S:
+            return
+        self._last_emit[dedup_key] = now
+        self._emit_connection_blocked(event, domain)
+
+    def _resolve_domain(self, dest: str) -> str:
+        """Look *dest* up in the domain cache, refreshing once on miss."""
+        domain = self._domain_cache.lookup(dest)
         if not domain:
             self._domain_cache.refresh()
-            domain = self._domain_cache.lookup(event.dest)
+            domain = self._domain_cache.lookup(dest)
+        return domain
+
+    def _emit_connection_blocked(self, event: _RawBlockEvent, domain: str) -> None:
+        """Publish one ``ConnectionBlocked`` for *event* — caller supplies the domain."""
         request_id = f"{self._container}:{self._next_id}"
         self._next_id += 1
         self._emitter.connection_blocked(

--- a/tests/testnet.py
+++ b/tests/testnet.py
@@ -111,6 +111,10 @@ IPV6_ULA = "fd00::1"  # Unique Local Address (RFC 4193, fc00::/7)
 IPV6_ULA_CIDR = "fc00::/7"  # Unique Local Address CIDR (RFC 4193)
 IPV6_LINK_LOCAL = "fe80::1"  # Link-local address (RFC 4291, fe80::/10)
 
+# ── IPv6 link-local multicast (used to test clearance-noise filtering) ──
+IPV6_MCAST_ALL_ROUTERS = "ff02::2"  # IPv6 all-routers link-local multicast
+IPV6_MCAST_MLDV2 = "ff02::16"  # MLDv2-capable routers link-local multicast
+
 # ── Expected private ranges (test-owned, independent from implementation) ──
 # These duplicate the implementation constants intentionally so tests catch
 # accidental removal of a range from the production code.

--- a/tests/unit/test_nflog_reader.py
+++ b/tests/unit/test_nflog_reader.py
@@ -22,7 +22,14 @@ import pytest
 from terok_shield.resources import nflog_reader as reader
 
 from ..testfs import DNSMASQ_LOG_FILENAME, READER_EVENTS_SOCK_FILENAME
-from ..testnet import TEST_DOMAIN, TEST_IP1, TEST_IP99
+from ..testnet import (
+    IPV6_MCAST_ALL_ROUTERS,
+    IPV6_MCAST_MLDV2,
+    TEST_DOMAIN,
+    TEST_IP1,
+    TEST_IP2,
+    TEST_IP99,
+)
 
 # ── Packet-format helpers (pure constructors for fixtures) ────────────
 
@@ -461,6 +468,82 @@ class TestReaderSession:
         kinds = [kind for kind, _ in recorder.calls]
         assert kinds[0] == "started"
         assert kinds[-1] == "exited"
+
+    def test_ipv6_link_local_multicast_is_silently_dropped(self, tmp_path: Path) -> None:
+        """MLD / router-discovery blocks are kernel noise — the reader drops them."""
+        recorder = _RecordingEmitter()
+        session = reader.ReaderSession(state_dir=tmp_path, container="c1", emitter=recorder)
+        fake_sock = _FakeSocket()
+        noise = [
+            reader._RawBlockEvent(dest=IPV6_MCAST_ALL_ROUTERS, port=0, proto=socket.IPPROTO_ICMPV6),
+            reader._RawBlockEvent(dest=IPV6_MCAST_MLDV2, port=0, proto=socket.IPPROTO_ICMPV6),
+        ]
+
+        def fake_select(rfds: list, *_args: object, **_kwargs: object) -> tuple[list, list, list]:
+            session._stop_requested = True
+            return (list(rfds), [], [])
+
+        with (
+            mock.patch.object(reader, "_open_nflog_socket", return_value=fake_sock),
+            mock.patch.object(reader, "_drain", return_value=noise),
+            mock.patch.object(reader.select, "select", side_effect=fake_select),
+        ):
+            session.run()
+
+        blocked_events = [payload for kind, payload in recorder.calls if kind == "blocked"]
+        assert blocked_events == []
+
+    def test_multi_ip_for_one_domain_is_emitted_once(self, tmp_path: Path) -> None:
+        """Two IPs that resolve to the same domain collapse to one block event."""
+        recorder = _RecordingEmitter()
+        session = reader.ReaderSession(state_dir=tmp_path, container="c1", emitter=recorder)
+        # Seed the domain cache so both IPs map to the same name.
+        session._domain_cache._mapping = {TEST_IP1: TEST_DOMAIN, TEST_IP2: TEST_DOMAIN}
+        fake_sock = _FakeSocket()
+        events = [
+            reader._RawBlockEvent(dest=TEST_IP1, port=443, proto=socket.IPPROTO_TCP),
+            reader._RawBlockEvent(dest=TEST_IP2, port=443, proto=socket.IPPROTO_TCP),
+        ]
+
+        def fake_select(rfds: list, *_args: object, **_kwargs: object) -> tuple[list, list, list]:
+            session._stop_requested = True
+            return (list(rfds), [], [])
+
+        with (
+            mock.patch.object(reader, "_open_nflog_socket", return_value=fake_sock),
+            mock.patch.object(reader, "_drain", return_value=events),
+            mock.patch.object(reader.select, "select", side_effect=fake_select),
+        ):
+            session.run()
+
+        blocked_events = [payload for kind, payload in recorder.calls if kind == "blocked"]
+        assert len(blocked_events) == 1
+        assert blocked_events[0].domain == TEST_DOMAIN
+
+    def test_dedup_falls_back_to_dest_when_domain_unknown(self, tmp_path: Path) -> None:
+        """With no cached domain, dedup stays on raw dest IP — no regression."""
+        recorder = _RecordingEmitter()
+        session = reader.ReaderSession(state_dir=tmp_path, container="c1", emitter=recorder)
+        fake_sock = _FakeSocket()
+        # Two *distinct* IPs, no domain in cache → two emissions expected.
+        events = [
+            reader._RawBlockEvent(dest=TEST_IP1, port=443, proto=socket.IPPROTO_TCP),
+            reader._RawBlockEvent(dest=TEST_IP99, port=443, proto=socket.IPPROTO_TCP),
+        ]
+
+        def fake_select(rfds: list, *_args: object, **_kwargs: object) -> tuple[list, list, list]:
+            session._stop_requested = True
+            return (list(rfds), [], [])
+
+        with (
+            mock.patch.object(reader, "_open_nflog_socket", return_value=fake_sock),
+            mock.patch.object(reader, "_drain", return_value=events),
+            mock.patch.object(reader.select, "select", side_effect=fake_select),
+        ):
+            session.run()
+
+        blocked_events = [payload for kind, payload in recorder.calls if kind == "blocked"]
+        assert {e.dest for e in blocked_events} == {TEST_IP1, TEST_IP99}
 
 
 class _FakeSocket:

--- a/tests/unit/test_nflog_reader.py
+++ b/tests/unit/test_nflog_reader.py
@@ -143,6 +143,25 @@ class TestSelectEmitter:
         assert isinstance(reader._select_emitter("socket"), reader.SocketEmitter)
 
 
+class TestIsNoiseDest:
+    """``_is_noise_dest`` filters IPv6 link-local multicast only."""
+
+    def test_ff02_address_is_noise(self) -> None:
+        assert reader._is_noise_dest(IPV6_MCAST_ALL_ROUTERS) is True
+        assert reader._is_noise_dest(IPV6_MCAST_MLDV2) is True
+
+    def test_regular_ipv6_is_not_noise(self) -> None:
+        """A public IPv6 destination must surface normally."""
+        assert reader._is_noise_dest("2001:db8::1") is False
+
+    def test_ipv4_is_not_noise(self) -> None:
+        assert reader._is_noise_dest(TEST_IP1) is False
+
+    def test_non_address_string_is_not_noise(self) -> None:
+        """Unparseable input maps to False so malformed data falls through to emit."""
+        assert reader._is_noise_dest("not-an-ip") is False
+
+
 class TestEventsSocketPath:
     """``_events_socket_path`` honours XDG, falls back to /run/user/<uid>."""
 


### PR DESCRIPTION
## Summary

Two UX polish items for the clearance flow, both at the NFLOG
reader's pre-emit pipeline.

**IPv6 link-local multicast noise is now silently dropped.** Every
shielded container emits routine blocks for \`ff02::2\` / \`ff02::16\`
(MLD, router / neighbor discovery, mDNS).  Those aren't operator
decisions — they're kernel/systemd housekeeping that the shield
correctly blocks but that the clearance UI has no useful question to
ask about.  \`ff02::/16\` was chosen over the broader \`ff00::/8\` to
stay conservative — any non-link-local multicast still surfaces.

**Dedup key is the domain when one is known, otherwise the dest IP.**
A multi-A-record destination like \`seznam.cz → 77.75.77.222 +
77.75.79.222\` used to produce two clearance prompts for what the
operator reads as one decision about one domain.  Roll the dedup key
up to the domain when the per-container dnsmasq cache has one; fall
back to raw dest IP otherwise so blocks without a resolved name (raw
IP access, unresolvable lookups) keep the old behaviour.

While here, extract \`_maybe_emit\` and \`_resolve_domain\` so the
per-event decision reads as three named steps (filter → resolve →
dedup-and-emit) rather than an if-chain buried inside \`_loop\`.

## Test plan
- [x] \`make check\` green (lint, 1044 unit tests, tach, docstrings,
      reuse, bandit).
- [x] New unit coverage: link-local multicast is dropped;
      two IPs → one domain collapses to one emission; no-domain
      fallback keeps per-IP dedup.
- [ ] Integration smoke on a shielded container (handled by user on
      test machine per project convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Filter IPv6 link-local multicast noise to reduce unnecessary alerts
  * Improve deduplication of "connection blocked" notifications by consolidating related events using cached domain info, falling back to raw destination IPs when needed
* **Refactor**
  * Reorganized emission flow to ensure the deduplication window is applied before notifications
* **Tests**
  * Added unit tests for IPv6 noise filtering and deduplication behaviors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->