### PR TITLE
fix(state): force state_dir mode to 0o700 to satisfy OCI hook validator

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.poetry]
 name = "terok-shield"
-version = "0.6.35"
+version = "0.6.36"
 description = "nftables-based egress firewalling for Podman containers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/terok_shield/state.py
+++ b/src/terok_shield/state.py
@@ -264,7 +264,28 @@ def read_effective_ips(state_dir: Path) -> list[str]:
 # ── Setup ───────────────────────────────────────────────
 
 
+STATE_DIR_MODE = 0o700
+"""Permission mode for ``state_dir`` and its subdirectories.
+
+Owner-only.  The OCI hook in ``_oci_state.py`` rejects ``state_dir`` if
+``st_mode & 0o022`` (group- or world-writable), because a loose mode
+would let any local peer drop a ``ruleset.nft`` for the hook to apply
+with ``CAP_NET_ADMIN``.  ``mkdir(mode=…)`` is masked by ``umask``, so
+the writer side has to ``chmod`` after creation to guarantee the bit
+pattern the validator demands.
+"""
+
+
 def ensure_state_dirs(state_dir: Path) -> None:
-    """Create the state directory and its required subdirectories."""
+    """Create the state directory and its required subdirectories.
+
+    Both directories are forced to ``STATE_DIR_MODE`` (``0o700``) on
+    every call — the OCI hook rejects anything looser, and a prior
+    run under a permissive ``umask`` (Fedora's default ``0o002`` is
+    a common offender) would otherwise leave the bundle stranded.
+    """
     state_dir.mkdir(parents=True, exist_ok=True)
-    hooks_dir(state_dir).mkdir(parents=True, exist_ok=True)
+    state_dir.chmod(STATE_DIR_MODE)
+    hd = hooks_dir(state_dir)
+    hd.mkdir(parents=True, exist_ok=True)
+    hd.chmod(STATE_DIR_MODE)

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -3,13 +3,16 @@
 
 """Tests for per-container state bundle layout (state.py)."""
 
-from collections.abc import Callable
+import os
+import stat
+from collections.abc import Callable, Iterator
 from pathlib import Path
 
 import pytest
 
 from terok_shield.state import (
     BUNDLE_VERSION,
+    STATE_DIR_MODE,
     audit_path,
     container_id_path,
     denied_domains_path,
@@ -108,6 +111,60 @@ def test_ensure_state_dirs_is_idempotent(tmp_path: Path) -> None:
     ensure_state_dirs(state_dir)
     ensure_state_dirs(state_dir)
     assert state_dir.is_dir()
+
+
+@pytest.fixture
+def loose_umask() -> Iterator[None]:
+    """Run the test body under ``umask 0o002`` (Fedora's USERGROUPS_ENAB default)."""
+    old = os.umask(0o002)
+    try:
+        yield
+    finally:
+        os.umask(old)
+
+
+def _mode(path: Path) -> int:
+    """Return permission bits of *path* (``st_mode & 0o7777``)."""
+    return stat.S_IMODE(path.stat().st_mode)
+
+
+def test_ensure_state_dirs_forces_owner_only_mode(
+    tmp_path: Path,
+    loose_umask: None,
+) -> None:
+    """Fresh dirs land at 0o700 even when the caller's umask would relax them.
+
+    Regression test for the v0.6.35 ``_oci_state`` validator rejecting
+    bundles created under ``umask 0o002`` (group-writable).  ``mkdir``
+    alone is umask-masked, so ``ensure_state_dirs`` must ``chmod``.
+    """
+    state_dir = tmp_path / "container-1"
+
+    ensure_state_dirs(state_dir)
+
+    assert _mode(state_dir) == STATE_DIR_MODE
+    assert _mode(hooks_dir(state_dir)) == STATE_DIR_MODE
+    # Validator-side invariant: no group/world write bits.
+    assert state_dir.stat().st_mode & 0o022 == 0
+    assert hooks_dir(state_dir).stat().st_mode & 0o022 == 0
+
+
+def test_ensure_state_dirs_repairs_loose_existing_mode(tmp_path: Path) -> None:
+    """A pre-existing too-permissive bundle is tightened on next call.
+
+    Users hit by v0.6.35 with a 0o775 dir from a prior 0.6.34 run
+    should recover automatically — no manual ``chmod`` required.
+    """
+    state_dir = tmp_path / "container-1"
+    state_dir.mkdir()
+    hooks_dir(state_dir).mkdir()
+    state_dir.chmod(0o775)
+    hooks_dir(state_dir).chmod(0o775)
+
+    ensure_state_dirs(state_dir)
+
+    assert _mode(state_dir) == STATE_DIR_MODE
+    assert _mode(hooks_dir(state_dir)) == STATE_DIR_MODE
 
 
 def test_read_denied_ips_empty_when_file_missing(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Fixes a checker/producer mismatch introduced in v0.6.35: the new OCI hook
validator in [`_oci_state.py:202`](https://github.com/terok-ai/terok-shield/blob/master/src/terok_shield/resources/_oci_state.py#L202)
rejects `state_dir` when `st_mode & 0o022` (group- or world-writable),
but `ensure_state_dirs` never tightened the producer side.  Under
Fedora's default `umask 0o002`, `mkdir()` lands the dir at `0o775`
and runc aborts container init with:

```
terok-shield hook: state_dir must not be group/world-writable
```

`ensure_state_dirs` now chmods both `state_dir` and its `hooks/`
subdirectory to a new `STATE_DIR_MODE = 0o700` constant on every
call.  Doing it unconditionally — rather than only on first
creation — also tightens any bundles that were left at `0o775` by
a prior 0.6.34 run, so users bitten by upgrading to 0.6.35 don't
have to `chmod` by hand.

## Root cause

- `Path.mkdir(mode=…)` is masked by `umask` (cf. POSIX `mkdir(2)`),
  so a default `0o755`/`0o700` argument has no force on hosts where
  the operator's umask is loose.
- The v0.6.35 hook validator was added without the corresponding
  writer-side enforcement — classic "checker stricter than the
  producer."

The pattern lives elsewhere in the ecosystem too — `terok` itself
chmods `WORKSPACE_DANGEROUS_DIRNAME` to `0o700` after `mkdir` for the
same reason.

## Test plan

- [x] `poetry run pytest tests/unit/test_state.py -v` — 30 passed (incl. 2 new regression tests)
- [x] `poetry run pytest tests/unit/` — 1142 passed
- [x] `poetry run ruff check . && poetry run ruff format --check .` — clean
- [x] `poetry run tach check` — clean
- [x] `poetry run docstr-coverage src/terok_shield/ --fail-under=95` — 100%
- [x] `poetry run bandit -r src/terok_shield/ -ll` — no medium/high findings
- [x] `poetry run reuse lint` — compliant

New regression tests cover:
- Fresh `state_dir` created under `umask 0o002` lands at `0o700` (the original bug)
- Pre-existing `0o775` bundle is tightened on the next call (recovery for users hit by v0.6.35)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed state directory permissions enforcement. State directories now consistently maintain proper restrictive permissions, ensuring security is not compromised by varying system configurations.

* **Chores**
  * Updated project version to 0.6.36.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->