### PR TITLE
chore(deps): bump mkdocs-terok to v0.5.7a4

### DIFF
--- a/.github/workflows/inventory.yml
+++ b/.github/workflows/inventory.yml
@@ -24,6 +24,6 @@ permissions:
 jobs:
   publish:
     if: github.repository == 'terok-ai/terok-shield' && github.ref == 'refs/heads/master'
-    uses: terok-ai/mkdocs-terok/.github/workflows/publish-inventory.yml@v0.5.7a3
+    uses: terok-ai/mkdocs-terok/.github/workflows/publish-inventory.yml@v0.5.7a4
     secrets:
       INVENTORY_WRITE_TOKEN: ${{ secrets.INVENTORY_WRITE_TOKEN }}

--- a/poetry.lock
+++ b/poetry.lock
@@ -1122,13 +1122,13 @@ properdocs = ">=1.6.5"
 
 [[package]]
 name = "mkdocs-terok"
-version = "0.5.7a3"
+version = "0.5.7a4"
 description = "Shared ProperDocs documentation generators for terok projects"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["docs"]
 files = [
-    {file = "mkdocs_terok-0.5.7a3-py3-none-any.whl", hash = "sha256:ed90289ebac816145018d503d36866d42b713d987dddbb6fb80e31c68040e270"},
+    {file = "mkdocs_terok-0.5.7a4-py3-none-any.whl", hash = "sha256:24d74e20d15e948f5acdcded11a42fc2ab4a7fc437ba5207e5a5c88bc254f690"},
 ]
 
 [package.dependencies]
@@ -1137,7 +1137,7 @@ PyYAML = ">=6.0"
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/mkdocs-terok/releases/download/v0.5.7a3/mkdocs_terok-0.5.7a3-py3-none-any.whl"
+url = "https://github.com/terok-ai/mkdocs-terok/releases/download/v0.5.7a4/mkdocs_terok-0.5.7a4-py3-none-any.whl"
 
 [[package]]
 name = "mkdocstrings"
@@ -2304,4 +2304,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "48f92e0431f4a0ce93b8df232d4d4fc2fa44447f290b8a7e65b46b51e892a810"
+content-hash = "0168e0ad9c419a5d3044c2e65cf8f9f0695af4a01a4035f3934ac7777e0ee0d4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ mkdocstrings = {extras = ["python"], version = ">=0.24"}
 mkdocs-literate-nav = ">=0.6"
 mkdocs-section-index = ">=0.3"
 mkdocs-gen-files = ">=0.5"
-mkdocs-terok = {url = "https://github.com/terok-ai/mkdocs-terok/releases/download/v0.5.7a3/mkdocs_terok-0.5.7a3-py3-none-any.whl"}
+mkdocs-terok = {url = "https://github.com/terok-ai/mkdocs-terok/releases/download/v0.5.7a4/mkdocs_terok-0.5.7a4-py3-none-any.whl"}
 
 [tool.poetry.scripts]
 terok-shield = "terok_shield.cli.main:main"


### PR DESCRIPTION
## Summary

Bump `mkdocs-terok` wheel pin and the reusable-workflow `uses:` ref from `v0.5.7a3` → `v0.5.7a4`.

## Why

a4 (terok-ai/mkdocs-terok#64) adds the `MKDOCS_TEROK_INVENTORY_ONLY` env-var kill switch on the `terok` plugin. In inventory mode the plugin skips `ci_map` / `quality_report` / `test_map` / `module_map` — the generators that need `pytest` / `scc` / `vulture` binaries and would fail in a stripped `--only main,docs` install. `ref_pages` keeps running (every `objects.inv` symbol comes from those pages).

a3 fixed the `dbus-python` build by switching to `--only main,docs`, but exposed the next layer: `test_map` calls `pytest --collect-only` unconditionally → "No module named pytest" → "Generate inventory" failed everywhere.

## Test plan

- [ ] After merge, the next master push runs `inventory.yml` to completion (no startup_failure, no Generate-inventory failure)
- [ ] `https://raw.githubusercontent.com/terok-ai/docs-inventories/master/<this-repo>/objects.inv` resolves to a fresh file
- [ ] Subsequent docs builds across siblings start picking up the new bucket entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)