### PR TITLE
ci: split SonarQube into its own workflow; simplify docs wait

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -150,36 +150,8 @@ jobs:
           path: reports/bandit-report.json
           retention-days: 1
 
-  # Same-repo pushes and pull requests can scan directly here because the run has access
-  # to SONAR_TOKEN. Fork PRs are handled by sonar_pr.yml via workflow_run, using the
-  # artifacts uploaded above, because GitHub does not expose secrets to fork PR runs.
-  sonar:
-    name: SonarQube Cloud
-    if: github.repository == 'terok-ai/terok-shield' && github.actor != 'dependabot[bot]' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
-    needs: [unit-tests, ruff, bandit]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - uses: actions/download-artifact@v8
-        with:
-          name: coverage
-          path: reports
-
-      - uses: actions/download-artifact@v8
-        with:
-          name: ruff
-          path: reports
-
-      - uses: actions/download-artifact@v8
-        with:
-          name: bandit
-          path: reports
-
-      - name: SonarQube Cloud scan
-        uses: SonarSource/sonarqube-scan-action@59db25f34e16620e48ab4bb9e4a5dce155cb5432 # v8.0.0
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+  # The SonarQube Cloud scan runs in sonar.yml (same-repo) and sonar_pr.yml
+  # (fork PRs) — both consume the coverage/ruff/bandit artifacts uploaded
+  # above. Splitting Sonar out keeps this workflow free of third-party wait
+  # time, so downstream consumers (docs.yml, sonar.yml) unblock as soon as
+  # the local jobs finish.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,5 +1,22 @@
 # Pin third-party actions to full commit SHAs for supply-chain security.
 # GitHub-owned actions (actions/*) may use version tags.
+#
+# Coverage handoff contract (well-known address):
+#   workflow=analysis.yml  job=unit-tests  artifact=coverage  contains reports/coverage.{json,xml}
+#
+# reports/coverage.json drives mkdocs-terok's code-coverage treemap. The unit
+# tests workflow already produces it, so the docs build downloads that artifact
+# instead of paying for a second `make test-unit`. The coverage JSON itself is
+# throwaway: only the rendered SVG is published.
+#
+# Freshness policy:
+#   master ref  -> require the same-SHA Tests & Analysis run to complete
+#                  successfully (with a 20m wait). The published treemap must
+#                  match the published code.
+#   other refs  -> try same-SHA opportunistically, fall back immediately to
+#                  the latest successful master run. PR builds are not
+#                  published, so a one-merge-stale treemap is acceptable in
+#                  exchange for never-pending PR feedback.
 name: Documentation
 
 on:
@@ -13,12 +30,14 @@ concurrency:
   group: "pages"
   cancel-in-progress: false
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   build:
     if: github.repository == 'terok-ai/terok-shield'
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     steps:
       - uses: actions/checkout@v6
 
@@ -51,17 +70,86 @@ jobs:
           echo "6c31f4d0cf3b7a8c5ca910fa4e451949434798f6541ec5dea4b83f4973e13772  scc_Linux_x86_64.tar.gz" | sha256sum -c
           sudo tar xzf scc_Linux_x86_64.tar.gz -C /usr/local/bin scc
 
