### PR TITLE
fix: namespace reader script under ~/.local/share/terok/shield/

### DIFF
--- a/src/terok_shield/paths.py
+++ b/src/terok_shield/paths.py
@@ -41,4 +41,4 @@ def reader_script_path() -> Path:
     computation inlined in ``resources/hook_entrypoint.py``.
     """
     data_home = os.environ.get("XDG_DATA_HOME") or f"{os.environ.get('HOME', '')}/.local/share"
-    return Path(data_home) / "terok-shield" / "nflog-reader.py"
+    return Path(data_home) / "terok" / "shield" / "nflog-reader.py"

--- a/src/terok_shield/paths.py
+++ b/src/terok_shield/paths.py
@@ -12,10 +12,12 @@ containers or installed into host-wide locations:
   ``containers/oci/hooks.d/`` and inside each per-container
   ``state_dir``.
 
-The reader-script path has one duplicated computation in
-``resources/hook_entrypoint.py`` — that file is stdlib-only and cannot
-import from this package at runtime.  When either definition changes,
-the other must be updated by hand; the synced pair is the contract.
+The reader-script path is computed in two places: ``reader_script_path()``
+in this module, and its stdlib-only mirror ``_reader_script_path()`` in
+``resources/reader_hook.py`` — that file cannot import from this package
+at runtime, so the computation is inlined there verbatim.  When either
+definition changes, the other must be updated by hand; the synced pair
+is the contract.
 """
 
 from __future__ import annotations
@@ -38,7 +40,7 @@ def reader_script_path() -> Path:
 
     Respects ``XDG_DATA_HOME`` when set, otherwise falls back to the
     POSIX default ``~/.local/share``.  Mirrors the stdlib-only
