### PR TITLE
feat(shield): emit shield_up/shield_down events to the hub

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.poetry]
 name = "terok-shield"
-version = "0.6.24"
+version = "0.6.25"
 description = "nftables-based egress firewalling for Podman containers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/terok_shield/__init__.py
+++ b/src/terok_shield/__init__.py
@@ -48,6 +48,7 @@ from .podman_info import (
 from .util import is_ip as _is_ip
 
 if TYPE_CHECKING:
+    from ._hub_events import HubEventEmitter
     from .audit import AuditLogger
     from .dns.resolver import DnsResolver
     from .nft.rules import RulesetBuilder
@@ -169,6 +170,7 @@ class Shield:
         dns: "DnsResolver | None" = None,
         profiles: "ProfileLoader | None" = None,
         ruleset: "RulesetBuilder | None" = None,
+        hub_events: "HubEventEmitter | None" = None,
     ) -> None:
         """Create the shield facade.
 
@@ -179,8 +181,13 @@ class Shield:
             dns: DNS resolver (default: from runner).
             profiles: Profile loader (default: from config.profiles_dir).
             ruleset: Ruleset builder (default: from config loopback_ports).
+            hub_events: Best-effort emitter for ``shield_up`` / ``shield_down``
+                events bound for the terok-dbus hub (default: a fresh
+                :class:`HubEventEmitter` pointed at the canonical socket).
+                Pass a no-op stub in tests that should not touch the socket.
         """
         from . import state
+        from ._hub_events import HubEventEmitter
         from .audit import AuditLogger
         from .dns.resolver import DnsResolver
         from .nft.rules import RulesetBuilder
@@ -198,6 +205,7 @@ class Shield:
             user_dir=config.profiles_dir or Path("/nonexistent"),
         )
         self.ruleset = ruleset or RulesetBuilder(loopback_ports=config.loopback_ports)
+        self.hub_events = hub_events or HubEventEmitter()
         self._mode = self._create_mode(config.mode)
 
     def _create_mode(self, mode: ShieldMode):  # noqa: ANN202
@@ -357,6 +365,7 @@ class Shield:
             "shield_down",
             detail="allow_all=True" if allow_all else None,
         )
+        self.hub_events.shield_down(container, allow_all=allow_all)
 
     def block(self, container: str) -> None:
         """Total network blackout — drop all traffic, log for forensics."""
@@ -367,6 +376,7 @@ class Shield:
         """Restore normal deny-all mode for a running container."""
         self._mode.shield_up(container)
         self.audit.log_event(container, "shield_up")
+        self.hub_events.shield_up(container)
 
     def state(self, container: str) -> ShieldState:
         """Query the live nft ruleset to determine a container's shield state."""

