### PR TITLE
chore: release 0.6.29 Shield User Circuit Routing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.poetry]
 name = "terok-shield"
-version = "0.6.28"
+version = "0.6.29"
 description = "nftables-based egress firewalling for Podman containers"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
Automated release bump to v0.6.29.