### PR TITLE
feat: producer-side wire-format sanitisation on container-out path

### DIFF
--- a/src/terok_shield/_hub_events.py
+++ b/src/terok_shield/_hub_events.py
@@ -22,6 +22,8 @@ import os
 import socket
 from pathlib import Path
 
+from terok_shield._wire_sanitize import sanitize, sanitize_mapping
+
 _log = logging.getLogger(__name__)
 
 _SOCKET_BASENAME = "terok-shield-events.sock"
@@ -83,10 +85,19 @@ class HubEventEmitter:
         keeps the wire identical to the pre-v12 shape on standalone
         containers (``podman run`` without orchestrator annotations),
         so old ingesters never see a key they don't understand.
+
+        Every string value is run through the producer-side sanitiser
+        (``WIRE_SPEC(safe-string)``) before serialisation so the wire
+        format invariant — printable ASCII, length-capped — holds at
+        the boundary the container actually crosses.  The clearance
+        hub re-applies the same rule on receive as belt-and-braces.
         """
+        sanitised: dict[str, object] = {
+            k: sanitize(v) if isinstance(v, str) else v for k, v in payload.items()
+        }
         if dossier:
-            payload = {**payload, "dossier": dossier}
-        line = (json.dumps(payload, separators=(",", ":")) + "\n").encode()
+            sanitised["dossier"] = sanitize_mapping(dossier)
+        line = (json.dumps(sanitised, separators=(",", ":")) + "\n").encode()
         try:
             sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
             sock.settimeout(_IO_TIMEOUT_S)

--- a/src/terok_shield/_wire_sanitize.py
+++ b/src/terok_shield/_wire_sanitize.py
@@ -49,12 +49,19 @@ _TRUNCATION_MARKER = "..."
 
 
 def sanitize(value: str, *, max_len: int = DEFAULT_MAX_LEN) -> str:
-    """Coerce *value* to printable ASCII, capped at *max_len* characters."""
+    """Coerce *value* to printable ASCII, capped at *max_len* characters.
+
+    When *max_len* is shorter than the truncation marker, the marker is
+    clipped so the post-condition ``len(result) <= max_len`` always
+    holds.
+    """
     if not value:
         return ""
     cleaned = "".join(ch if _PRINTABLE_LO <= ord(ch) <= _PRINTABLE_HI else " " for ch in value)
     if len(cleaned) <= max_len:
         return cleaned
+    if max_len <= len(_TRUNCATION_MARKER):
+        return _TRUNCATION_MARKER[:max_len]
     return cleaned[: max_len - len(_TRUNCATION_MARKER)] + _TRUNCATION_MARKER
 
 

--- a/src/terok_shield/_wire_sanitize.py
+++ b/src/terok_shield/_wire_sanitize.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Producer-side wire-format invariant — printable ASCII, length-capped.
+
+# WIRE_SPEC(safe-string): keep in sync with
+# terok_clearance/src/terok_clearance/wire/sanitize.py — same rule,
+# same character class, same length cap.  ``grep WIRE_SPEC`` finds
+# every copy across the producer/consumer boundary; clearance owns
+# the canonical version (it's the wire-format consumer).
+
+The threat model: container processes can craft DNS names, hostnames,
+or annotation bytes that flow through the shield's watchers and the
+NFLOG reader straight onto the hub socket.  A consumer downstream
+(notification daemon, terminal TUI, audit listener) sees those bytes
+verbatim unless someone trims them along the way.
+
+Sanitising at every emit point — here, in `_hub_events`, in the
+reader resource — is belt-and-braces: clearance also applies the
+same rule on the receive side, so a regression on either side keeps
+the contract.  Producer-side sanitisation specifically protects the
+container-out path that's the primary attack surface; consumer-side
+catches every other event source.
+
+Rule (single, simple):
+
+* Printable ASCII (``[\\x20, \\x7E]``) passes through unchanged.
+* Anything else — control bytes, non-ASCII, RTLO/LRO bidi overrides,
+  the lot — collapses to a single space, position-preserving.
+* Strings longer than ``max_len`` are truncated with a trailing
+  ``...`` ASCII marker.
+
+Stdlib-only by design — no external imports — so this module sits in
+the foundation tach layer alongside `_hub_events`.
+"""
+
+from __future__ import annotations
+
+#: Default per-value length cap.  Wide enough for any realistic
+#: hostname or task name; tighter caps suit titles or compact labels.
+DEFAULT_MAX_LEN = 256
+
+_PRINTABLE_LO = 0x20
+_PRINTABLE_HI = 0x7E
+
+#: Truncation marker — three ASCII dots rather than ``…`` (which is
+#: itself non-ASCII under the very rule this module enforces).
+_TRUNCATION_MARKER = "..."
+
+
+def sanitize(value: str, *, max_len: int = DEFAULT_MAX_LEN) -> str:
+    """Coerce *value* to printable ASCII, capped at *max_len* characters."""
+    if not value:
+        return ""
+    cleaned = "".join(ch if _PRINTABLE_LO <= ord(ch) <= _PRINTABLE_HI else " " for ch in value)
+    if len(cleaned) <= max_len:
+        return cleaned
+    return cleaned[: max_len - len(_TRUNCATION_MARKER)] + _TRUNCATION_MARKER
+
+
+def sanitize_mapping(mapping: dict[str, str], *, max_len: int = DEFAULT_MAX_LEN) -> dict[str, str]:
+    """Apply [`sanitize`][terok_shield._wire_sanitize.sanitize] to every value in *mapping*."""
+    return {k: sanitize(v, max_len=max_len) for k, v in mapping.items()}

