### PR TITLE
test(matrix): repair integration matrix; add ubuntu26.04, fedora44

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ test-integration:
 	mkdir -p $(REPORTS_DIR)
 	poetry run pytest tests/integration/ -v --junitxml=$(INTEGRATION_JUNIT_XML) -o junit_family=legacy
 
-# Multi-distro integration test matrix (Debian 12/13, Ubuntu 24.04, Fedora 43)
+# Multi-distro integration test matrix (Debian 12/13, Ubuntu 24.04/26.04, Fedora 43/44, podman:stable)
 # Options (env vars):
 #   NO_CACHE=1    Rebuild images from scratch (ignore layer cache)
 #   BUILD_ONLY=1  Build images without running tests

--- a/poetry.lock
+++ b/poetry.lock
@@ -1738,14 +1738,14 @@ test = ["pytest", "pytest-cov"]
 
 [[package]]
 name = "python-discovery"
-version = "1.2.2"
+version = "1.3.1"
 description = "Python interpreter discovery"
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
 files = [
-    {file = "python_discovery-1.2.2-py3-none-any.whl", hash = "sha256:e1ae95d9af875e78f15e19aed0c6137ab1bb49c200f21f5061786490c9585c7a"},
-    {file = "python_discovery-1.2.2.tar.gz", hash = "sha256:876e9c57139eb757cb5878cbdd9ae5379e5d96266c99ef731119e04fffe533bb"},
+    {file = "python_discovery-1.3.1-py3-none-any.whl", hash = "sha256:ed188687ebb3b82c01a17cd5ac62fc94d9f6487a7f1a0f9dfe89753fec91039c"},
+    {file = "python_discovery-1.3.1.tar.gz", hash = "sha256:62f6db28064c9613e7ca76cb3f00c38c839a07c31c00dfe7ed0986493d2150a6"},
 ]
 
 [package.dependencies]
@@ -1753,7 +1753,7 @@ filelock = ">=3.15.4"
 platformdirs = ">=4.3.6,<5"
 
 [package.extras]
-docs = ["furo (>=2025.12.19)", "sphinx (>=9.1)", "sphinx-autodoc-typehints (>=3.6.3)", "sphinxcontrib-mermaid (>=2)"]
+docs = ["furo (>=2025.12.19)", "sphinx (>=9.1)", "sphinx-autodoc-typehints (>=3.6.3)", "sphinxcontrib-mermaid (>=2)", "sphinxcontrib-towncrier (>=0.4)", "towncrier (>=25.8)"]
 testing = ["covdefaults (>=2.3)", "coverage (>=7.5.4)", "pytest (>=8.3.5)", "pytest-mock (>=3.14)", "setuptools (>=75.1)"]
 
 [[package]]
@@ -2228,14 +2228,14 @@ zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 
 [[package]]
 name = "virtualenv"
-version = "21.2.4"
+version = "21.3.2"
 description = "Virtual Python Environment builder"
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
 files = [
-    {file = "virtualenv-21.2.4-py3-none-any.whl", hash = "sha256:29d21e941795206138d0f22f4e45ff7050e5da6c6472299fb7103318763861ac"},
-    {file = "virtualenv-21.2.4.tar.gz", hash = "sha256:b294ef68192638004d72524ce7ef303e9d0cf5a44c95ce2e54a7500a6381cada"},
+    {file = "virtualenv-21.3.2-py3-none-any.whl", hash = "sha256:c58ea748fa50bb2a4367da5ba3d30b02458ed40b4ea888faad94021f3309f764"},
+    {file = "virtualenv-21.3.2.tar.gz", hash = "sha256:3ecda97894a6fc1c53106356f488690e5c86278c1f693f3fc0805ac85a513686"},
 ]
 
 [package.dependencies]

