### PR TITLE
feat(registry): add children field to CommandDef for unified structural shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ also the "Changelog" link in PyPI metadata.
 
 [rel]: https://github.com/terok-ai/terok-shield/releases
 
+## v0.6.40 — The Tree of Command
+
+**Full Changelog**: https://github.com/terok-ai/terok-shield/compare/v0.6.39...v0.6.40
+
 ## v0.6.39 — Checkpoint Charlie
 
 * introduce mypy as the static type checker in https://github.com/terok-ai/terok-shield/pull/288

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.poetry]
 name = "terok-shield"
-version = "0.6.39"
+version = "0.6.40"
 description = "nftables-based egress firewalling for Podman containers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/terok_shield/cli/registry.py
+++ b/src/terok_shield/cli/registry.py
@@ -35,6 +35,15 @@ class ArgDef:
 class CommandDef:
     """Definition of a shield subcommand.
 
+    Structurally compatible with terok-sandbox's ``CommandDef``: same
+    attribute names + ``children`` for nested verb groups, so
+    downstream consumers (terok-sandbox) can wire the registry through
+    sandbox's ``CommandTree`` without a per-package adapter.  Shield-
+    specific fields (``needs_container``, ``standalone_only``) stay
+    first-class — they're load-bearing for shield's own CLI — but the
+    unified ``CommandTree.wire`` ignores fields it doesn't know about,
+    so the extra fields don't leak downstream.
+
     Attributes:
         name: Subcommand name (e.g. ``"allow"``).
         help: One-line help string for ``--help``.
@@ -42,6 +51,9 @@ class CommandDef:
         needs_container: Whether the command requires a ``container`` positional arg.
         args: Extra arguments beyond the implicit ``container``.
         standalone_only: If True, only available in the standalone CLI, not via terok.
+        children: Sub-verbs.  Empty for every existing shield verb —
+            present for structural compatibility with the unified
+            CommandDef shape across the terok-ai ecosystem.
     """
 
     name: str
@@ -50,6 +62,7 @@ class CommandDef:
     needs_container: bool = False
     args: tuple[ArgDef, ...] = ()
     standalone_only: bool = False
+    children: tuple["CommandDef", ...] = ()
 
 
 # ── Handler functions (ordered to match COMMANDS) ────────

--- a/src/terok_shield/cli/registry.py
+++ b/src/terok_shield/cli/registry.py
@@ -35,14 +35,15 @@ class ArgDef:
 class CommandDef:
     """Definition of a shield subcommand.
 
-    Structurally compatible with terok-sandbox's ``CommandDef``: same
-    attribute names + ``children`` for nested verb groups, so
-    downstream consumers (terok-sandbox) can wire the registry through
-    sandbox's ``CommandTree`` without a per-package adapter.  Shield-
-    specific fields (``needs_container``, ``standalone_only``) stay
-    first-class — they're load-bearing for shield's own CLI — but the
-    unified ``CommandTree.wire`` ignores fields it doesn't know about,
-    so the extra fields don't leak downstream.
+    Structurally compatible with terok-sandbox's
+    [`CommandDef`][terok_sandbox.commands.CommandDef]: same attribute
+    names + ``children`` for nested verb groups, so downstream
+    consumers (terok-sandbox) can wire the registry through sandbox's
+    [`CommandTree`][terok_sandbox.commands.CommandTree] without a
+    per-package adapter.  Shield-specific fields (``needs_container``,
+    ``standalone_only``) stay first-class — they're load-bearing for
+    shield's own CLI — but the unified wire layer ignores fields it
+    doesn't know about, so the extra fields don't leak downstream.
 
     Attributes:
         name: Subcommand name (e.g. ``"allow"``).


### PR DESCRIPTION
## Summary

Adds a \`children: tuple[CommandDef, ...] = ()\` field to shield's \`CommandDef\` — default empty since every existing shield verb is a leaf. Brings shield's vocabulary into structural alignment with [terok-sandbox's CommandDef](https://github.com/terok-ai/terok-sandbox/pull/295) so downstream consumers (terok-sandbox) can wire the shield registry through sandbox's \`CommandTree\` without a per-package adapter.

Shield-specific fields (\`needs_container\`, \`standalone_only\`) stay first-class — they're load-bearing for shield's standalone CLI — but the unified wire layer reads only the fields it understands, so the extras don't leak downstream.

Pure additive — no behavioural change to the standalone CLI.

## Context

Part of the broader CLI-registry unification across terok-ai. After this lands, terok-sandbox's hand-rolled \`commands/shield.py\` (which currently re-defines a 3-verb subset around shield's library) can consume shield's own \`COMMANDS\` registry directly. Operators get sandbox CLI parity with shield CLI (all verbs reachable via \`terok-sandbox shield <verb>\`).

## Test plan

- [x] \`make lint\`
- [x] \`make test-unit\` — 1176 passed
- [x] \`make tach\`
- [x] \`make docstrings\`
- [x] \`make reuse\`
- [x] \`make security\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI now supports hierarchical subcommand groups for nested command organization; existing commands remain compatible.
* **Documentation**
  * Release notes updated for v0.6.40 with full changelog entry.
* **Chores**
  * Package version bumped to v0.6.40.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok-shield/pull/304)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->