### PR TITLE
docs: drop README Documentation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,13 +111,6 @@ terok-shield allow my-container example.com
 terok-shield deny my-container example.com   # revoke later
 ```
 
-## Documentation
-
-- **[User Guide](https://terok-ai.github.io/terok-shield/guide/)** —
-  getting started, allowlist profiles, firewall modes, CLI reference
-- **[Developer Guide](https://terok-ai.github.io/terok-shield/developer/)** —
-  contributing, security model, architecture
-
 ## License
 
 Apache-2.0 — see [LICENSES/Apache-2.0.txt](LICENSES/Apache-2.0.txt).


### PR DESCRIPTION
## Summary

Remove the **Documentation** section from `README.md`.  The deeper
docs are being audited; don't advertise them loudly until that pass
completes.

## Test plan

- [x] Doc-only change.
- [ ] CI green (lint, reuse, docstrings, tach).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the "Documentation" section from the README that previously provided links to the User Guide and Developer Guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->