--- a/src/terok_shield/_hub_events.py
+++ b/src/terok_shield/_hub_events.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Best-effort JSON event emitter for the terok-dbus hub.
+
+Shield CLI calls (``up``/``down``) notify the hub so desktop/TUI consumers
+can reflect the state change — in particular, the hub closes pending
+block notifications for a container whose shield just dropped.  Stays
+stdlib-only so the reader script resource (which bypasses the package)
+can mirror the same wire format without importing this module.
+
+Fails silent when the hub isn't listening: flipping shield state must
+never be held up by a desktop-side daemon being absent.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import os
+import socket
+from pathlib import Path
+
+_log = logging.getLogger(__name__)
+
+_SOCKET_BASENAME = "terok-shield-events.sock"
+#: Cap on the socket connect/send syscalls so a dead but unreaped hub
+#: (listener exists, accept thread wedged) can't block the shield CLI
+#: for longer than the operator will patiently hold the keyboard.
+_IO_TIMEOUT_S = 0.5
+
+
+def hub_socket_path() -> Path:
+    """Return the canonical hub ingester path under ``$XDG_RUNTIME_DIR``."""
+    xdg = os.environ.get("XDG_RUNTIME_DIR") or f"/run/user/{os.getuid()}"
+    return Path(xdg) / _SOCKET_BASENAME
+
+
+class HubEventEmitter:
+    """One-shot writer of JSON-line events to the hub's unix ingester.
+
+    Each ``emit_*`` call opens a fresh connection, sends a single line,
+    and closes.  The hub stays up across many CLI invocations while each
+    CLI invocation is short-lived — pooling would save nothing and would
+    complicate the fail-silent semantics.
+    """
+
+    def __init__(self, socket_path: Path | None = None) -> None:
+        """Remember the target socket; defaults to :func:`hub_socket_path`."""
+        self._path = socket_path or hub_socket_path()
+
+    def shield_up(self, container: str) -> None:
+        """Emit a ``shield_up`` event for *container*."""
+        self._send({"type": "shield_up", "container": container})
+
+    def shield_down(self, container: str, *, allow_all: bool = False) -> None:
+        """Emit a ``shield_down`` (or ``shield_down_all``) event for *container*."""
+        event_type = "shield_down_all" if allow_all else "shield_down"
+        self._send({"type": event_type, "container": container})
+
+    def _send(self, payload: dict) -> None:
+        """Write one JSON line to the hub socket, swallowing all I/O errors."""
+        line = (json.dumps(payload, separators=(",", ":")) + "\n").encode()
+        try:
+            sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            sock.settimeout(_IO_TIMEOUT_S)
+            with contextlib.closing(sock):
+                sock.connect(str(self._path))
+                sock.sendall(line)
+        except OSError as exc:
+            # Hub absent, socket path stale, peer buffer full — none of
+            # these should block a state-change CLI command.  Log at debug
+            # so a diagnosing operator can still see the reason.
+            _log.debug("hub event emit failed (%s): %s", payload.get("type"), exc)

--- a/tach.toml
+++ b/tach.toml
@@ -67,6 +67,12 @@ path = "terok_shield.run"
 layer = "foundation"
 depends_on = []
 
+# Hub event emitter — stdlib-only client for the terok-dbus unix ingester
+[[modules]]
+path = "terok_shield._hub_events"
+layer = "foundation"
+depends_on = []
+
 # ── Core ───────────────────────────────────────────────────
 # Security-critical modules — the auditable boundary.
 # May import from foundation freely; must declare same-layer deps.

--- a/tests/unit/test_hub_events.py
+++ b/tests/unit/test_hub_events.py
@@ -48,8 +48,13 @@ class _SocketRecorder:
             except OSError:
                 return
             with conn:
-                chunk = conn.recv(4096)
-                if chunk:
+                # AF_UNIX SOCK_STREAM may hand us the payload in multiple
+                # chunks under scheduler pressure — drain until EOF so the
+                # full JSON line is always available to the asserting helper.
+                while True:
+                    chunk = conn.recv(4096)
+                    if not chunk:
+                        break
                     self.received.append(chunk)
 
 