--- a/tests/containers/Containerfile.fedora44
+++ b/tests/containers/Containerfile.fedora44
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+# Fedora 44 — podman 5.x line, pasta default, looking forward
+FROM registry.fedoraproject.org/fedora:44
+
+RUN dnf install -y \
+    podman passt nftables slirp4netns fuse-overlayfs crun \
+    python3 python3-pip \
+    git curl bind-utils \
+    && dnf clean all
+
+# ── Rootless podman nesting setup (mirrors quay.io/podman/stable) ────
+# Subordinate UID/GID ranges MUST stay within 0-65535 so they fit inside
+# the outer rootless-podman container's user-namespace mapping.
+RUN useradd -m testrunner \
+    && uid=$(id -u testrunner) \
+    && printf "testrunner:1:%d\ntestrunner:%d:%d\n" \
+        $((uid - 1)) $((uid + 1)) $((65535 - uid)) > /etc/subuid \
+    && cp /etc/subuid /etc/subgid \
+    && chmod 4755 /usr/bin/newuidmap /usr/bin/newgidmap \
+    && printf '[storage]\ndriver = "overlay"\n\n[storage.options.overlay]\nmount_program = "/usr/bin/fuse-overlayfs"\nmountopt = "nodev,fsync=0"\n' \
+        > /etc/containers/storage.conf \
+    && printf '[engine]\ncgroup_manager = "cgroupfs"\nevents_logger = "file"\n\n# Disable per-container kernel keyring \xe2\x80\x94 prevents keyring leak / EDQUOT\n[containers]\nkeyring = false\n' \
+        > /etc/containers/containers.conf \
+    && mkdir -p /run/user/$uid \
+    && chown testrunner:testrunner /run/user/$uid
+
+WORKDIR /src

--- a/tests/containers/Containerfile.podman
+++ b/tests/containers/Containerfile.podman
@@ -14,7 +14,11 @@ RUN dnf install -y \
 # Ensure runtime dir exists for the pre-existing 'podman' user
 RUN mkdir -p /run/user/$(id -u podman) && chown podman:podman /run/user/$(id -u podman)
 
-# Disable per-container kernel keyring — prevents keyring leak / EDQUOT
-RUN printf '\n[containers]\nkeyring = false\n' >> /etc/containers/containers.conf
+# Disable per-container kernel keyring — prevents keyring leak / EDQUOT.
+# Use a conf.d drop-in: the base image already defines [containers] in the
+# main file, and TOML rejects a duplicate section header.
+RUN mkdir -p /etc/containers/containers.conf.d \
+    && printf '[containers]\nkeyring = false\n' \
+        > /etc/containers/containers.conf.d/00-no-keyring.conf
 
 WORKDIR /src

