### PR TITLE
ci(release): restore gh-only dispatch path + drop github-release actor check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
       target:
         description: "What to publish"
         type: choice
-        options: [pypi, testpypi]
+        options: [pypi, testpypi, gh-only]
         default: pypi
 
 # Empty default; each job re-grants only what it needs.
@@ -57,19 +57,18 @@ jobs:
 
   github-release:
     needs: build
-    if: github.event_name == 'push'
+    if: |
+      github.event_name == 'push' ||
+      (github.event_name == 'workflow_dispatch' && inputs.target == 'gh-only')
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
-      - name: Verify triggering actor
-        env:
-          ACTOR: ${{ github.triggering_actor }}
-        run: |
-          if [ "$ACTOR" != "terok-warden" ]; then
-            echo "Releases must be triggered by terok-warden (got: $ACTOR)" >&2
-            exit 1
-          fi
+      # No triggering-actor check on github-release: tag creation is already
+      # gated by the v*.*.* tag-creation ruleset on the org (release-officers
+      # team only).  Anyone who succeeded in pushing the tag is authorised
+      # for the GH release.  The actor check stays on pypi-publish /
+      # testpypi-publish where the consequence is external publication.
 
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
Restores `gh-only` to the workflow_dispatch target dropdown (re-trigger GH release from the Actions UI) and drops the redundant warden-only actor check from `github-release` (tag-creation ruleset already gates that path; actor check stays on `pypi-publish`/`testpypi-publish` where external publication makes it meaningful).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated release workflow to support selective publishing targets (PyPI, TestPyPI, or GitHub-only releases), providing more granular control over release destinations.
  * Enhanced security practices in the release process with improved verification mechanisms and stricter action pinning.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok-shield/pull/289)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->