### PR TITLE
feat(docs): wire local coverage treemap from mkdocs-terok v0.5.7a5

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -51,11 +51,13 @@ jobs:
       - name: Run unit tests
         run: make test-unit
 
-      - name: Upload coverage for SonarQube Cloud
+      - name: Upload coverage for SonarQube Cloud and docs treemap
         uses: actions/upload-artifact@v7
         with:
           name: coverage
-          path: reports/coverage.xml
+          path: |
+            reports/coverage.xml
+            reports/coverage.json
           retention-days: 1
 
       - name: Save PR metadata

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,7 +42,7 @@ jobs:
           key: venv-${{ runner.os }}-py${{ steps.setup-python.outputs.python-version }}-docs-${{ hashFiles('**/pyproject.toml', '**/poetry.lock') }}
 
       - name: Install dependencies
-        run: poetry install --with dev,docs --no-interaction
+        run: poetry install --with dev,docs,test --no-interaction
 
       - name: Install scc (lines of code counter)
         run: |
@@ -51,13 +51,12 @@ jobs:
           echo "6c31f4d0cf3b7a8c5ca910fa4e451949434798f6541ec5dea4b83f4973e13772  scc_Linux_x86_64.tar.gz" | sha256sum -c
           sudo tar xzf scc_Linux_x86_64.tar.gz -C /usr/local/bin scc
 
-      - name: Fetch Codecov coverage treemap
-        run: |
-          mkdir -p docs/assets
-          curl -sfL "https://codecov.io/gh/terok-ai/terok-shield/graphs/tree.svg?token=D74Q7lvnIF" \
-            > docs/assets/coverage_treemap.svg
-          # Non-fatal: an empty file is handled gracefully by the report generator.
-          [ -s docs/assets/coverage_treemap.svg ] || rm -f docs/assets/coverage_treemap.svg
+      - name: Generate coverage data for treemap
+        # Produces reports/coverage.json, consumed by mkdocs-terok's
+        # code_metrics generator to render a local SVG treemap. Replaces
+        # the previous curl from codecov.io/.../tree.svg, which intermittently
+        # failed.
+        run: make test-unit
 
       - name: Build documentation
         run: poetry run properdocs build --strict

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 
 REPORTS_DIR ?= reports
 COVERAGE_XML ?= $(REPORTS_DIR)/coverage.xml
+COVERAGE_JSON ?= $(REPORTS_DIR)/coverage.json
 UNIT_JUNIT_XML ?= $(REPORTS_DIR)/unit.junit.xml
 INTEGRATION_HOST_JUNIT_XML ?= $(REPORTS_DIR)/integration-host.junit.xml
 INTEGRATION_NETWORK_JUNIT_XML ?= $(REPORTS_DIR)/integration-network.junit.xml
@@ -29,7 +30,7 @@ format:
 # Run tests with coverage (excludes podman-dependent integration tests)
 test-unit:
 	mkdir -p $(REPORTS_DIR)
-	poetry run pytest tests/unit/ --cov=terok_shield --cov-report=term-missing --cov-report=xml:$(COVERAGE_XML) --junitxml=$(UNIT_JUNIT_XML) -o junit_family=legacy
+	poetry run pytest tests/unit/ --cov=terok_shield --cov-report=term-missing --cov-report=xml:$(COVERAGE_XML) --cov-report=json:$(COVERAGE_JSON) --junitxml=$(UNIT_JUNIT_XML) -o junit_family=legacy
 
 # Write Ruff's JSON report without failing on findings.
 ruff-report:

--- a/properdocs.yml
+++ b/properdocs.yml
@@ -57,6 +57,7 @@ plugins:
   - terok:
       ci_map: true
       code_metrics: true
+      code_metrics_coverage_json_path: reports/coverage.json
       code_metrics_codecov_repo: terok-ai/terok-shield
       test_map: true
       module_map: true


### PR DESCRIPTION
## Summary
- Replace the brittle \`curl https://codecov.io/.../tree.svg\` step in \`docs.yml\` with mkdocs-terok's local SVG treemap generator (shipped in v0.5.7a5, already pinned).
- \`test-unit\` now also emits \`reports/coverage.json\` alongside \`coverage.xml\`; \`analysis.yml\`'s \`coverage\` artifact bundles both.
- \`docs.yml\` runs \`make test-unit\` before \`properdocs build\` so the generator finds the JSON.
- \`properdocs.yml\` adds \`code_metrics_coverage_json_path: reports/coverage.json\`.

## Why
Codecov's tree.svg endpoint flakes out semi-regularly and requires a manual workflow rerun to ship docs. Generating the treemap from data we already collect for Sonar/Codecov removes that external dependency. Part of a coordinated change across terok-ai packages.

## Test plan
- [x] \`ruff check .\` clean
- [ ] CI: \`make test-unit\` produces \`reports/coverage.{xml,json}\`
- [ ] CI: docs build produces \`coverage_treemap.svg\` via the generator (no codecov curl)

🤖 Generated with [Claude Code](https://claude.com/claude-code)