### PR TITLE
fix(simple-clearance): point stop-hub hint at renamed unit

### DIFF
--- a/src/terok_shield/cli/simple_clearance.py
+++ b/src/terok_shield/cli/simple_clearance.py
@@ -51,7 +51,7 @@ def run_simple_clearance(state_dir: Path, container: str) -> None:
         print(
             "D-Bus hub (org.terok.Shield1) is active — use a D-Bus clearance "
             "client (desktop notifier or TUI).  To use this terminal fallback, "
-            "stop the hub first:  systemctl --user stop terok-dbus",
+            "stop the hub first:  systemctl --user stop terok-clearance-hub",
             file=sys.stderr,
         )
         raise SystemExit(1)


### PR DESCRIPTION
## Summary

- `terok-clearance` #65 renames `terok-dbus.service` → `terok-clearance-hub.service` (plus a new sidecar `terok-clearance-verdict.service` for the unhardened shield exec).
- The hint `terok-shield simple-clearance` prints when the hub is active still told operators to run `systemctl --user stop terok-dbus` — the suggested command no longer works once the clearance release lands.
- One-line string update; no behaviour change otherwise.

The rest of the guard (`_dbus_hub_active()` and the "D-Bus hub" wording) is stale for independent reasons — the hub migrated to varlink over a unix socket some time ago — but that's a wider refactor I'll handle separately. This PR is the minimal nomenclature fix that keeps the printed remediation command correct.

## Test plan

- [x] `make check` passes locally (lint + tests + tach + docstrings + reuse + security).
- [ ] Visual verification: once terok-clearance #65 is released and both `terok-clearance-hub.service` + `terok-clearance-verdict.service` are installed, `terok-shield simple-clearance <container>` prints the correct `systemctl --user stop terok-clearance-hub` hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected error message in terminal fallback mode to direct operators to the correct systemd unit that needs to be stopped when D-Bus hub is active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->