-      - name: Generate coverage data for treemap
-        # Produces reports/coverage.json, consumed by mkdocs-terok's
-        # code_metrics generator to render a local SVG treemap. Replaces
-        # the previous curl from codecov.io/.../tree.svg, which intermittently
-        # failed.
-        run: make test-unit
+      # On master we strictly require the Tests & Analysis run for *this* commit
+      # to have finished successfully — published docs must agree with published
+      # code. Tests & Analysis only contains the fast in-repo jobs (unit-tests,
+      # ruff, bandit); the third-party SonarQube scan lives in sonar.yml, so
+      # waiting on workflow completion here no longer drags in Sonar wait time.
+      # Polling rather than `workflow_run` keeps this build visible as its own
+      # PR check.
+      - name: Wait for Tests & Analysis on this commit (master)
+        if: github.ref == 'refs/heads/master'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const deadline = Date.now() + 20 * 60 * 1000;
+            const sleep = ms => new Promise(r => setTimeout(r, ms));
+            while (Date.now() < deadline) {
+              const { data } = await github.rest.actions.listWorkflowRuns({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: 'analysis.yml',
+                head_sha: context.sha,
+                per_page: 5,
+              });
+              const run = data.workflow_runs[0];
+              if (run?.status === 'completed') {
+                if (run.conclusion === 'success') {
+                  core.info(`Tests & Analysis succeeded for ${context.sha}`);
+                  return;
+                }
+                core.setFailed(
+                  `Tests & Analysis ${run.conclusion} for ${context.sha} — refusing to publish docs with a mismatched treemap`
+                );
+                return;
+              }
+              core.info(`Tests & Analysis for ${context.sha}: ${run?.status ?? 'not yet started'} — waiting`);
+              await sleep(20_000);
+            }
+            core.setFailed('Timed out after 20m waiting for Tests & Analysis')
+
+      - name: Coverage artifact (master — same SHA, required)
+        if: github.ref == 'refs/heads/master'
+        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
+        with:
+          workflow: analysis.yml
+          workflow_conclusion: success
+          commit: ${{ github.sha }}
+          name: coverage
+          path: reports
+          if_no_artifact_found: fail
+
+      # First push of a PR: Tests & Analysis and this workflow start together,
+      # so this step usually misses and we fall through to latest-master below.
+      # Re-running this workflow after Tests & Analysis goes green picks up the
+      # same-SHA artifact here instead.
+      - name: Coverage artifact (non-master — same SHA, best effort)
+        if: github.ref != 'refs/heads/master'
+        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
+        with:
+          workflow: analysis.yml
+          workflow_conclusion: success
+          commit: ${{ github.event.pull_request.head.sha || github.sha }}
+          name: coverage
+          path: reports
+          if_no_artifact_found: warn
+
+      - name: Coverage artifact (non-master — fall back to latest master)
+        if: github.ref != 'refs/heads/master' && !hashFiles('reports/coverage.json')
+        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
+        with:
+          workflow: analysis.yml
+          workflow_conclusion: success
+          branch: master
+          name: coverage
+          path: reports
+          if_no_artifact_found: fail
 
       - name: Build documentation
         run: poetry run properdocs build --strict
 
       - name: Upload artifact
