### PR TITLE
feat(reader): audit blocked connections to state_dir/audit.jsonl

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.poetry]
 name = "terok-shield"
-version = "0.6.33"
+version = "0.6.34"
 description = "nftables-based egress firewalling for Podman containers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/terok_shield/resources/hook_entrypoint.py
+++ b/src/terok_shield/resources/hook_entrypoint.py
@@ -44,7 +44,7 @@ from pathlib import Path
 # (``reader.log`` is bridge-local — no state.py counterpart.)
 _ANN_STATE_DIR = "terok.shield.state_dir"
 _ANN_VERSION = "terok.shield.version"
-_BUNDLE_VERSION = 9
+_BUNDLE_VERSION = 10
 _TABLE = "inet terok_shield"
 _RULESET_NAME = "ruleset.nft"
 _DNSMASQ_CONF_NAME = "dnsmasq.conf"

--- a/src/terok_shield/resources/nflog_reader.py
+++ b/src/terok_shield/resources/nflog_reader.py
@@ -270,7 +270,20 @@ class ReaderSession:
         self._container = container
         self._emitter = emitter
         self._domain_cache = _DomainCache(state_dir)
+        # Two independent dedup windows, both keyed on (domain or dest):
+        #
+        # * ``_last_emit`` rate-limits *wire* delivery — only updated when
+        #   the hub accepts the event, so a hub-down period leaves the
+        #   key un-marked and the next NFLOG packet retries the emit.
+        # * ``_last_audit`` rate-limits *audit-log* writes — updated when
+        #   the JSONL append succeeds, so a hub outage doesn't flood
+        #   ``audit.jsonl`` with one entry per TCP-retransmit.
+        #
+        # Splitting them is what keeps the audit-volume bound honest
+        # ("one entry per (container, dest) per ``_DEDUP_WINDOW_S``")
+        # without giving up the wire's retry-on-failure semantics.
         self._last_emit: dict[str, float] = {}
+        self._last_audit: dict[str, float] = {}
         self._next_id = 1
         self._stop_requested = False
 
@@ -306,21 +319,38 @@ class ReaderSession:
     def _maybe_emit(self, event: _RawBlockEvent, now: float) -> None:
         """Filter noise, dedupe by domain-or-dest, emit if fresh.
 
-        The dedup key is only mutated once the emit actually reaches
-        the hub.  Marking before the emit would poison the 30-s window
-        when the write fails (hub restarted, socket unreachable, …),
-        silently suppressing retries even though the operator never
-        saw a popup for the first attempt.
+        The wire dedup key (``_last_emit``) is only mutated once the
+        emit actually reaches the hub.  Marking before the emit would
+        poison the 30-s window when the write fails (hub restarted,
+        socket unreachable, …), silently suppressing retries even
+        though the operator never saw a popup for the first attempt.
+
+        Audit dedup is independent (``_last_audit``): it's marked
+        whenever the JSONL append succeeds, regardless of whether the
+        wire emit lands.  Without this split, a hub outage would
+        re-trigger ``_emit_connection_blocked`` every NFLOG packet
+        (because ``_last_emit`` stays unmarked), and *each* of those
+        retries would currently re-write the same ``"blocked"`` line
+        to ``audit.jsonl`` — flooding the forensic log during the
+        very window where it's least helpful.
         """
         if _is_noise_dest(event.dest):
             return
         domain = self._resolve_domain(event.dest)
         dedup_key = domain or event.dest
-        last = self._last_emit.get(dedup_key)
-        if last is not None and now - last < self._DEDUP_WINDOW_S:
+        last_emit = self._last_emit.get(dedup_key)
+        last_audit = self._last_audit.get(dedup_key)
+        emit_fresh = last_emit is None or (now - last_emit) >= self._DEDUP_WINDOW_S
+        audit_fresh = last_audit is None or (now - last_audit) >= self._DEDUP_WINDOW_S
+        if not emit_fresh and not audit_fresh:
             return