--- a/src/terok_shield/resources/nflog_reader.py
+++ b/src/terok_shield/resources/nflog_reader.py
@@ -77,7 +77,12 @@ _SANITIZE_TRUNCATION = "..."
 
 
 def _sanitize_str(value: str, max_len: int = _SANITIZE_DEFAULT_MAX_LEN) -> str:
-    """Coerce *value* to printable ASCII, capped at *max_len* characters."""
+    """Coerce *value* to printable ASCII, capped at *max_len* characters.
+
+    Mirrors the canonical helper in ``terok_shield._wire_sanitize``;
+    when *max_len* is shorter than the truncation marker, the marker is
+    clipped so ``len(result) <= max_len`` always holds.
+    """
     if not value:
         return ""
     cleaned = "".join(
@@ -85,6 +90,8 @@ def _sanitize_str(value: str, max_len: int = _SANITIZE_DEFAULT_MAX_LEN) -> str:
     )
     if len(cleaned) <= max_len:
         return cleaned
+    if max_len <= len(_SANITIZE_TRUNCATION):
+        return _SANITIZE_TRUNCATION[:max_len]
     return cleaned[: max_len - len(_SANITIZE_TRUNCATION)] + _SANITIZE_TRUNCATION
 
 

--- a/src/terok_shield/resources/nflog_reader.py
+++ b/src/terok_shield/resources/nflog_reader.py
@@ -61,6 +61,38 @@ _log = logging.getLogger("terok-shield.nflog-reader")
 NFLOG_GROUP = 100
 _BLOCKED_PREFIX_TAG = "BLOCKED"
 
