### PR TITLE
docs: refresh terok-dbus → terok-clearance references

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.poetry]
 name = "terok-shield"
-version = "0.6.27"
+version = "0.6.28"
 description = "nftables-based egress firewalling for Podman containers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/terok_shield/__init__.py
+++ b/src/terok_shield/__init__.py
@@ -182,7 +182,7 @@ class Shield:
             profiles: Profile loader (default: from config.profiles_dir).
             ruleset: Ruleset builder (default: from config loopback_ports).
             hub_events: Best-effort emitter for ``shield_up`` / ``shield_down``
-                events bound for the terok-dbus hub (default: a fresh
+                events bound for the terok-clearance hub (default: a fresh
                 :class:`HubEventEmitter` pointed at the canonical socket).
                 Pass a no-op stub in tests that should not touch the socket.
         """

--- a/src/terok_shield/_hub_events.py
+++ b/src/terok_shield/_hub_events.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
-"""Best-effort JSON event emitter for the terok-dbus hub.
+"""Best-effort JSON event emitter for the terok-clearance hub.
 
 Shield CLI calls (``up``/``down``) notify the hub so desktop/TUI consumers
 can reflect the state change — in particular, the hub closes pending

--- a/src/terok_shield/resources/nflog_reader.py
+++ b/src/terok_shield/resources/nflog_reader.py
@@ -10,7 +10,7 @@ an event.  Events always travel as JSON; the reader itself never speaks
 D-Bus.  Two destinations are supported:
 
 * ``--emit=socket`` (default): write events to a unix socket served by the
-  ``terok-dbus`` hub.  The hub lives in the *host* user namespace, where
+  ``terok-clearance`` hub.  The hub lives in the *host* user namespace, where
   it can emit the matching ``org.terok.Shield1`` signals onto the session
   bus.  The reader itself is stuck inside ``NS_ROOTLESS`` (that's where
   the container netns lives) and the session ``dbus-daemon`` rejects its
@@ -137,7 +137,7 @@ def _select_emitter(mode: str) -> EventEmitter:
 
 
 def _events_socket_path() -> Path:
-    """Return the canonical hub-ingester socket path (mirrors ``terok_dbus``)."""
+    """Return the canonical hub-ingester socket path (mirrors ``terok_clearance``)."""
     xdg = os.environ.get("XDG_RUNTIME_DIR") or f"/run/user/{os.getuid()}"
     return Path(xdg) / "terok-shield-events.sock"
 

--- a/tach.toml
+++ b/tach.toml
@@ -67,7 +67,7 @@ path = "terok_shield.run"
 layer = "foundation"
 depends_on = []
 
-# Hub event emitter — stdlib-only client for the terok-dbus unix ingester
+# Hub event emitter — stdlib-only client for the terok-clearance unix ingester
 [[modules]]
 path = "terok_shield._hub_events"
 layer = "foundation"


### PR DESCRIPTION
## Summary

Docs-only refresh of the shield side for the package rename
(terok-ai/terok-dbus#62).  Every occurrence of the old package name
in docstrings and comments updated to the new name.

## Intentionally preserved

- ``simple_clearance.py``: ``systemctl --user stop terok-dbus`` in the
  hub-liveness refusal message — that's the systemd unit name, and the
  unit stays ``terok-dbus.service`` until terok-ai/terok-dbus#48 splits
  the hub / verdict-helper.

## Companion PRs

- terok-ai/terok-dbus#62 — the actual rename.
- terok-ai/terok#795 — consumer-side imports + dependency pin.

## Test plan

- [x] ``make check`` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped package version to 0.6.28

* **Documentation**
  * Updated documentation references to reflect hub configuration changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->