-        if self._emit_connection_blocked(event, domain):
-            self._last_emit[dedup_key] = now
+        if audit_fresh and self._append_audit_block(event, domain):
+            self._last_audit[dedup_key] = now
+        if emit_fresh:
+            request_id = f"{self._container}:{self._next_id}"
+            self._next_id += 1
+            if self._emit_connection_blocked(event, domain, request_id):
+                self._last_emit[dedup_key] = now
 
     def _resolve_domain(self, dest: str) -> str:
         """Look *dest* up in the domain cache, refreshing once on miss."""
@@ -330,24 +360,18 @@ class ReaderSession:
             domain = self._domain_cache.lookup(dest)
         return domain
 
-    def _emit_connection_blocked(self, event: _RawBlockEvent, domain: str) -> bool:
+    def _emit_connection_blocked(self, event: _RawBlockEvent, domain: str, request_id: str) -> bool:
         """Publish one ``ConnectionBlocked`` for *event* — caller supplies the domain.
 
-        Audits the block to ``state_dir/audit.jsonl`` *before* the wire
-        emit so a hub-down or socket-rejected event is still recorded
-        forensically.  Auditing should be terminal-end, not best-effort
-        — the per-container forensic log is the single ground-truth
-        timeline of what shield decided and what the operator
-        subsequently said about it (verdict entries are written by the
-        host-side ``terok-shield allow|deny`` path).
+        Audit-vs-wire dedup is split: ``_maybe_emit`` decides
+        independently whether each side should fire and tracks them
+        in separate windows (``_last_audit`` / ``_last_emit``).  This
+        method handles only the wire half.
 
         Returns ``True`` when the emitter accepted the event; ``False``
         when it was dropped (socket emitter: hub unreachable).  Callers
-        use the result to decide whether to mark the dedup window.
+        use the result to decide whether to mark the wire dedup window.
         """
-        request_id = f"{self._container}:{self._next_id}"
-        self._next_id += 1
-        self._append_audit_block(event, domain)
         return self._emitter.connection_blocked(
             BlockedEvent(
                 container=self._container,
@@ -359,7 +383,7 @@ class ReaderSession:
             )
         )
 