+
+# ── Wire-format sanitiser (producer side, container-out) ──────────────
+# WIRE_SPEC(safe-string): mirrored inline because this resource ships
+# stdlib-only and bypasses the terok-shield package.  Keep in sync with
+# terok_shield/_wire_sanitize.py and the canonical version at
+# terok_clearance/src/terok_clearance/wire/sanitize.py.  Same rule
+# everywhere: printable ASCII (``[\x20, \x7E]``) passes through, anything
+# else collapses to a space, length cap with a three-dot ASCII marker.
+
+_SANITIZE_DEFAULT_MAX_LEN = 256
+_SANITIZE_PRINTABLE_LO = 0x20
+_SANITIZE_PRINTABLE_HI = 0x7E
+_SANITIZE_TRUNCATION = "..."
+
+
+def _sanitize_str(value: str, max_len: int = _SANITIZE_DEFAULT_MAX_LEN) -> str:
+    """Coerce *value* to printable ASCII, capped at *max_len* characters."""
+    if not value:
+        return ""
+    cleaned = "".join(
+        ch if _SANITIZE_PRINTABLE_LO <= ord(ch) <= _SANITIZE_PRINTABLE_HI else " " for ch in value
+    )
+    if len(cleaned) <= max_len:
+        return cleaned
+    return cleaned[: max_len - len(_SANITIZE_TRUNCATION)] + _SANITIZE_TRUNCATION
+
+
+def _sanitize_dict(mapping: dict) -> dict:
+    """Apply `_sanitize_str` to every string value in *mapping*; pass others through."""
+    return {k: _sanitize_str(v) if isinstance(v, str) else v for k, v in mapping.items()}
+
+
 #: Reserved dossier key — the *orchestrator-side* path to the per-container
 #: meta JSON.  Read by the reader as plumbing; never appears on the wire or
 #: in the audit log.  ``_resolve_dossier`` strips it from any dict it merges.