+        if: github.ref == 'refs/heads/master'
         uses: actions/upload-pages-artifact@v5
         with:
           path: site

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -1,0 +1,103 @@
+name: SonarQube Cloud
+
+# Pin third-party actions to full commit SHAs for supply-chain security.
+# GitHub-owned actions (actions/*) may use version tags.
+#
+# Same-repo SonarQube scan. Split out of analysis.yml so its third-party
+# wait time doesn't block the Tests & Analysis workflow's conclusion (which
+# docs.yml waits on, and which gates the master Pages deploy).
+#
+# Triggering contexts (must match the inline sonar job this replaces):
+#   - push to master in terok-ai/terok-shield
+#   - same-repo pull request against master (excluding dependabot)
+# Fork PRs continue to be handled by sonar_pr.yml via workflow_run in the
+# trusted base-repo context, because GitHub does not expose SONAR_TOKEN to
+# runs originating from forks.
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  sonar:
+    name: SonarQube Cloud
+    if: >-
+      github.repository == 'terok-ai/terok-shield' &&
+      github.actor != 'dependabot[bot]' &&
+      (github.event_name == 'push'
+       || github.event_name == 'workflow_dispatch'
+       || github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Wait for Tests & Analysis on this commit
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const deadline = Date.now() + 20 * 60 * 1000;
+            const sleep = ms => new Promise(r => setTimeout(r, ms));
+            const sha = context.payload.pull_request?.head.sha || context.sha;
+            while (Date.now() < deadline) {
+              const { data } = await github.rest.actions.listWorkflowRuns({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: 'analysis.yml',
+                head_sha: sha,
+                per_page: 5,
+              });
+              const run = data.workflow_runs[0];
+              if (run?.status === 'completed') {
+                if (run.conclusion === 'success') {
+                  core.info(`Tests & Analysis succeeded for ${sha}`);
+                  return;
+                }
+                core.setFailed(`Tests & Analysis ${run.conclusion} for ${sha}`);
+                return;
+              }
+              core.info(`Tests & Analysis for ${sha}: ${run?.status ?? 'not yet started'} — waiting`);
+              await sleep(20_000);
+            }
+            core.setFailed('Timed out after 20m waiting for Tests & Analysis')
+
+      - name: Coverage artifact
+        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
+        with:
+          workflow: analysis.yml
+          workflow_conclusion: success
+          commit: ${{ github.event.pull_request.head.sha || github.sha }}
+          name: coverage
+          path: reports
+
+      - name: Ruff artifact
+        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
+        with:
+          workflow: analysis.yml
+          workflow_conclusion: success
+          commit: ${{ github.event.pull_request.head.sha || github.sha }}
+          name: ruff
+          path: reports
+
+      - name: Bandit artifact
+        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
+        with:
+          workflow: analysis.yml
+          workflow_conclusion: success
+          commit: ${{ github.event.pull_request.head.sha || github.sha }}
+          name: bandit
+          path: reports
+
+      - name: SonarQube Cloud scan
+        uses: SonarSource/sonarqube-scan-action@59db25f34e16620e48ab4bb9e4a5dce155cb5432 # v8.0.0
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## Summary

Mirrors the cleanup landed in terok-ai/terok#930. Splits the inline `sonar` job out of `analysis.yml` so that the **Tests & Analysis** workflow no longer blocks on a third-party service. Downstream consumers reuse the `coverage`/`ruff`/`bandit` artifacts already uploaded by the unit-tests/ruff/bandit jobs.

## File changes

| File | Change |
|---|---|
| `analysis.yml` | Remove the inline `sonar` job. Replace with a comment pointing at sonar.yml / sonar_pr.yml. |
| `sonar.yml` | **New.** Triggers on push to master + same-repo PR + workflow_dispatch. Polls analysis.yml's run for this commit to complete, then downloads the artifacts via dawidd6 and runs SonarSource scan. |
| `docs.yml` | Drops the `make test-unit` step in favour of `dawidd6/action-download-artifact` against analysis.yml's `coverage` artifact. Master gate waits for the same-SHA Tests & Analysis run; PR builds fall back to latest-master coverage. |
| `sonar_pr.yml` | Unchanged — still handles fork PRs via workflow_run. |

## Contexts preserved

| Context | Before | After |
|---|---|---|
| same-repo push to master | inline `sonar` job | `sonar.yml` |
| same-repo PR against master | inline `sonar` job (skip dependabot) | `sonar.yml` (same skip) |
| fork PR against master | `sonar_pr.yml` | `sonar_pr.yml` (unchanged) |

Both `sonar.yml` and `docs.yml` trigger on `push`/`pull_request` directly so they appear as their own PR checks.

## Test plan

- [ ] PR check column shows `Tests & Analysis`, `Documentation`, and `SonarQube Cloud` as separate checks.
- [ ] `Tests & Analysis` finishes in a few minutes (no longer waits on sonar).
- [ ] `Documentation` PR build falls back to latest-master coverage on first run; re-run picks up same-SHA after Tests & Analysis goes green.
- [ ] `SonarQube Cloud` on a same-repo PR waits for Tests & Analysis success, downloads artifacts, runs scan.
- [ ] After merge to master: Documentation deploys to Pages as soon as Tests & Analysis succeeds; SonarQube Cloud scans master in parallel.
- [ ] Fork PRs still scan via `sonar_pr.yml` workflow_run path (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized code quality scanning workflows for improved efficiency and maintainability
  * Enhanced documentation publication process with additional validation checks
  * Strengthened CI/CD security measures through enhanced permission controls and dependency pinning

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok-shield/pull/301)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->