--- a/tests/containers/Containerfile.ubuntu2604
+++ b/tests/containers/Containerfile.ubuntu2604
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+# Ubuntu 26.04 (Resolute) — next LTS, pulls in a newer podman than 24.04
+FROM docker.io/library/ubuntu:26.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    podman slirp4netns passt nftables uidmap fuse-overlayfs crun \
+    python3 python3-pip python3-venv \
+    git curl ca-certificates dnsutils \
+    && rm -rf /var/lib/apt/lists/*
+
+# ── Rootless podman nesting setup (mirrors quay.io/podman/stable) ────
+# Subordinate UID/GID ranges MUST stay within 0-65535 so they fit inside
+# the outer rootless-podman container's user-namespace mapping.
+RUN useradd -m testrunner \
+    && uid=$(id -u testrunner) \
+    && printf "testrunner:1:%d\ntestrunner:%d:%d\n" \
+        $((uid - 1)) $((uid + 1)) $((65535 - uid)) > /etc/subuid \
+    && cp /etc/subuid /etc/subgid \
+    && chmod 4755 /usr/bin/newuidmap /usr/bin/newgidmap \
+    && mkdir -p /etc/containers \
+    && printf '[storage]\ndriver = "overlay"\n\n[storage.options.overlay]\nmount_program = "/usr/bin/fuse-overlayfs"\nmountopt = "nodev,fsync=0"\n' \
+        > /etc/containers/storage.conf \
+    && printf '[engine]\ncgroup_manager = "cgroupfs"\nevents_logger = "file"\n\n# Disable per-container kernel keyring \xe2\x80\x94 prevents keyring leak / EDQUOT\n[containers]\nkeyring = false\n' \
+        > /etc/containers/containers.conf \
+    && mkdir -p /run/user/$uid \
+    && chown testrunner:testrunner /run/user/$uid
+
+WORKDIR /src

--- a/tests/containers/run-matrix.sh
+++ b/tests/containers/run-matrix.sh
@@ -186,13 +186,15 @@ run_tests() {
                 cd $WORKSPACE_DIR
 
                 echo \"--- podman version ---\"
-                # Capture observed version into the shared /results dir
-                # for the host-side summary (line 1, last whitespace field
-                # → e.g. \"5.8.2\").  Tolerate podman being unavailable.
-                if podman_ver=\$(podman --version 2>&1); then
-                    echo \"\$podman_ver\"
-                    echo \"\$podman_ver\" | head -n1 | awk '{print \$NF}' \
-                        > /results/$name.podman-version
+                # Capture observed version into the shared /results dir.
+                # No single quotes anywhere in this inner block — it is
+                # wrapped in a single-quoted su -c argument, so any single
+                # quote would close it early.  Parameter expansion only.
+                if command -v podman >/dev/null 2>&1; then
+                    podman_ver_line=\$(podman --version 2>&1 | head -n1)
+                    echo \"\$podman_ver_line\"
+                    # podman version 5.8.2 -> 5.8.2
+                    echo \"\${podman_ver_line##* }\" > /results/$name.podman-version
                 else
                     echo \"podman not available\"
                     : > /results/$name.podman-version

--- a/tests/containers/run-matrix.sh
+++ b/tests/containers/run-matrix.sh
@@ -42,8 +42,10 @@ fi
 declare -A DISTROS=(
     [debian12]="debian12"
     [ubuntu2404]="ubuntu2404"
+    [ubuntu2604]="ubuntu2604"
     [debian13]="debian13"
     [fedora43]="fedora43"
+    [fedora44]="fedora44"
     [podman]="podman"
 )
 
@@ -51,8 +53,10 @@ declare -A DISTROS=(
 declare -A EXPECTED_VERSIONS=(
     [debian12]="4.3.x"
     [ubuntu2404]="4.9.x"
+    [ubuntu2604]="5.x"
     [debian13]="5.4.x"
     [fedora43]="5.8.x"
+    [fedora44]="5.x"
     [podman]="latest"
 )
 
@@ -61,8 +65,10 @@ declare -A EXPECTED_VERSIONS=(
 declare -A TEST_USERS=(
     [debian12]="testrunner"
     [ubuntu2404]="testrunner"
+    [ubuntu2604]="testrunner"
     [debian13]="testrunner"
     [fedora43]="testrunner"
+    [fedora44]="testrunner"
     [podman]="podman"
 )
 

--- a/tests/containers/run-matrix.sh
+++ b/tests/containers/run-matrix.sh
@@ -25,6 +25,16 @@ SOURCE_MOUNT="/src"
 WORKSPACE_DIR="/workspace"
 PYTHON_VERSION="3.12"
 
+# Host-side scratch dir each test container writes its observed podman
+# version to.  Surfaced after each distro and in the final summary so the
+# matrix report shows what was actually exercised, not just what we expected.
+RESULTS_DIR="$(mktemp -d "${TMPDIR:-/tmp}/terok-shield-matrix-XXXXXX")"
+chmod 0777 "$RESULTS_DIR"
+trap 'rm -rf "$RESULTS_DIR"' EXIT
+
+# distro name -> observed podman version (populated by run_tests).
+declare -A ACTUAL_VERSIONS=()
+
 # ── Terminal colors (disabled when stdout is not a tty) ──
 if [[ -t 1 ]]; then
     C_BOLD='\033[1m'
@@ -53,10 +63,10 @@ declare -A DISTROS=(
 declare -A EXPECTED_VERSIONS=(
     [debian12]="4.3.x"
     [ubuntu2404]="4.9.x"
-    [ubuntu2604]="5.x"
+    [ubuntu2604]="5.7.x"
     [debian13]="5.4.x"
     [fedora43]="5.8.x"
-    [fedora44]="5.x"
+    [fedora44]="5.8.x"
     [podman]="latest"
 )
 
@@ -151,6 +161,7 @@ run_tests() {
         --device /dev/fuse:rw \
         -e container=podman \
         -v "$REPO_ROOT:$SOURCE_MOUNT:ro,Z" \
+        -v "$RESULTS_DIR:/results:rw,Z" \
         "$image" \
         bash -c "
             set -e
@@ -175,7 +186,17 @@ run_tests() {
                 cd $WORKSPACE_DIR
 
                 echo \"--- podman version ---\"
-                podman --version || echo \"podman not available\"
+                # Capture observed version into the shared /results dir
+                # for the host-side summary (line 1, last whitespace field
+                # → e.g. \"5.8.2\").  Tolerate podman being unavailable.
+                if podman_ver=\$(podman --version 2>&1); then
+                    echo \"\$podman_ver\"
+                    echo \"\$podman_ver\" | head -n1 | awk '{print \$NF}' \
+                        > /results/$name.podman-version
+                else
+                    echo \"podman not available\"
+                    : > /results/$name.podman-version
+                fi
 
                 echo \"--- rootless podman preflight ---\"
                 podman info --format \"podman={{.Version.Version}} storage={{.Store.GraphDriverName}}\" \
@@ -237,10 +258,18 @@ run_tests() {
         "
 
     local status=$?
+
+    # Pick up what the inner script observed (may be empty if podman
+    # was missing or the container died before reaching that step).
+    local actual
+    actual=$(cat "$RESULTS_DIR/$name.podman-version" 2>/dev/null || true)
+    ACTUAL_VERSIONS[$name]="${actual:-?}"
+
+    local versions="expected ${EXPECTED_VERSIONS[$name]}, got ${ACTUAL_VERSIONS[$name]}"
     if [[ $status -eq 0 ]]; then
-        echo -e "${C_GREEN}==> $name: PASS${C_RESET}"
+        echo -e "${C_GREEN}==> $name: PASS${C_RESET} ${C_DIM}($versions)${C_RESET}"
     else
-        echo -e "${C_RED}==> $name: FAIL${C_RESET}" >&2
+        echo -e "${C_RED}==> $name: FAIL${C_RESET} ${C_DIM}($versions)${C_RESET}" >&2
     fi
     return "$status"
 }
@@ -311,10 +340,10 @@ done
 echo ""
 echo -e "${C_BOLD}===== Matrix Summary =====${C_RESET}"
 for target in "${PASSED[@]}"; do
-    echo -e "  ${C_GREEN}PASS${C_RESET}: $target ${C_DIM}(podman ${EXPECTED_VERSIONS[$target]})${C_RESET}"
+    echo -e "  ${C_GREEN}PASS${C_RESET}: $target ${C_DIM}(expected ${EXPECTED_VERSIONS[$target]}, got ${ACTUAL_VERSIONS[$target]:-?})${C_RESET}"
 done
 for target in "${FAILED[@]}"; do
-    echo -e "  ${C_RED}FAIL${C_RESET}: $target ${C_DIM}(podman ${EXPECTED_VERSIONS[$target]})${C_RESET}"
+    echo -e "  ${C_RED}FAIL${C_RESET}: $target ${C_DIM}(expected ${EXPECTED_VERSIONS[$target]}, got ${ACTUAL_VERSIONS[$target]:-?})${C_RESET}"
 done
 
 if [[ ${#FAILED[@]} -gt 0 ]]; then

--- a/tests/integration/bypass/test_lifecycle.py
+++ b/tests/integration/bypass/test_lifecycle.py
@@ -33,6 +33,7 @@ from ..conftest import (
 from ..helpers import (
     assert_blocked,
     assert_connectable,
+    assert_not_connectable,
     assert_reachable,
     disposable_shield as _shield,
     start_shielded_container,
@@ -180,18 +181,17 @@ class TestBypassWithAllowDeny:
         # Verify the IP is still allowed
         assert_connectable(shielded_container, BLOCKED_TARGET_IP, BLOCKED_TARGET_DNS_PORT)
 
-    def test_deny_during_bypass_has_no_traffic_effect(self, shielded_container: str) -> None:
-        """Denying during bypass doesn't block traffic (policy is accept).
+    def test_deny_during_bypass_blocks_traffic(self, shielded_container: str) -> None:
+        """Deny is enforced even in bypass mode — deny sets shadow the accept policy.
 
-        In bypass mode the output chain policy is accept, so removing
-        an IP from the allow set has no effect on traffic flow.
+        The bypass ruleset retains the ``deny_v4``/``deny_v6`` sets so an
+        operator-driven deny still drops matching traffic.  See PR #230.
         """
         shield = _shield()
         shield.down(shielded_container)
 
-        # Deny shouldn't affect traffic in bypass mode
         shield.deny(shielded_container, BLOCKED_TARGET_IP)
-        assert_connectable(shielded_container, BLOCKED_TARGET_IP, BLOCKED_TARGET_DNS_PORT)
+        assert_not_connectable(shielded_container, BLOCKED_TARGET_IP, BLOCKED_TARGET_DNS_PORT)
 
 
 @pytest.mark.needs_podman

--- a/tests/integration/dns/test_api_resolve.py
+++ b/tests/integration/dns/test_api_resolve.py
@@ -57,7 +57,7 @@ class TestCLIResolve:
 
     def test_cli_resolve(self, shield_env: Path, capsys: pytest.CaptureFixture) -> None:
         """``main(["resolve", container])`` prints resolved IP count."""
-        main(["resolve", "cli-resolve-test"])
+        main(["--state-dir", str(shield_env), "resolve", "cli-resolve-test"])
         captured = capsys.readouterr()
         assert "Resolved" in captured.out
         assert "cli-resolve-test" in captured.out

--- a/tests/integration/safety/test_fail_closed.py
+++ b/tests/integration/safety/test_fail_closed.py
@@ -20,22 +20,22 @@ class TestCLIErrors:
     """Verify CLI error handling that requires podman."""
 
     def test_cli_allow_bad_container(self, shield_env: Path) -> None:
-        """Allowing on a nonexistent container exits 1."""
+        """Allowing on a nonexistent container exits non-zero."""
         bogus = f"nonexistent-{uuid.uuid4().hex[:12]}"
         with pytest.raises(SystemExit) as exc_info:
             main(["allow", bogus, TEST_IP1])
-        assert exc_info.value.code == 1
+        assert exc_info.value.code
 
     def test_cli_down_bad_container(self, shield_env: Path) -> None:
-        """``down`` on a nonexistent container exits 1."""
+        """``down`` on a nonexistent container exits non-zero."""
         bogus = f"nonexistent-{uuid.uuid4().hex[:12]}"
         with pytest.raises(SystemExit) as exc_info:
             main(["down", bogus])
-        assert exc_info.value.code == 1
+        assert exc_info.value.code
 
     def test_cli_up_bad_container(self, shield_env: Path) -> None:
-        """``up`` on a nonexistent container exits 1."""
+        """``up`` on a nonexistent container exits non-zero."""
         bogus = f"nonexistent-{uuid.uuid4().hex[:12]}"
         with pytest.raises(SystemExit) as exc_info:
             main(["up", bogus])
-        assert exc_info.value.code == 1
+        assert exc_info.value.code

--- a/tests/unit/test_nft_hook.py
+++ b/tests/unit/test_nft_hook.py
@@ -644,7 +644,8 @@ def test_main_returns_1_when_pid_missing_for_createruntime(tmp_path: Path) -> No
 def test_main_dispatches_createruntime_and_returns_0(tmp_path: Path) -> None:
     """main() calls _createruntime() and returns 0 on success."""
     sd = tmp_path / "sd"
-    sd.mkdir()
+    sd.mkdir(mode=0o700)
+    sd.chmod(0o700)  # state_dir_from_oci() rejects group/world-writable dirs
     (sd / "ruleset.nft").write_text("table inet terok_shield {}")
 
     oci = _oci_json(pid=42, state_dir=str(sd))
@@ -659,7 +660,8 @@ def test_main_dispatches_createruntime_and_returns_0(tmp_path: Path) -> None:
 def test_main_persists_container_id(tmp_path: Path) -> None:
     """main() writes the short container ID to state_dir/container.id."""
     sd = tmp_path / "sd"
-    sd.mkdir()
+    sd.mkdir(mode=0o700)
+    sd.chmod(0o700)  # state_dir_from_oci() rejects group/world-writable dirs
     full_id = "abc123def456789abcdef0123456789abcdef0123456789abcdef0123456789a"
     oci = _oci_json(pid=42, state_dir=str(sd), container_id=full_id)
 
@@ -675,7 +677,8 @@ def test_main_persists_container_id(tmp_path: Path) -> None:
 def test_main_dispatches_poststop_and_returns_0(tmp_path: Path) -> None:
     """main() calls _poststop() and returns 0 on success."""
     sd = tmp_path / "sd"
-    sd.mkdir()
+    sd.mkdir(mode=0o700)
+    sd.chmod(0o700)  # state_dir_from_oci() rejects group/world-writable dirs
 
     oci = _oci_json(pid=0, state_dir=str(sd))
 
@@ -693,7 +696,8 @@ def test_main_dispatches_poststop_on_version_mismatch(tmp_path: Path) -> None:
     before a terok-shield upgrade still needs its dnsmasq reaped on stop.
     """
     sd = tmp_path / "sd"
-    sd.mkdir()
+    sd.mkdir(mode=0o700)
+    sd.chmod(0o700)  # state_dir_from_oci() rejects group/world-writable dirs
     oci = _oci_json(pid=0, state_dir=str(sd), version=999)
 
     with mock.patch("terok_shield.resources.nft_hook._poststop") as mock_ps:


### PR DESCRIPTION
## Summary

Last matrix run failed on all 5 distros for three distinct reasons; this PR fixes each at the root and extends the matrix with ubuntu26.04 and fedora44.

**Runner-env fixes (no `pyproject.toml` capping)**
- `poetry.lock`: bump `virtualenv 21.2.4 → 21.3.2` and `python-discovery 1.2.2 → 1.3.1` — targeted refresh of just those two packages. The pinned versions had a broken plugin-discovery code path that Poetry's build-isolation venv setup tripped on every distro that *wasn't* using debian12's uv-installed Python 3.12. The matrix was emitting *No module named 'virtualenv.create.via_global_ref.builtin.cpython'* on Fedora 43 / Ubuntu 24.04 and *No discovery plugin found* on Debian 13 — different symptoms, same upstream bug.
- `Containerfile.podman` now drops `keyring = false` into `/etc/containers/containers.conf.d/00-no-keyring.conf` rather than appending a second `[containers]` header to the main file. The current `quay.io/podman/stable` (Fedora 44-based) already defines `[containers]`, and TOML rejects the duplicate.

Each distro keeps its native Python — debian12 stays on uv-installed 3.12, since bookworm's 3.11 system Python is below the project's required 3.12.

**Stale-test fixes surfaced by debian12 (the only distro that got to run tests last time)**
- `tests/integration/safety/test_fail_closed.py`: assert `exc_info.value.code` is truthy. `_resolve_state_dir` raises `SystemExit("error message…")` by design — pinned by the existing unit test `test_build_config_errors_when_annotation_missing` — so `.code` is a non-zero **string**, not `1`.
- `tests/integration/dns/test_api_resolve.py::test_cli_resolve`: pass `--state-dir <shield_env>` explicitly. There is no real podman container called `cli-resolve-test`, so without `--state-dir` the new annotation-required path correctly aborts before `resolve` runs.
- `tests/integration/bypass/test_lifecycle.py`: renamed `test_deny_during_bypass_has_no_traffic_effect` → `test_deny_during_bypass_blocks_traffic`, swapped `assert_connectable` for `assert_not_connectable`. PR #230 deliberately made `deny.list` enforced in bypass mode; the previous assertion encoded pre-#230 behavior.

**Matrix extension**
- New `Containerfile.fedora44` and `Containerfile.ubuntu2604`.
- `tests/containers/run-matrix.sh` `DISTROS` / `EXPECTED_VERSIONS` / `TEST_USERS` arrays extended; Makefile help comment updated.

## Test plan

- [ ] `make test-matrix` runs cleanly on the dev HW machine across all 7 distros (`debian12`, `debian13`, `ubuntu2404`, `ubuntu2604`, `fedora43`, `fedora44`, `podman`)
- [ ] `NO_CACHE=1 make test-matrix` produces the same green result (no stale image layers hiding the fix)
- [ ] Each distro reports `podman_version=…` consistent with its `EXPECTED_VERSIONS` entry and runs both unit and integration suites
- [ ] Spot-check the renamed bypass test passes — confirms the `deny`-in-bypass enforcement contract from #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added Ubuntu 26.04 and Fedora 44 to the integration test matrix and container images.
  * Test runner now collects observed Podman versions per distro for pass/fail reporting.
  * Strengthened bypass tests to assert denied IPs remain blocked (including DNS).
  * Relaxed CLI error tests to accept any non-zero exit code for certain failure cases.
  * Hardened temp state-dir permissions in several unit tests.

* **Chores**
  * Expanded test matrix documentation to list additional target environments and switched Podman keyring to a drop-in configuration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok-shield/pull/303)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->