@@ -504,16 +536,16 @@ class ReaderSession:
         """
         entry = {
             "ts": datetime.now(UTC).isoformat(timespec="seconds"),
-            "container": self._container,
+            "container": _sanitize_str(self._container),
             "action": "blocked",
-            "dest": event.dest,
+            "dest": _sanitize_str(event.dest),
             "port": event.port,
             "proto": _PROTO_NAMES.get(event.proto, str(event.proto)),
         }
         if domain:
-            entry["domain"] = domain
+            entry["domain"] = _sanitize_str(domain)
         if dossier:
-            entry["dossier"] = dossier
+            entry["dossier"] = _sanitize_dict(dossier)
         line = json.dumps(entry, separators=(",", ":")) + "\n"
         path = self._state_dir / "audit.jsonl"
         try:
@@ -546,25 +578,35 @@ class ReaderSession:
 
 def _started_payload(container: str) -> dict:
     """Build the wire payload for a ``container_started`` lifecycle event."""
-    return {"type": "container_started", "container": container}
+    return {"type": "container_started", "container": _sanitize_str(container)}
 
 
 def _exited_payload(container: str, reason: str) -> dict:
     """Build the wire payload for a ``container_exited`` lifecycle event."""
-    return {"type": "container_exited", "container": container, "reason": reason}
+    return {
+        "type": "container_exited",
+        "container": _sanitize_str(container),
+        "reason": _sanitize_str(reason),
+    }
 
 
 def _pending_payload(event: BlockedEvent) -> dict:
-    """Build the wire payload for a blocked-connection (``pending``) event."""
+    """Build the wire payload for a blocked-connection (``pending``) event.
+
+    Container-controlled bytes (``dest``, ``domain``) and orchestrator-supplied
+    dossier strings pass through ``_sanitize_*`` here — this is the producer
+    chokepoint for every reader-emitted event.  See ``WIRE_SPEC(safe-string)``
+    above the sanitiser block for the contract.
+    """
     return {
         "type": "pending",
-        "container": event.container,
-        "id": event.request_id,
-        "dest": event.dest,
+        "container": _sanitize_str(event.container),
+        "id": _sanitize_str(event.request_id),
+        "dest": _sanitize_str(event.dest),
         "port": event.port,
         "proto": event.proto,
-        "domain": event.domain,
-        "dossier": event.dossier,
+        "domain": _sanitize_str(event.domain),
+        "dossier": _sanitize_dict(event.dossier),
         "ts": datetime.now(UTC).isoformat(),
     }
 

--- a/src/terok_shield/watchers/_event.py
+++ b/src/terok_shield/watchers/_event.py
@@ -6,6 +6,8 @@
 import json
 from dataclasses import asdict, dataclass, field
 
+from terok_shield._wire_sanitize import sanitize, sanitize_mapping
+
 
 @dataclass(frozen=True)
 class WatchEvent:
@@ -29,10 +31,22 @@ class WatchEvent:
     extra: dict[str, str] = field(default_factory=dict)
 
     def to_json(self) -> str:
-        """Serialize to a compact JSON line, omitting empty optional fields."""
-        d = {
-            k: v
-            for k, v in asdict(self).items()
-            if v or k in ("ts", "source", "action", "container")
-        }
+        """Serialise to a compact JSON line, omitting empty optional fields.
+
+        Every string value passes through the producer-side
+        ``WIRE_SPEC(safe-string)`` sanitiser — container-controlled
+        bytes (DNS query name, dest IP, audit detail) reach this
+        method straight from kernel logs / dnsmasq output, so the
+        boundary lives here, not in any caller.
+        """
+        d = {}
+        for k, v in asdict(self).items():
+            if not v and k not in ("ts", "source", "action", "container"):
+                continue
+            if isinstance(v, str):
+                d[k] = sanitize(v)
+            elif isinstance(v, dict):
+                d[k] = sanitize_mapping(v)
+            else:
+                d[k] = v
         return json.dumps(d, separators=(",", ":"))

--- a/tach.toml
+++ b/tach.toml
@@ -78,6 +78,15 @@ depends_on = []
 [[modules]]
 path = "terok_shield._hub_events"
 layer = "foundation"
+depends_on = ["terok_shield._wire_sanitize"]
+
+# Producer-side wire-format sanitiser.  WIRE_SPEC(safe-string): the
+# canonical version lives in terok_clearance.wire.sanitize; keep both
+# in sync.  Stdlib-only by design so the reader-script resource (which
+# bypasses the package) can mirror the function inline.
+[[modules]]
+path = "terok_shield._wire_sanitize"
+layer = "foundation"
 depends_on = []
 
 # ── Core ───────────────────────────────────────────────────

--- a/tests/testnet.py
+++ b/tests/testnet.py
@@ -25,6 +25,12 @@ CUSTOM_DOMAIN = "custom.example.com"  # Fixture domain for user-override profile
 BLOCKED_DOMAIN = "evil.example.com"  # Domain NOT in any allowlist (for watch tests)
 BLOCKED_SUBDOMAIN = "api.evil.example.com"  # Subdomain of BLOCKED_DOMAIN
 
+# Adversarial domain shapes used by the wire-format sanitiser tests.
+# Centralised here so SonarCloud only flags the constant definitions,
+# not every call site that needs to verify defence against them.
+TEST_DOMAIN_ATTACK = "evil\x1b[31mfake\x00.example.com"  # Control-byte injection probe
+TEST_DOMAIN_MARKUP = "<a&b>.example.com"  # Pango-markup chars (printable ASCII)
+
 # ── RFC 5737 TEST-NET addresses (non-routable, safe for unit tests) ──
 
 # TEST-NET-1 (192.0.2.0/24)

--- a/tests/unit/test_hub_events.py
+++ b/tests/unit/test_hub_events.py
@@ -144,6 +144,24 @@ class TestHubEventEmitter:
             "container": _CONTAINER,
         }
 
+    def test_attacker_bytes_in_container_id_are_sanitised(
+        self, hub_socket: _SocketRecorder
+    ) -> None:
+        """A crafted container name can't smuggle control chars onto the wire."""
+        HubEventEmitter(hub_socket.path).shield_up("evil\x00\x1bfoo")
+        parsed = json.loads(_received_one_line(hub_socket))
+        assert parsed["container"] == "evil  foo"
+
+    def test_dossier_values_are_sanitised(self, hub_socket: _SocketRecorder) -> None:
+        """Producer-side belt-and-braces: dossier strings hit the wire as printable ASCII."""
+        HubEventEmitter(hub_socket.path).shield_up(
+            _CONTAINER,
+            dossier={"name": "p1\nProtocol: spoof", "task": "café"},
+        )
+        parsed = json.loads(_received_one_line(hub_socket))
+        assert parsed["dossier"]["name"] == "p1 Protocol: spoof"
+        assert parsed["dossier"]["task"] == "caf "
+
 
 def _received_one_line(recorder: _SocketRecorder) -> str:
     """Drain the recorder and return the single newline-terminated payload."""

