### PR TITLE
chore(deps): restore PyPI pin for mkdocs-terok at ^0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ also the "Changelog" link in PyPI metadata.
 
 [rel]: https://github.com/terok-ai/terok-shield/releases
 
+## v0.6.39 — Checkpoint Charlie
+
+* introduce mypy as the static type checker in https://github.com/terok-ai/terok-shield/pull/288
+* seed CHANGELOG.md for the first PyPI release in https://github.com/terok-ai/terok-shield/pull/290
+* publish sibling-decoupled inventory on master push in https://github.com/terok-ai/terok-shield/pull/293
+
+
+**Full Changelog**: https://github.com/terok-ai/terok-shield/compare/v0.6.38...v0.6.39
+
 ## v0.7.0 — first PyPI release
 
 `terok-shield` joined PyPI in v0.7.0. Versions before that were GitHub Release

--- a/poetry.lock
+++ b/poetry.lock
@@ -1122,23 +1122,20 @@ properdocs = ">=1.6.5"
 
 [[package]]
 name = "mkdocs-terok"
-version = "0.5.7a5"
+version = "0.6.0"
 description = "Shared ProperDocs documentation generators for terok projects"
 optional = false
-python-versions = ">=3.12,<4.0"
+python-versions = "<4.0,>=3.12"
 groups = ["docs"]
 files = [
-    {file = "mkdocs_terok-0.5.7a5-py3-none-any.whl", hash = "sha256:71aa681d4b7f032c3660cc7015d86e25b3f1f4ce99020cadc598ec09fe37ac35"},
+    {file = "mkdocs_terok-0.6.0-py3-none-any.whl", hash = "sha256:d567b15f38850f70f288df321939ac1689953b5b4e8be17a3bd7eb79d05d210f"},
+    {file = "mkdocs_terok-0.6.0.tar.gz", hash = "sha256:a1ce936ec8968ec79c784de277934a02395485719723a3124c16578839673523"},
 ]
 
 [package.dependencies]
 properdocs = ">=1.6.7"
 PyYAML = ">=6.0"
 squarify = ">=0.4"
-
-[package.source]
-type = "url"
-url = "https://github.com/terok-ai/mkdocs-terok/releases/download/v0.5.7a5/mkdocs_terok-0.5.7a5-py3-none-any.whl"
 
 [[package]]
 name = "mkdocstrings"
@@ -2317,4 +2314,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "234df6f21ffb2210340c31ce8d08311aeb8b4c336da0cb2751a2aaa64dafb02b"
+content-hash = "cf2e3c28d3466c4e08e561d76e86f29dfe3e1b22897c484272b949b01683e4b5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.poetry]
 name = "terok-shield"
-version = "0.6.38"
+version = "0.6.39"
 description = "nftables-based egress firewalling for Podman containers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ mkdocstrings = {extras = ["python"], version = ">=0.24"}
 mkdocs-literate-nav = ">=0.6"
 mkdocs-section-index = ">=0.3"
 mkdocs-gen-files = ">=0.5"
-mkdocs-terok = {url = "https://github.com/terok-ai/mkdocs-terok/releases/download/v0.5.7a5/mkdocs_terok-0.5.7a5-py3-none-any.whl"}
+mkdocs-terok = "^0.6"
 
 [tool.poetry.scripts]
 terok-shield = "terok_shield.cli.main:main"


### PR DESCRIPTION
## Summary
- Move `mkdocs-terok` docs-group pin from the temporary `v0.5.7a5` wheel URL back to a stable PyPI version spec: `^0.6`.
- Regenerate `poetry.lock` so it resolves to mkdocs-terok 0.6.x.

## Why
The wheel-URL pin was a dev-cycle artefact (alpha integration for the local-coverage-treemap work). With mkdocs-terok v0.6.0 now on PyPI as a real release, switch back to a normal version specifier so future `poetry lock` runs can pick up patches automatically.

`^0.6` (Poetry caret) = `>=0.6.0,<0.7.0` — gets 0.6.x patch upgrades, holds back on a future 0.7 minor bump.

## Test plan
- [x] `poetry lock` regenerates cleanly, lockfile pins mkdocs-terok 0.6.0.
- [ ] Docs build on the next CI run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation tool dependency management from direct pinning to flexible version constraints for improved compatibility and easier maintenance.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok-shield/pull/299)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->