--- a/tests/unit/test_hub_events.py
+++ b/tests/unit/test_hub_events.py
@@ -1,0 +1,126 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the stdlib-only hub event emitter."""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import threading
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from terok_shield._hub_events import HubEventEmitter, hub_socket_path
+
+_CONTAINER = "test-ctr"
+
+
+class _SocketRecorder:
+    """Minimal unix-socket listener for exercising the emitter end-to-end."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.received: list[bytes] = []
+        self._sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self._sock.bind(str(path))
+        self._sock.listen(1)
+        self._thread = threading.Thread(target=self._accept_loop, daemon=True)
+        self._stop = False
+
+    def start(self) -> None:
+        """Begin accepting connections on the listener thread."""
+        self._thread.start()
+
+    def stop(self) -> None:
+        """Stop the accept loop and close the listener."""
+        self._stop = True
+        self._sock.close()
+        self._thread.join(timeout=1.0)
+
+    def _accept_loop(self) -> None:
+        while not self._stop:
+            try:
+                conn, _ = self._sock.accept()
+            except OSError:
+                return
+            with conn:
+                chunk = conn.recv(4096)
+                if chunk:
+                    self.received.append(chunk)
+
+
+@pytest.fixture
+def hub_socket(tmp_path: Path) -> Iterator[_SocketRecorder]:
+    """Spin up a throwaway AF_UNIX listener the emitter can hit."""
+    recorder = _SocketRecorder(tmp_path / "hub.sock")
+    recorder.start()
+    try:
+        yield recorder
+    finally:
+        recorder.stop()
+
+
+class TestHubSocketPath:
+    """Canonical socket path resolution."""
+
+    def test_uses_xdg_runtime_dir(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """The canonical path sits directly under XDG_RUNTIME_DIR."""
+        monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+        assert hub_socket_path() == tmp_path / "terok-shield-events.sock"
+
+    def test_falls_back_to_run_user_uid(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Without XDG_RUNTIME_DIR we fall back to ``/run/user/<uid>``."""
+        monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
+        assert hub_socket_path() == Path(f"/run/user/{os.getuid()}/terok-shield-events.sock")
+
+
+class TestHubEventEmitter:
+    """End-to-end emitter behaviour against a real unix socket."""
+
+    def test_shield_up_writes_single_json_line(self, hub_socket: _SocketRecorder) -> None:
+        """``shield_up`` produces one newline-terminated JSON payload."""
+        HubEventEmitter(hub_socket.path).shield_up(_CONTAINER)
+        line = _received_one_line(hub_socket)
+        assert json.loads(line) == {"type": "shield_up", "container": _CONTAINER}
+
+    def test_shield_down_default_is_plain_down(self, hub_socket: _SocketRecorder) -> None:
+        """``shield_down`` without ``allow_all`` maps to ``shield_down``."""
+        HubEventEmitter(hub_socket.path).shield_down(_CONTAINER)
+        assert json.loads(_received_one_line(hub_socket)) == {
+            "type": "shield_down",
+            "container": _CONTAINER,
+        }
+
+    def test_shield_down_allow_all_maps_to_down_all(self, hub_socket: _SocketRecorder) -> None:
+        """``allow_all=True`` flips the event type to ``shield_down_all``."""
+        HubEventEmitter(hub_socket.path).shield_down(_CONTAINER, allow_all=True)
+        assert json.loads(_received_one_line(hub_socket)) == {
+            "type": "shield_down_all",
+            "container": _CONTAINER,
+        }
+
+    def test_missing_socket_is_fail_silent(self, tmp_path: Path) -> None:
+        """Emission against a missing hub must not raise."""
+        emitter = HubEventEmitter(tmp_path / "does-not-exist.sock")
+        emitter.shield_up(_CONTAINER)  # must not raise
+        emitter.shield_down(_CONTAINER, allow_all=True)  # must not raise
+
+
+def _received_one_line(recorder: _SocketRecorder) -> str:
+    """Drain the recorder and return the single newline-terminated payload."""
+    # The emitter does a blocking sendall before close; by the time we return
+    # here the accept loop has already written to ``recorder.received``.
+    for _ in range(100):
+        if recorder.received:
+            break
+        import time
+
+        time.sleep(0.01)
+    assert recorder.received, "emitter never reached the listener"
+    data = b"".join(recorder.received).decode()
+    assert data.endswith("\n")
+    return data.rstrip("\n")

--- a/tests/unit/test_shield_facade.py
+++ b/tests/unit/test_shield_facade.py
@@ -30,6 +30,7 @@ class ShieldHarness:
     profiles: mock.MagicMock
     ruleset: mock.MagicMock
     mode: mock.MagicMock
+    hub_events: mock.MagicMock
 
 
 ShieldHarnessFactory = Callable[..., ShieldHarness]
@@ -47,6 +48,7 @@ def make_shield(make_config: ConfigFactory) -> ShieldHarnessFactory:
         dns: mock.MagicMock | None = None,
         profiles: mock.MagicMock | None = None,
         ruleset: mock.MagicMock | None = None,
+        hub_events: mock.MagicMock | None = None,
     ) -> ShieldHarness:
         harness = ShieldHarness(
             shield=Shield.__new__(Shield),
@@ -56,6 +58,7 @@ def make_shield(make_config: ConfigFactory) -> ShieldHarnessFactory:
             profiles=profiles or mock.MagicMock(),
             ruleset=ruleset or mock.MagicMock(),
             mode=mode or mock.MagicMock(),
+            hub_events=hub_events or mock.MagicMock(),
         )
         harness.shield.config = config or make_config()
         harness.shield.runner = harness.runner
@@ -63,6 +66,7 @@ def make_shield(make_config: ConfigFactory) -> ShieldHarnessFactory:
         harness.shield.dns = harness.dns
         harness.shield.profiles = harness.profiles
         harness.shield.ruleset = harness.ruleset
+        harness.shield.hub_events = harness.hub_events
         harness.shield._mode = harness.mode
         return harness
 
@@ -78,6 +82,7 @@ def test_shield_default_collaborators(_find: mock.Mock, tmp_path: Path) -> None:
     assert shield.dns is not None
     assert shield.profiles is not None
     assert shield.ruleset is not None
+    assert shield.hub_events is not None
 
 
 def test_shield_uses_injected_collaborators(tmp_path: Path) -> None:
@@ -87,6 +92,7 @@ def test_shield_uses_injected_collaborators(tmp_path: Path) -> None:
     dns = mock.MagicMock()
     profiles = mock.MagicMock()
     ruleset = mock.MagicMock()
+    hub_events = mock.MagicMock()
 
     shield = Shield(
         ShieldConfig(state_dir=tmp_path),
@@ -95,6 +101,7 @@ def test_shield_uses_injected_collaborators(tmp_path: Path) -> None:
         dns=dns,
         profiles=profiles,
         ruleset=ruleset,
+        hub_events=hub_events,
     )
 
     assert shield.runner is runner
@@ -102,6 +109,7 @@ def test_shield_uses_injected_collaborators(tmp_path: Path) -> None:
     assert shield.dns is dns
     assert shield.profiles is profiles
     assert shield.ruleset is ruleset
+    assert shield.hub_events is hub_events
 
 
 def test_create_mode_rejects_unsupported_value(
@@ -240,21 +248,23 @@ def test_down_delegates_and_logs(
     allow_all: bool,
     expected_detail: str | None,
 ) -> None:
-    """down() delegates to the backend and records the right audit detail."""
+    """down() delegates to the backend, logs, and pings the hub."""
     harness = make_shield()
     harness.shield.down("test-ctr", allow_all=allow_all)
     harness.mode.shield_down.assert_called_once_with("test-ctr", allow_all=allow_all)
     harness.audit.log_event.assert_called_once_with(
         "test-ctr", "shield_down", detail=expected_detail
     )
+    harness.hub_events.shield_down.assert_called_once_with("test-ctr", allow_all=allow_all)
 
 
 def test_up_delegates_and_logs(make_shield: ShieldHarnessFactory) -> None:
-    """up() delegates to the backend and logs the transition."""
+    """up() delegates to the backend, logs, and pings the hub."""
     harness = make_shield()
     harness.shield.up("test-ctr")
     harness.mode.shield_up.assert_called_once_with("test-ctr")
     harness.audit.log_event.assert_called_once_with("test-ctr", "shield_up")
+    harness.hub_events.shield_up.assert_called_once_with("test-ctr")
 
 
 def test_block_delegates_and_logs(make_shield: ShieldHarnessFactory) -> None:


### PR DESCRIPTION
## Summary

- Manual `terok-shield up|down|down --all <ctr>` now pings the terok-dbus hub's unix ingester with a one-line JSON event (`shield_up`, `shield_down`, or `shield_down_all`).
- The emitter is fail-silent — a missing hub never blocks a state-change CLI command — and reuses the wire format already used by the NFLOG reader so the hub's event catalog stays the single update point.
- Pairs with terok-dbus `feat/shield-state-signals` which translates the events into `org.terok.Shield1.Shield{Up,Down,DownAll}` D-Bus signals so desktop/TUI consumers can close stale block notifications when shield is bypassed.

## Test plan

- [x] `make check` green (lint, unit, tach, docstrings, reuse, security)
- [ ] End-to-end smoke with terok-dbus PR merged: `terok-shield down <ctr>` closes pending desktop notifications for that container

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shield can optionally emit lightweight state-change events (up/down) to external listeners; emissions are best-effort and non-blocking.

* **Documentation**
  * Behavior and testing guidance for the optional event emitter are documented.

* **Tests**
  * Added end-to-end and unit tests covering event emission, socket delivery, fallbacks, and silent-failure behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->