--- a/tests/unit/test_nflog_reader.py
+++ b/tests/unit/test_nflog_reader.py
@@ -1042,7 +1042,7 @@ class TestPayloadSanitisation:
             reader.BlockedEvent(
                 container="c1",
                 request_id="c1:1",
-                dest="192.0.2.1",
+                dest=TEST_IP1,
                 port=443,
                 proto=6,
                 domain="evil\x1b[31mfake\x00.example.com",
@@ -1058,7 +1058,7 @@ class TestPayloadSanitisation:
             reader.BlockedEvent(
                 container="c1",
                 request_id="c1:1",
-                dest="192.0.2.1",
+                dest=TEST_IP1,
                 port=443,
                 proto=6,
                 domain="example.com",
@@ -1074,7 +1074,7 @@ class TestPayloadSanitisation:
             reader.BlockedEvent(
                 container="c1",
                 request_id="c1:1",
-                dest="192.0.2.1",
+                dest=TEST_IP1,
                 port=443,
                 proto=6,
                 domain="<a&b>.example.com",
@@ -1090,6 +1090,34 @@ class TestPayloadSanitisation:
     def test_exited_payload_sanitises_reason(self) -> None:
         payload = reader._exited_payload("c1", "reason\nwith\tcontrol")
         assert payload["reason"] == "reason with control"
+
+
+class TestInlineSanitizer:
+    """The reader's stdlib-only sanitiser mirrors the canonical helper.
+
+    Resource bypasses the package, so the inline copy can drift unless the
+    invariants are pinned both ends.  These tests pair with
+    ``test_wire_sanitize.py`` against the canonical version.
+    """
+
+    def test_empty_string_short_circuits(self) -> None:
+        assert reader._sanitize_str("") == ""
+
+    def test_truncation_marker_clipped_when_max_len_smaller(self) -> None:
+        """``max_len`` shorter than ``...`` still bounds the result length."""
+        assert reader._sanitize_str("x" * 100, max_len=2) == ".."
+        assert reader._sanitize_str("x" * 100, max_len=1) == "."
+        assert reader._sanitize_str("x" * 100, max_len=0) == ""
+
+    def test_long_value_uses_full_marker(self) -> None:
+        out = reader._sanitize_str("x" * 1000, max_len=10)
+        assert out == "xxxxxxx..."
+        assert len(out) == 10
+
+    def test_dict_helper_passes_through_non_string_values(self) -> None:
+        """``_sanitize_dict`` only touches strings — ints / lists pass verbatim."""
+        out = reader._sanitize_dict({"name": "p\nspoof", "port": 8080, "tags": ["x"]})
+        assert out == {"name": "p spoof", "port": 8080, "tags": ["x"]}
 
 
 class _FakeSocket:

--- a/tests/unit/test_nflog_reader.py
+++ b/tests/unit/test_nflog_reader.py
@@ -23,9 +23,12 @@ from terok_shield.resources import nflog_reader as reader
 
 from ..testfs import AUDIT_FILENAME, DNSMASQ_LOG_FILENAME, READER_EVENTS_SOCK_FILENAME
 from ..testnet import (
+    DNSMASQ_DOMAIN,
     IPV6_MCAST_ALL_ROUTERS,
     IPV6_MCAST_MLDV2,
     TEST_DOMAIN,
+    TEST_DOMAIN_ATTACK,
+    TEST_DOMAIN_MARKUP,
     TEST_IP1,
     TEST_IP2,
     TEST_IP99,
@@ -1045,7 +1048,7 @@ class TestPayloadSanitisation:
                 dest=TEST_IP1,
                 port=443,
                 proto=6,
-                domain="evil\x1b[31mfake\x00.example.com",
+                domain=TEST_DOMAIN_ATTACK,
                 dossier={},
             )
         )
@@ -1061,7 +1064,7 @@ class TestPayloadSanitisation:
                 dest=TEST_IP1,
                 port=443,
                 proto=6,
-                domain="example.com",
+                domain=DNSMASQ_DOMAIN,
                 dossier={"name": "p\nspoof", "task": "café"},
             )
         )
