### PR TITLE
fix(inventory): grant contents: read so the reusable call validates

### DIFF
--- a/.github/workflows/inventory.yml
+++ b/.github/workflows/inventory.yml
@@ -14,11 +14,16 @@ on:
     branches: [master]
   workflow_dispatch:
 
-permissions: {}
+# `contents: read` here is required so the called reusable workflow can
+# request the same — GitHub Actions rejects a called workflow that asks
+# for permissions outside the caller's grant, which manifests as
+# ``startup_failure`` with no jobs spawned.
+permissions:
+  contents: read
 
 jobs:
   publish:
     if: github.repository == 'terok-ai/terok-shield' && github.ref == 'refs/heads/master'
-    uses: terok-ai/mkdocs-terok/.github/workflows/publish-inventory.yml@v0.5.7a1
+    uses: terok-ai/mkdocs-terok/.github/workflows/publish-inventory.yml@v0.5.7a3
     secrets:
       INVENTORY_WRITE_TOKEN: ${{ secrets.INVENTORY_WRITE_TOKEN }}

--- a/poetry.lock
+++ b/poetry.lock
@@ -1122,13 +1122,13 @@ properdocs = ">=1.6.5"
 
 [[package]]
 name = "mkdocs-terok"
-version = "0.5.7a1"
+version = "0.5.7a3"
 description = "Shared ProperDocs documentation generators for terok projects"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["docs"]
 files = [
-    {file = "mkdocs_terok-0.5.7a1-py3-none-any.whl", hash = "sha256:14460c98870cf3f4d4153594bc38d6d3b4a7048f4e080be179cc2431b1cab55d"},
+    {file = "mkdocs_terok-0.5.7a3-py3-none-any.whl", hash = "sha256:ed90289ebac816145018d503d36866d42b713d987dddbb6fb80e31c68040e270"},
 ]
 
 [package.dependencies]
@@ -1137,7 +1137,7 @@ PyYAML = ">=6.0"
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/mkdocs-terok/releases/download/v0.5.7a1/mkdocs_terok-0.5.7a1-py3-none-any.whl"
+url = "https://github.com/terok-ai/mkdocs-terok/releases/download/v0.5.7a3/mkdocs_terok-0.5.7a3-py3-none-any.whl"
 
 [[package]]
 name = "mkdocstrings"
@@ -2304,4 +2304,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "c1576025c8bb3f470b2e8c06cda632105dbef6987dbafbab6e213bf9654f145c"
+content-hash = "48f92e0431f4a0ce93b8df232d4d4fc2fa44447f290b8a7e65b46b51e892a810"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ mkdocstrings = {extras = ["python"], version = ">=0.24"}
 mkdocs-literate-nav = ">=0.6"
 mkdocs-section-index = ">=0.3"
 mkdocs-gen-files = ">=0.5"
-mkdocs-terok = {url = "https://github.com/terok-ai/mkdocs-terok/releases/download/v0.5.7a1/mkdocs_terok-0.5.7a1-py3-none-any.whl"}
+mkdocs-terok = {url = "https://github.com/terok-ai/mkdocs-terok/releases/download/v0.5.7a3/mkdocs_terok-0.5.7a3-py3-none-any.whl"}
 
 [tool.poetry.scripts]
 terok-shield = "terok_shield.cli.main:main"


### PR DESCRIPTION
## Summary

The `inventory.yml` caller had `permissions: {}` while the `publish-inventory.yml` reusable workflow it invokes asks for `contents: read` at the job level (for `actions/checkout@v6`).

GitHub Actions rejects a called workflow whose permission requests aren't a subset of the caller's grant. Net result on master: every `Publish inventory` run since the merge has been `startup_failure` with **zero jobs spawned**, leaving `terok-ai/docs-inventories` empty and breaking `properdocs build --strict` everywhere.

This grants `contents: read` at the workflow level — the minimum that satisfies the reusable workflow's `checkout` step. The Contents-API `PUT` in the publish step uses `INVENTORY_WRITE_TOKEN`, not `GITHUB_TOKEN`, so no further permissions are needed.

## Why startup_failure with no diagnostic

When the called workflow's permissions exceed the caller's, GitHub fails the run at validation time *before* spawning any check runs — which is why `gh run view` shows "This run likely failed because of a workflow file issue." with no useful detail.

## Companion PRs

mkdocs-terok#60 (root cause fix) plus identical one-line changes in every consumer repo: terok#TBD, terok-executor#TBD, terok-sandbox#TBD, terok-shield#TBD, terok-clearance#TBD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)