### PR TITLE
ci(docs): let workflow_dispatch trigger Pages deploy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -68,7 +68,7 @@ jobs:
           path: site
 
   deploy:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    if: github.repository == 'terok-ai/terok-shield' && github.ref == 'refs/heads/master'
     needs: build
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary

The deploy job was gated on `github.event_name == 'push' && github.ref == 'refs/heads/master'`, which meant a manual "Run workflow" run built the site fine but **skipped** the deploy step. That's how the transient inventory race during the [mkdocs-terok 0.5.0](https://github.com/terok-ai/mkdocs-terok/releases/tag/v0.5.0) cross-repo bump left master stuck — the rerun had to use `gh run rerun` on the original `push` run, since `workflow_dispatch` couldn't deploy.

Mirror the pattern that [mkdocs-terok's own docs.yml](https://github.com/terok-ai/mkdocs-terok/blob/master/.github/workflows/docs.yml) uses:

```yaml
if: github.repository == 'terok-ai/<repo>' && github.ref == 'refs/heads/master'
```

This:

- still blocks deploys from fork PRs (the repo guard is stricter than event-name in the fork-vs-upstream case),
- still blocks deploys from PRs or non-master refs (ref guard),
- but allows `workflow_dispatch` on master to deploy, so future rebuild-races (whether from inventory propagation or anything else) can be unblocked with one click of "Run workflow" instead of `gh run rerun` on the original push run.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, "Run workflow" on master from the Actions tab triggers a build *and* a deploy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow configuration to enforce stricter conditions for documentation deployments to the master branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->