@@ -1077,11 +1080,11 @@ class TestPayloadSanitisation:
                 dest=TEST_IP1,
                 port=443,
                 proto=6,
-                domain="<a&b>.example.com",
+                domain=TEST_DOMAIN_MARKUP,
                 dossier={},
             )
         )
-        assert payload["domain"] == "<a&b>.example.com"
+        assert payload["domain"] == TEST_DOMAIN_MARKUP
 
     def test_started_payload_sanitises_container_id(self) -> None:
         payload = reader._started_payload("evil\x00\x1bfoo")

--- a/tests/unit/test_nflog_reader.py
+++ b/tests/unit/test_nflog_reader.py
@@ -1033,6 +1033,65 @@ class TestAuditBlockAppend:
         )
 
 
+class TestPayloadSanitisation:
+    """``WIRE_SPEC(safe-string)``: every wire payload field is printable-ASCII clean."""
+
+    def test_pending_payload_sanitises_attacker_controlled_domain(self) -> None:
+        """A crafted DNS name leaves no control bytes in the wire JSON."""
+        payload = reader._pending_payload(
+            reader.BlockedEvent(
+                container="c1",
+                request_id="c1:1",
+                dest="192.0.2.1",
+                port=443,
+                proto=6,
+                domain="evil\x1b[31mfake\x00.example.com",
+                dossier={},
+            )
+        )
+        assert "\x1b" not in payload["domain"]
+        assert "\x00" not in payload["domain"]
+
+    def test_pending_payload_sanitises_dossier_values(self) -> None:
+        """Non-ASCII / control bytes in dossier values collapse to spaces."""
+        payload = reader._pending_payload(
+            reader.BlockedEvent(
+                container="c1",
+                request_id="c1:1",
+                dest="192.0.2.1",
+                port=443,
+                proto=6,
+                domain="example.com",
+                dossier={"name": "p\nspoof", "task": "café"},
+            )
+        )
+        assert payload["dossier"]["name"] == "p spoof"
+        assert payload["dossier"]["task"] == "caf "
+
+    def test_pending_payload_keeps_pango_chars_intact(self) -> None:
+        """``& < >`` are printable ASCII — wire layer leaves them alone."""
+        payload = reader._pending_payload(
+            reader.BlockedEvent(
+                container="c1",
+                request_id="c1:1",
+                dest="192.0.2.1",
+                port=443,
+                proto=6,
+                domain="<a&b>.example.com",
+                dossier={},
+            )
+        )
+        assert payload["domain"] == "<a&b>.example.com"
+
+    def test_started_payload_sanitises_container_id(self) -> None:
+        payload = reader._started_payload("evil\x00\x1bfoo")
+        assert payload["container"] == "evil  foo"
+
+    def test_exited_payload_sanitises_reason(self) -> None:
+        payload = reader._exited_payload("c1", "reason\nwith\tcontrol")
+        assert payload["reason"] == "reason with control"
+
+
 class _FakeSocket:
     """Minimal file-like stand-in for the NFLOG netlink socket."""
 

--- a/tests/unit/test_watch.py
+++ b/tests/unit/test_watch.py
@@ -161,6 +161,43 @@ class TestWatchEvent:
         assert "action" in parsed
         assert "container" in parsed
 