-    def _append_audit_block(self, event: _RawBlockEvent, domain: str) -> None:
+    def _append_audit_block(self, event: _RawBlockEvent, domain: str) -> bool:
         """Write one ``"action": "blocked"`` entry to ``state_dir/audit.jsonl``.
 
         Inlined (rather than importing ``terok_shield.audit.AuditLogger``)
@@ -370,9 +394,13 @@ class ReaderSession:
         for short JSON lines (atomic up to PIPE_BUF on Linux), so the
         timeline interleaves cleanly without locks.
 
-        Soft-fail on every error: an unwriteable audit log must not
-        break the wire emit, since the wire is the operator's
-        immediate signal and the audit is the long-term record.
+        Returns ``True`` on a successful append, ``False`` on any
+        ``OSError``.  Soft-fail behaviour is preserved (callers do
+        nothing on a ``False`` return), but the failure is logged at
+        ``WARNING`` so a sudden silence in ``audit.jsonl`` doesn't
+        disappear into DEBUG noise on a host where the default log
+        level is INFO — see ``terok_shield.audit.AuditLogger``'s
+        host-side path for the same posture.
         """
         entry = {
             "ts": datetime.now(UTC).isoformat(timespec="seconds"),
@@ -390,7 +418,9 @@ class ReaderSession:
             with path.open("a", encoding="utf-8") as f:
                 f.write(line)
         except OSError as exc:
-            _log.debug("audit append failed (%s): %s", path, exc)
+            _log.warning("audit append failed (%s): %s", path, exc)
+            return False
+        return True
 
     def _install_signal_handlers(self) -> None:
         """Arrange a clean shutdown on SIGTERM / SIGINT."""

--- a/src/terok_shield/resources/nflog_reader.py
+++ b/src/terok_shield/resources/nflog_reader.py
@@ -80,6 +80,11 @@ _AF_INET = 2
 _IPPROTO_TCP = 6
 _IPPROTO_UDP = 17
 
+#: Human-readable protocol names for audit entries.  Numeric IP protocol
+#: numbers leak in for anything outside TCP/UDP — rare in practice (ICMP
+#: is suppressed earlier as noise) but better than a misleading "tcp" label.
+_PROTO_NAMES: dict[int, str] = {_IPPROTO_TCP: "tcp", _IPPROTO_UDP: "udp"}
+
 _NLMSG_HDR = struct.Struct("=IHHII")
 _NFGEN_HDR = struct.Struct("=BBH")
 _NFULNL_CFG_CMD = struct.Struct("=BBH")
@@ -328,12 +333,21 @@ class ReaderSession:
     def _emit_connection_blocked(self, event: _RawBlockEvent, domain: str) -> bool:
         """Publish one ``ConnectionBlocked`` for *event* — caller supplies the domain.
 
+        Audits the block to ``state_dir/audit.jsonl`` *before* the wire
+        emit so a hub-down or socket-rejected event is still recorded
+        forensically.  Auditing should be terminal-end, not best-effort
+        — the per-container forensic log is the single ground-truth
+        timeline of what shield decided and what the operator
+        subsequently said about it (verdict entries are written by the
+        host-side ``terok-shield allow|deny`` path).
+
         Returns ``True`` when the emitter accepted the event; ``False``
         when it was dropped (socket emitter: hub unreachable).  Callers
         use the result to decide whether to mark the dedup window.
         """
         request_id = f"{self._container}:{self._next_id}"
         self._next_id += 1
+        self._append_audit_block(event, domain)
         return self._emitter.connection_blocked(
             BlockedEvent(
                 container=self._container,
@@ -344,6 +358,39 @@ class ReaderSession:
                 domain=domain,
             )
         )
+
+    def _append_audit_block(self, event: _RawBlockEvent, domain: str) -> None:
+        """Write one ``"action": "blocked"`` entry to ``state_dir/audit.jsonl``.
+
+        Inlined (rather than importing ``terok_shield.audit.AuditLogger``)
+        because the reader script is shipped as a stdlib-only resource —
+        keeping the dependency surface flat preserves the
+        ``/usr/bin/python3``-can-run-it invariant.  Concurrent appends
+        with the host-side shield's own ``log_event`` writer are safe
+        for short JSON lines (atomic up to PIPE_BUF on Linux), so the
+        timeline interleaves cleanly without locks.
+
+        Soft-fail on every error: an unwriteable audit log must not
+        break the wire emit, since the wire is the operator's
+        immediate signal and the audit is the long-term record.
+        """
+        entry = {
+            "ts": datetime.now(UTC).isoformat(timespec="seconds"),
+            "container": self._container,
+            "action": "blocked",
+            "dest": event.dest,
+            "port": event.port,
+            "proto": _PROTO_NAMES.get(event.proto, str(event.proto)),
+        }
+        if domain:
+            entry["domain"] = domain
+        line = json.dumps(entry, separators=(",", ":")) + "\n"
+        path = self._state_dir / "audit.jsonl"
+        try:
+            with path.open("a", encoding="utf-8") as f:
+                f.write(line)
+        except OSError as exc:
+            _log.debug("audit append failed (%s): %s", path, exc)
 
     def _install_signal_handlers(self) -> None:
         """Arrange a clean shutdown on SIGTERM / SIGINT."""

--- a/src/terok_shield/state.py
+++ b/src/terok_shield/state.py
@@ -37,7 +37,7 @@ from pathlib import Path
 
 from .paths import HOOK_ENTRYPOINT_NAME
 
-BUNDLE_VERSION = 9
+BUNDLE_VERSION = 10
 """Integer version of the state bundle layout.
 
 Bumped whenever the file layout changes in a backwards-incompatible way.
@@ -48,6 +48,11 @@ changes even if the file layout itself is unchanged, so that
 ``terok setup`` rewrites the script instead of short-circuiting.
 
 Version history:
+    10 — reader appends ``"action": "blocked"`` entries to
+        ``audit.jsonl`` before each wire emit, closing the
+        block→verdict timeline gap (verdicts were already audited
+        by the host-side ``allow``/``deny`` path; blocks were not).
+        Same on-disk layout; new action keyword in an existing file.
     9 — pre_start on dnsmasq tier seeds profile.allowed with resolved
         domains so the initial allow set has permanent entries before
         dnsmasq starts.  Reader swaps lifetime-dedup for a 30 s rolling

--- a/tests/unit/test_hook_entrypoint.py
+++ b/tests/unit/test_hook_entrypoint.py
@@ -23,7 +23,7 @@ from terok_shield.resources import hook_entrypoint
 def _oci_json(
     pid: int = 42,
     state_dir: str = "/tmp/sd",
-    version: int = 9,
+    version: int = 10,
     container_id: str = "abc123def456789abcdef0123456789abcdef0123456789abcdef0123456789a",
 ) -> str:
     """Return a minimal OCI state JSON for hook_entrypoint.main()."""
@@ -575,7 +575,7 @@ def _run_main(json_str: str, *, stage: str = "createRuntime") -> int:
             id="annotations-not-dict",
         ),
         pytest.param(
-            json.dumps({"pid": 42, "annotations": {"terok.shield.version": "9"}}),
+            json.dumps({"pid": 42, "annotations": {"terok.shield.version": "10"}}),
             id="state-dir-missing",
         ),
         pytest.param(
@@ -604,7 +604,7 @@ def test_main_returns_1_when_pid_missing_for_createruntime(tmp_path: Path) -> No
             "pid": 0,
             "annotations": {
                 "terok.shield.state_dir": str(tmp_path),
-                "terok.shield.version": "9",
+                "terok.shield.version": "10",
             },
         }
     )
@@ -706,7 +706,7 @@ def test_main_returns_1_for_relative_state_dir() -> None:
             "pid": 42,
             "annotations": {
                 "terok.shield.state_dir": "relative/path",
-                "terok.shield.version": "9",
+                "terok.shield.version": "10",
             },
         }
     )

--- a/tests/unit/test_hook_entrypoint_bridge.py
+++ b/tests/unit/test_hook_entrypoint_bridge.py
@@ -41,7 +41,7 @@ def _oci_json(state_dir: str, container_id: str = _CONTAINER_ID) -> str:
             "pid": 42,
             "annotations": {
                 "terok.shield.state_dir": state_dir,
-                "terok.shield.version": "9",
+                "terok.shield.version": "10",
             },
         }
     )
@@ -100,7 +100,7 @@ class TestBridgeDispatch:
                 "pid": 42,
                 "annotations": {
                     "terok.shield.state_dir": str(tmp_path),
-                    "terok.shield.version": "9",
+                    "terok.shield.version": "10",
                 },
             }
         )

--- a/tests/unit/test_nflog_reader.py
+++ b/tests/unit/test_nflog_reader.py
@@ -21,7 +21,7 @@ import pytest
 
 from terok_shield.resources import nflog_reader as reader
 
-from ..testfs import DNSMASQ_LOG_FILENAME, READER_EVENTS_SOCK_FILENAME
+from ..testfs import AUDIT_FILENAME, DNSMASQ_LOG_FILENAME, READER_EVENTS_SOCK_FILENAME
 from ..testnet import (
     IPV6_MCAST_ALL_ROUTERS,
     IPV6_MCAST_MLDV2,
@@ -670,7 +670,7 @@ class TestAuditBlockAppend:
         raw = reader._RawBlockEvent(dest=TEST_IP1, port=443, proto=socket.IPPROTO_TCP)
         session._maybe_emit(raw, now=0.0)
 
-        audit_path = tmp_path / "audit.jsonl"
+        audit_path = tmp_path / AUDIT_FILENAME
         assert audit_path.is_file()
         entries = [json.loads(line) for line in audit_path.read_text().splitlines()]
         assert len(entries) == 1
@@ -693,7 +693,9 @@ class TestAuditBlockAppend:
         raw = reader._RawBlockEvent(dest=TEST_IP1, port=443, proto=socket.IPPROTO_TCP)
         session._maybe_emit(raw, now=0.0)
 
-        entries = [json.loads(line) for line in (tmp_path / "audit.jsonl").read_text().splitlines()]
+        entries = [
+            json.loads(line) for line in (tmp_path / AUDIT_FILENAME).read_text().splitlines()
+        ]
         assert entries[0]["domain"] == TEST_DOMAIN
 
     def test_audit_omits_domain_when_unresolved(self, tmp_path: Path) -> None:
@@ -703,7 +705,7 @@ class TestAuditBlockAppend:
         raw = reader._RawBlockEvent(dest=TEST_IP1, port=443, proto=socket.IPPROTO_TCP)
         session._maybe_emit(raw, now=0.0)
 
-        entry = json.loads((tmp_path / "audit.jsonl").read_text().splitlines()[0])
+        entry = json.loads((tmp_path / AUDIT_FILENAME).read_text().splitlines()[0])
         assert "domain" not in entry
 
     def test_audit_written_before_wire_emit(self, tmp_path: Path) -> None:
@@ -727,7 +729,7 @@ class TestAuditBlockAppend:
         raw = reader._RawBlockEvent(dest=TEST_IP1, port=443, proto=socket.IPPROTO_TCP)
         session._maybe_emit(raw, now=0.0)
 
-        audit_path = tmp_path / "audit.jsonl"
+        audit_path = tmp_path / AUDIT_FILENAME
         assert audit_path.is_file()
         assert "blocked" in audit_path.read_text()
 
@@ -735,7 +737,7 @@ class TestAuditBlockAppend:
         """Unwriteable audit log soft-fails — the wire emit must still happen."""
         recorder = _RecordingEmitter()
         # Make the audit write impossible by replacing audit.jsonl with a directory.
-        (tmp_path / "audit.jsonl").mkdir()
+        (tmp_path / AUDIT_FILENAME).mkdir()
 
         session = reader.ReaderSession(state_dir=tmp_path, container="c1", emitter=recorder)
         raw = reader._RawBlockEvent(dest=TEST_IP1, port=443, proto=socket.IPPROTO_TCP)
@@ -752,8 +754,41 @@ class TestAuditBlockAppend:
         raw = reader._RawBlockEvent(dest=TEST_IP1, port=0, proto=132)  # SCTP
         session._maybe_emit(raw, now=0.0)
 
-        entry = json.loads((tmp_path / "audit.jsonl").read_text().splitlines()[0])
+        entry = json.loads((tmp_path / AUDIT_FILENAME).read_text().splitlines()[0])
         assert entry["proto"] == "132"
+
+    def test_hub_outage_does_not_flood_audit_log(self, tmp_path: Path) -> None:
+        """Repeated retries during a hub outage produce one audit line per dedup window.
+
+        Without separate audit/wire dedup tracking, a hub-down scenario
+        would re-trigger ``_emit_connection_blocked`` on every NFLOG
+        packet (because ``_last_emit`` stays unmarked while the wire
+        keeps failing) and *each* of those retries would re-write the
+        same ``"blocked"`` line — flooding the forensic log during the
+        very window where it's least helpful.  ``_last_audit`` is the
+        knob that prevents that without giving up wire-side retries.
+        """
+
+        class _AlwaysFailingEmitter:
+            def container_started(self, container: str) -> None: ...
+            def container_exited(self, container: str, *, reason: str) -> None: ...
+            def close(self) -> None: ...
+
+            def connection_blocked(self, event: reader.BlockedEvent) -> bool:
+                return False
+
+        emitter = _AlwaysFailingEmitter()
+        session = reader.ReaderSession(state_dir=tmp_path, container="c1", emitter=emitter)
+        raw = reader._RawBlockEvent(dest=TEST_IP1, port=443, proto=socket.IPPROTO_TCP)
+        # Five NFLOG packets within the same dedup window — TCP retries.
+        for t in (0.0, 1.0, 2.0, 5.0, 10.0):
+            session._maybe_emit(raw, now=t)
+
+        lines = (tmp_path / AUDIT_FILENAME).read_text().splitlines()
+        assert len(lines) == 1, (
+            "audit-log dedup window must collapse retry storms to one entry; "
+            f"got {len(lines)} entries"
+        )
 
 
 class _FakeSocket:

--- a/tests/unit/test_nflog_reader.py
+++ b/tests/unit/test_nflog_reader.py
@@ -655,6 +655,107 @@ class TestReaderSession:
         assert {e.dest for e in blocked_events} == {TEST_IP1, TEST_IP99}
 
 
+class TestAuditBlockAppend:
+    """Reader writes ``"action": "blocked"`` to ``state_dir/audit.jsonl`` per emit.
+
+    Closes the audit-trail asymmetry: lifecycle (``shield_up`` /
+    ``shield_down``) and verdicts (``allowed`` / ``denied``) were
+    already audited by host-side shield code; blocks were not, leaving
+    the timeline missing the very events that triggered every verdict.
+    """
+
+    def test_block_writes_audit_line_with_expected_shape(self, tmp_path: Path) -> None:
+        recorder = _RecordingEmitter()
+        session = reader.ReaderSession(state_dir=tmp_path, container="c1", emitter=recorder)
+        raw = reader._RawBlockEvent(dest=TEST_IP1, port=443, proto=socket.IPPROTO_TCP)
+        session._maybe_emit(raw, now=0.0)
+
+        audit_path = tmp_path / "audit.jsonl"
+        assert audit_path.is_file()
+        entries = [json.loads(line) for line in audit_path.read_text().splitlines()]
+        assert len(entries) == 1
+        entry = entries[0]
+        assert entry["action"] == "blocked"
+        assert entry["container"] == "c1"
+        assert entry["dest"] == TEST_IP1
+        assert entry["port"] == 443
+        assert entry["proto"] == "tcp"
+        assert "ts" in entry  # don't pin timestamp content; just ensure presence
+
+    def test_audit_includes_domain_when_resolved(self, tmp_path: Path) -> None:
+        """Resolved domain ends up in the audit entry alongside dest IP."""
+        # Seed the dnsmasq log so DomainCache resolves TEST_IP1 → TEST_DOMAIN.
+        log_path = tmp_path / DNSMASQ_LOG_FILENAME
+        log_path.write_text(f"... reply {TEST_DOMAIN} is {TEST_IP1}\n")
+
+        recorder = _RecordingEmitter()
+        session = reader.ReaderSession(state_dir=tmp_path, container="c1", emitter=recorder)
+        raw = reader._RawBlockEvent(dest=TEST_IP1, port=443, proto=socket.IPPROTO_TCP)
+        session._maybe_emit(raw, now=0.0)
+
+        entries = [json.loads(line) for line in (tmp_path / "audit.jsonl").read_text().splitlines()]
+        assert entries[0]["domain"] == TEST_DOMAIN
+
+    def test_audit_omits_domain_when_unresolved(self, tmp_path: Path) -> None:
+        """No resolved domain → no ``domain`` key in the audit entry (vs. empty string)."""
+        recorder = _RecordingEmitter()
+        session = reader.ReaderSession(state_dir=tmp_path, container="c1", emitter=recorder)
+        raw = reader._RawBlockEvent(dest=TEST_IP1, port=443, proto=socket.IPPROTO_TCP)
+        session._maybe_emit(raw, now=0.0)
+
+        entry = json.loads((tmp_path / "audit.jsonl").read_text().splitlines()[0])
+        assert "domain" not in entry
+
+    def test_audit_written_before_wire_emit(self, tmp_path: Path) -> None:
+        """Hub down (emitter returns False) → audit entry is still recorded.
+
+        Auditing should be terminal-end, not best-effort: the operator
+        can lose a popup to a hub restart and still need the forensic
+        record of which destination got blocked when.
+        """
+
+        class _AlwaysFailingEmitter:
+            def container_started(self, container: str) -> None: ...
+            def container_exited(self, container: str, *, reason: str) -> None: ...
+            def close(self) -> None: ...
+
+            def connection_blocked(self, event: reader.BlockedEvent) -> bool:
+                return False  # hub unreachable
+
+        emitter = _AlwaysFailingEmitter()
+        session = reader.ReaderSession(state_dir=tmp_path, container="c1", emitter=emitter)
+        raw = reader._RawBlockEvent(dest=TEST_IP1, port=443, proto=socket.IPPROTO_TCP)
+        session._maybe_emit(raw, now=0.0)
+
+        audit_path = tmp_path / "audit.jsonl"
+        assert audit_path.is_file()
+        assert "blocked" in audit_path.read_text()
+
+    def test_audit_failure_does_not_break_wire_emit(self, tmp_path: Path) -> None:
+        """Unwriteable audit log soft-fails — the wire emit must still happen."""
+        recorder = _RecordingEmitter()
+        # Make the audit write impossible by replacing audit.jsonl with a directory.
+        (tmp_path / "audit.jsonl").mkdir()
+
+        session = reader.ReaderSession(state_dir=tmp_path, container="c1", emitter=recorder)
+        raw = reader._RawBlockEvent(dest=TEST_IP1, port=443, proto=socket.IPPROTO_TCP)
+        session._maybe_emit(raw, now=0.0)
+
+        # Wire still received the event despite audit failure.
+        kinds = [kind for kind, _ in recorder.calls]
+        assert "blocked" in kinds
+
+    def test_proto_falls_back_to_numeric_for_non_tcp_udp(self, tmp_path: Path) -> None:
+        """Anything other than TCP/UDP gets the numeric proto in the audit entry."""
+        recorder = _RecordingEmitter()
+        session = reader.ReaderSession(state_dir=tmp_path, container="c1", emitter=recorder)
+        raw = reader._RawBlockEvent(dest=TEST_IP1, port=0, proto=132)  # SCTP
+        session._maybe_emit(raw, now=0.0)
+
+        entry = json.loads((tmp_path / "audit.jsonl").read_text().splitlines()[0])
+        assert entry["proto"] == "132"
+
+
 class _FakeSocket:
     """Minimal file-like stand-in for the NFLOG netlink socket."""
 


### PR DESCRIPTION
## Summary

- NFLOG reader now appends a JSONL entry with `\"action\": \"blocked\"` to `state_dir/audit.jsonl` for every dedup-passing block — closes the audit-trail asymmetry where lifecycle (`shield_up`/`shield_down`) and verdicts (`allowed`/`denied`) were already audited but the blocks that triggered every verdict were not.
- Audit append happens **before** the wire emit so a hub-down or socket-rejected event is still recorded forensically (auditing is terminal-end, not best-effort).
- Reader stays stdlib-only — JSONL append is inlined rather than importing `AuditLogger`, preserving the `/usr/bin/python3`-can-run-it invariant.
- `BUNDLE_VERSION` 9 → 10 (in both `state.py` and `resources/hook_entrypoint.py`).

## Why this matters

Reading `audit.jsonl` post-incident, operators saw \"shield came up, then five minutes later the operator allowed example.com\" with no record of the block in between — making blocks invisible until they manifested as approvals. The audit log was the natural place to look for the timeline; it just wasn't the place writing it. New entry shape:

```json
{\"ts\":\"…\",\"container\":\"…\",\"action\":\"blocked\",\"dest\":\"…\",\"port\":N,\"proto\":\"tcp\",\"domain\":\"…\"}
```

`domain` is omitted when not resolved; `proto` falls back to numeric for non-TCP/UDP.

## Concurrency / safety

Concurrent appends with the host-side `AuditLogger.log_event` are safe for short JSON lines on Linux (atomic up to PIPE_BUF), so the timeline interleaves cleanly without locks. The 30-second dedup window already collapses per-packet noise into per-`(container, dest)` events, so audit volume is bounded.

## Chain

Part of a four-PR chain wiring the shield→clearance bridge as a first-class integration phase:

1. terok-clearance#78 — docs: pluggability framing
2. **This PR** — audit blocks
3. terok-sandbox#NN — bridge install/uninstall as its own phase
4. terok#NN — pin all four siblings + remove uninstall workaround

Independent enough to ship on its own — the new audit lines are useful even before the bridge phase lands.

## Test plan

- [ ] `make lint` passes
- [ ] `make test-unit` passes (1077 tests)
- [ ] `make tach` boundaries clean
- [ ] `make docstrings`, `make reuse`, `make security` clean
- [ ] Six new tests cover shape, domain present/absent, audit-before-wire, audit-failure-doesn't-break-wire, non-TCP/UDP fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced audit logging for blocked connections: each blocked event now records protocol name (tcp/udp or numeric), destination, port, optional resolved domain, timestamp, and an explicit "blocked" action.
  * Audit and outbound event emissions are independently rate-limited to prevent missing or duplicate records during retries.

* **Chores**
  * State bundle version bumped to v10; runtime annotations must reflect the new version.

* **Tests**
  * Added and updated tests covering audit behavior and versioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->