-    computation inlined in ``resources/hook_entrypoint.py``.
+    ``_reader_script_path()`` inlined in ``resources/reader_hook.py``.
     """
     data_home = os.environ.get("XDG_DATA_HOME") or f"{os.environ.get('HOME', '')}/.local/share"
     return Path(data_home) / "terok" / "shield" / "nflog-reader.py"

--- a/src/terok_shield/resources/reader_hook.py
+++ b/src/terok_shield/resources/reader_hook.py
@@ -284,7 +284,7 @@ def _is_our_reader(pid_int: int, sd: Path) -> bool:
 def _reader_script_path() -> Path:
     """Return the on-disk path ``terok setup`` places the reader script at."""
     data_home = os.environ.get("XDG_DATA_HOME") or f"{os.environ.get('HOME', '')}/.local/share"
-    return Path(data_home) / "terok-shield" / "nflog-reader.py"
+    return Path(data_home) / "terok" / "shield" / "nflog-reader.py"
 
 
 def _session_bus_address() -> str | None:

--- a/tests/unit/test_hook_mode_class.py
+++ b/tests/unit/test_hook_mode_class.py
@@ -682,7 +682,7 @@ def test_setup_global_hooks_non_sudo(tmp_path: Path, monkeypatch) -> None:
     """``setup_global_hooks()`` lays down nft + reader hooks + ballast + reader resource."""
     from terok_shield.hooks.install import setup_global_hooks
 
-    # Reader resource lands at ``$XDG_DATA_HOME/terok-shield/nflog-reader.py``;
+    # Reader resource lands at ``$XDG_DATA_HOME/terok/shield/nflog-reader.py``;
     # redirect it under tmp_path so the test stays hermetic.
     monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "share"))
     target = tmp_path / "hooks.d"
@@ -710,7 +710,7 @@ def test_setup_global_hooks_non_sudo(tmp_path: Path, monkeypatch) -> None:
     assert bridge["hook"]["args"] == ["terok-shield-bridge-hook", "createRuntime"]
 
     # NFLOG reader resource lands at the canonical XDG path.
-    reader = tmp_path / "share" / "terok-shield" / "nflog-reader.py"
+    reader = tmp_path / "share" / "terok" / "shield" / "nflog-reader.py"
     assert reader.is_file()
     assert reader.stat().st_mode & 0o100
 
@@ -763,7 +763,7 @@ def test_setup_global_hooks_sudo_uses_subprocess(tmp_path: Path, monkeypatch) ->
         cmds = [call.args[0] for call in mock_run.call_args_list]
         assert all(cmd[0] == "sudo" for cmd in cmds)
     # Reader resource still lands locally (no sudo for the per-user path).
-    assert (tmp_path / "share" / "terok-shield" / "nflog-reader.py").is_file()
+    assert (tmp_path / "share" / "terok" / "shield" / "nflog-reader.py").is_file()
 
 
 @mock.patch("terok_shield.hooks.mode.has_global_hooks", return_value=True)

--- a/tests/unit/test_reader_hook.py
+++ b/tests/unit/test_reader_hook.py
@@ -665,7 +665,9 @@ class TestReaderScriptPath:
 
     def test_xdg_data_home_wins(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
-        assert reader_hook._reader_script_path() == (tmp_path / "terok-shield" / "nflog-reader.py")
+        assert reader_hook._reader_script_path() == (
+            tmp_path / "terok" / "shield" / "nflog-reader.py"
+        )
 
     def test_falls_back_to_home_local_share(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
@@ -673,7 +675,7 @@ class TestReaderScriptPath:
         monkeypatch.delenv("XDG_DATA_HOME", raising=False)
         monkeypatch.setenv("HOME", str(tmp_path))
         assert reader_hook._reader_script_path() == (
-            tmp_path / ".local" / "share" / "terok-shield" / "nflog-reader.py"
+            tmp_path / ".local" / "share" / "terok" / "shield" / "nflog-reader.py"
         )
 
 

--- a/tests/unit/test_reader_install.py
+++ b/tests/unit/test_reader_install.py
@@ -30,7 +30,7 @@ class TestInstallReaderResource:
     """``install_reader_resource`` copies the script verbatim to the given path."""
 
     def test_writes_executable_script_with_shebang(self, tmp_path: Path) -> None:
-        dest = tmp_path / "share" / "terok-shield" / "nflog-reader.py"
+        dest = tmp_path / "share" / "terok" / "shield" / "nflog-reader.py"
         install_reader_resource(dest)
 
         assert dest.exists()
@@ -58,7 +58,7 @@ class TestInstallReaderResource:
         env = {"XDG_DATA_HOME": str(tmp_path), "HOME": str(tmp_path)}
         with mock.patch.dict("os.environ", env, clear=False):
             installed = install_reader_resource()
-        assert installed == tmp_path / "terok-shield" / "nflog-reader.py"
+        assert installed == tmp_path / "terok" / "shield" / "nflog-reader.py"
         assert installed.is_file()
 
 
@@ -70,7 +70,7 @@ class TestReaderScriptPath:
 
     def test_respects_xdg_data_home(self, tmp_path: Path) -> None:
         with mock.patch.dict("os.environ", {"XDG_DATA_HOME": str(tmp_path)}, clear=False):
-            assert reader_script_path() == tmp_path / "terok-shield" / "nflog-reader.py"
+            assert reader_script_path() == tmp_path / "terok" / "shield" / "nflog-reader.py"
 
     def test_falls_back_to_home_local_share(self, tmp_path: Path) -> None:
         env = {"HOME": str(tmp_path)}
@@ -78,5 +78,5 @@ class TestReaderScriptPath:
             import os as _os
 
             _os.environ.pop("XDG_DATA_HOME", None)
-            expected = tmp_path / ".local" / "share" / "terok-shield" / "nflog-reader.py"
+            expected = tmp_path / ".local" / "share" / "terok" / "shield" / "nflog-reader.py"
             assert reader_script_path() == expected


### PR DESCRIPTION
## Summary

The NFLOG reader script was being installed at `$XDG_DATA_HOME/terok-shield/nflog-reader.py`, putting a `terok-shield/` directory at the top level of the XDG data home next to every other application's data dir.

Every other terok component lives under `$XDG_DATA_HOME/terok/<component>/` (sandbox, vault, core/gate, …). This PR moves the shield reader to `$XDG_DATA_HOME/terok/shield/nflog-reader.py` so the namespace is consistent.

## Changes

- `paths.reader_script_path()` and its stdlib-only mirror in `resources/reader_hook._reader_script_path()` now return the new path (the two are duplicated by design — `reader_hook.py` runs outside the venv, can't import the package — and `paths.py`'s docstring already calls this contract out).
- The four unit tests asserting on the exact install path are updated.
- No migration shim. Per the project's early-design policy, an existing `~/.local/share/terok-shield/` directory from a previous install will be orphaned and can be removed manually.

## Test plan

- [x] `make lint` clean
- [x] `make tach` clean
- [x] Full unit suite passes locally (1176 passed)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated on-disk resource layout: helper/reader files are now installed and looked up under the terok/shield directory inside the XDG data location (with the existing HOME fallback behavior preserved).


[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok-shield/pull/300)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->