+    def test_to_json_sanitises_attacker_controlled_domain(self) -> None:
+        """Crafted DNS-name bytes can't reach the JSON line — control chars squashed."""
+        event = WatchEvent(
+            ts="2026-01-01T00:00:00+00:00",
+            source="dns",
+            action="blocked_query",
+            domain="evil\x1b[31mfake\x00.example.com",
+            container=_CONTAINER,
+        )
+        parsed = json.loads(event.to_json())
+        assert "\x1b" not in parsed["domain"]
+        assert "\x00" not in parsed["domain"]
+
+    def test_to_json_sanitises_extra_dict_values(self) -> None:
+        """Sanitiser walks ``extra`` too — values from the kernel can carry bytes."""
+        event = WatchEvent(
+            ts="2026-01-01T00:00:00+00:00",
+            source="nflog",
+            action="blocked_connection",
+            container=_CONTAINER,
+            extra={"reason": "weird\nbytes\tfound"},
+        )
+        parsed = json.loads(event.to_json())
+        assert parsed["extra"]["reason"] == "weird bytes found"
+
+    def test_to_json_keeps_pango_markup_chars_intact(self) -> None:
+        """``& < >`` are printable ASCII; renderer-side handles markup escaping."""
+        event = WatchEvent(
+            ts="2026-01-01T00:00:00+00:00",
+            source="dns",
+            action="blocked_query",
+            domain="<a&b>.example.com",
+            container=_CONTAINER,
+        )
+        parsed = json.loads(event.to_json())
+        assert parsed["domain"] == "<a&b>.example.com"
+
 
 # ── Query regex ─────────────────────────────────────────
 

--- a/tests/unit/test_wire_sanitize.py
+++ b/tests/unit/test_wire_sanitize.py
@@ -57,7 +57,7 @@ class TestSanitize:
 
     def test_rtlo_bidi_override_is_neutralised(self) -> None:
         """U+202E becomes a space — kills the homoglyph attack at the boundary."""
-        assert sanitize("evil‮.com") == "evil .com"
+        assert sanitize("evil\u202e.com") == "evil .com"
 
     def test_length_cap_uses_ascii_marker(self) -> None:
         out = sanitize("x" * 1000, max_len=10)
@@ -71,6 +71,12 @@ class TestSanitize:
         name = "warp-core/t42-feature-rebuild-2026-04"
         assert len(name) < DEFAULT_MAX_LEN
         assert sanitize(name) == name
+
+    def test_truncation_marker_clipped_when_max_len_smaller(self) -> None:
+        """Pathological tiny ``max_len`` still satisfies the length post-condition."""
+        assert sanitize("x" * 100, max_len=2) == ".."
+        assert sanitize("x" * 100, max_len=1) == "."
+        assert sanitize("x" * 100, max_len=0) == ""
 
 
 class TestSanitizeMapping:

--- a/tests/unit/test_wire_sanitize.py
+++ b/tests/unit/test_wire_sanitize.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the producer-side wire-format sanitiser."""
+
+from __future__ import annotations
+
+import pytest
+
+from terok_shield._wire_sanitize import (
+    DEFAULT_MAX_LEN,
+    sanitize,
+    sanitize_mapping,
+)
+
+
+class TestSanitize:
+    """``sanitize`` collapses input to printable ASCII and applies the length cap."""
+
+    def test_empty_string_round_trips(self) -> None:
+        assert sanitize("") == ""
+
+    def test_plain_ascii_unchanged(self) -> None:
+        assert sanitize("alpine-7-redis") == "alpine-7-redis"
+
+    def test_full_printable_ascii_passes_through(self) -> None:
+        full = "".join(chr(c) for c in range(0x20, 0x7F))
+        assert sanitize(full) == full
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("café", "caf "),
+            ("münchen", "m nchen"),
+            ("naïve", "na ve"),
+        ],
+    )
+    def test_non_ascii_letters_become_spaces(self, raw: str, expected: str) -> None:
+        assert sanitize(raw) == expected
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("line1\nline2", "line1 line2"),
+            ("tab\there", "tab here"),
+            ("null\x00byte", "null byte"),
+            ("esc\x1bseq", "esc seq"),
+            ("del\x7fchar", "del char"),
+        ],
+    )
+    def test_control_chars_become_spaces(self, raw: str, expected: str) -> None:
+        assert sanitize(raw) == expected
+
+    def test_markup_chars_pass_through(self) -> None:
+        """``& < >`` are printable ASCII — wire layer leaves them untouched."""
+        assert sanitize("<script>alert(1)</script>") == "<script>alert(1)</script>"
+
+    def test_rtlo_bidi_override_is_neutralised(self) -> None:
+        """U+202E becomes a space — kills the homoglyph attack at the boundary."""
+        assert sanitize("evil‮.com") == "evil .com"
+
+    def test_length_cap_uses_ascii_marker(self) -> None:
+        out = sanitize("x" * 1000, max_len=10)
+        assert out == "xxxxxxx..."
+        assert len(out) == 10
+
+    def test_value_at_exact_cap_passes_through(self) -> None:
+        assert sanitize("x" * 10, max_len=10) == "x" * 10
+
+    def test_default_max_len_is_generous(self) -> None:
+        name = "warp-core/t42-feature-rebuild-2026-04"
+        assert len(name) < DEFAULT_MAX_LEN
+        assert sanitize(name) == name
+
+
+class TestSanitizeMapping:
+    """``sanitize_mapping`` applies the rule to every value in a dict."""
+
+    def test_sanitises_values_only(self) -> None:
+        out = sanitize_mapping({"task": "<a>", "name": "b\nc"})
+        assert out == {"task": "<a>", "name": "b c"}
+
+    def test_keys_pass_through_unchanged(self) -> None:
+        out = sanitize_mapping({"<weird>": "v"})
+        assert "<weird>" in out
+
+    def test_empty_dict_round_trips(self) -> None:
+        assert sanitize_mapping({}) == {}


### PR DESCRIPTION
## Summary

- Apply printable-ASCII / length-cap sanitisation at every emit chokepoint the container's bytes flow through: NFLOG reader payload builders (`_pending_payload`, `_started_payload`, `_exited_payload`), `HubEventEmitter._send`, `WatchEvent.to_json`, and the per-container audit JSONL append.
- New canonical helper `terok_shield/_wire_sanitize.py` (foundation tach layer, stdlib-only) used by `_hub_events` and `watchers/_event`.
- Inline duplicate (`_sanitize_str` / `_sanitize_dict`) in `resources/nflog_reader.py` because that resource ships as a stdlib-only script that bypasses the package. Both copies carry a `WIRE_SPEC(safe-string)` marker for grep-driven sync checks against the consumer-side authoritative version in `terok-clearance`.

## Why

Threat model: a container that crafts a DNS lookup with `\x1b` / `\x00` / RTLO bytes triggers an NFLOG block; the resulting bytes flow through the shield's reader straight onto the hub socket and into every host-side subscriber. Sanitising at the producer side closes the primary attack path — the one terok is explicitly designed to absorb, where the container is the untrusted payload.

Belt-and-braces pairing: the clearance hub re-applies the same rule on receive — see [terok-clearance#90](https://github.com/terok-ai/terok-clearance/pull/90). Both implementations are idempotent (sanitising twice yields the same string), so either side can land first.

## Rule

Bytes inside `[\x20, \x7E]` pass through unchanged. Everything else — control chars, non-ASCII, RTLO/LRO bidi overrides — becomes a single position-preserving space. Strings longer than 256 chars truncate with a trailing `...` ASCII marker. Pango / terminal renderers add their own narrower escape on top of this base layer.

## Test plan

- [x] `make check` passes (lint, ruff format, tach, docstrings 100%, REUSE, security)
- [x] New `tests/unit/test_wire_sanitize.py` covers the rule directly
- [x] `WatchEvent.to_json` test class extended for control-byte squash, non-ASCII squash, RTLO neutralisation, Pango chars passing through
- [x] `HubEventEmitter` integration test covers attacker bytes in container ID and dossier values
- [x] `nflog_reader` payload-builder tests cover all three builders + dossier sanitisation
- [ ] Manual: trigger a real container DNS lookup with a control-byte-bearing name; verify the JSON line on the hub socket and the audit JSONL entry are both sanitised

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Outgoing events and audit payloads now sanitize string fields: strip control/non‑ASCII, preserve common markup, and enforce length/truncation rules.

* **Bug Fixes**
  * Lifecycle, watch-event, and audit serialization no longer emit raw control bytes or unbounded strings; dossier and dict values are sanitized before sending.

* **Tests**
  * Added comprehensive unit tests covering sanitization behavior, edge cases, and truncation rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->