### PR TITLE
feat!: ShieldState vocabulary + tighten panic codepath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ also the "Changelog" link in PyPI metadata.
 
 [rel]: https://github.com/terok-ai/terok-shield/releases
 
+## v0.6.41 — The State of the Shields
+
+## What's Changed
+* feat!: ShieldState vocabulary + tighten panic codepath in https://github.com/terok-ai/terok-shield/pull/307
+* chore: bump virtualenv 21.3.2 → 21.3.3 in lock for py3.14.4 by @sliwowitz in https://github.com/terok-ai/terok-shield/pull/306
+
+
+**Full Changelog**: https://github.com/terok-ai/terok-shield/compare/v0.6.40...v0.6.41
+
 ## v0.6.40 — The Tree of Command
 
 **Full Changelog**: https://github.com/terok-ai/terok-shield/compare/v0.6.39...v0.6.40

--- a/docs/design.md
+++ b/docs/design.md
@@ -198,7 +198,7 @@ shield = Shield(ShieldConfig(state_dir=Path("/path/to/state")))
 | `deny(container, target)` | Live-deny a domain/IP (best-effort) |
 | `down(container)` | Switch to bypass mode (accept-all + log) |
 | `up(container)` | Restore deny-all mode |
-| `state(container)` | Query container shield state (`UP`, `DOWN`, `DOWN_ALL`, `INACTIVE`) |
+| `state(container)` | Query container shield state (`UP`, `DOWN`, `DISENGAGED`, `OFFLINE`) |
 | `rules(container)` | Return current nft ruleset for a container |
 | `resolve(container, profiles)` | Resolve DNS profiles and cache results |
 | `status()` | Return mode, profiles, audit config |

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -91,8 +91,8 @@ Audit:    enabled
 Profiles: base, dev-node, dev-python, dev-standard, nvidia-hpc
 ```
 
-With a container name, prints the live firewall state (`up`, `down`, `down_all`,
-`inactive`, or `error`). Useful for scripting and integration:
+With a container name, prints the live firewall state (`up`, `down`, `disengaged`,
+`offline`, or `error`). Useful for scripting and integration:
 
 ```bash
 terok-shield status my-container

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.poetry]
 name = "terok-shield"
-version = "0.6.40"
+version = "0.6.41"
 description = "nftables-based egress firewalling for Podman containers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/terok_shield/__init__.py
+++ b/src/terok_shield/__init__.py
@@ -372,10 +372,10 @@ class Shield:
         )
         self.hub_events.shield_down(container, allow_all=allow_all, dossier=self._read_dossier())
 
-    def block(self, container: str) -> None:
-        """Total network blackout — drop all traffic, log for forensics."""
-        self._mode.shield_block(container)
-        self.audit.log_event(container, "shield_block")
+    def quarantine(self, container: str) -> None:
+        """Total network blackout — drop all traffic, log dropped traffic."""
+        self._mode.shield_quarantine(container)
+        self.audit.log_event(container, "shield_quarantine")
 
     def up(self, container: str) -> None:
         """Restore normal deny-all mode for a running container."""

--- a/src/terok_shield/_hub_events.py
+++ b/src/terok_shield/_hub_events.py
@@ -71,11 +71,11 @@ class HubEventEmitter:
         allow_all: bool = False,
         dossier: dict[str, str] | None = None,
     ) -> None:
-        """Emit a ``shield_down`` (or ``shield_down_all``) event for *container*.
+        """Emit a ``shield_down`` (or ``shield_disengaged``) event for *container*.
 
         *dossier* — see [`shield_up`][terok_shield._hub_events.HubEventEmitter.shield_up].
         """
-        event_type = "shield_down_all" if allow_all else "shield_down"
+        event_type = "shield_disengaged" if allow_all else "shield_down"
         self._send({"type": event_type, "container": container}, dossier)
 
     def _send(self, payload: dict, dossier: dict[str, str] | None = None) -> None:

--- a/src/terok_shield/cli/main.py
+++ b/src/terok_shield/cli/main.py
@@ -196,7 +196,7 @@ def _build_parser() -> argparse.ArgumentParser:
         if idx == -1:
             return text
         eol = text.index("\n", idx + 1)
-        hint = "\n    status CONTAINER    Query container firewall state (up/down/down_all/inactive/error)"
+        hint = "\n    status CONTAINER    Query container firewall state (up/down/disengaged/offline/error)"
         return text[:eol] + hint + text[eol:]
 
     parser.format_help = _format_help  # type: ignore[method-assign]

--- a/src/terok_shield/cli/registry.py
+++ b/src/terok_shield/cli/registry.py
@@ -124,10 +124,10 @@ def _handle_up(shield: Shield, container: str) -> None:
     print(f"Shield up for {container}")
 
 
-def _handle_block(shield: Shield, container: str) -> None:
+def _handle_quarantine(shield: Shield, container: str) -> None:
     """Total network blackout."""
-    shield.block(container)
-    print(f"Shield BLOCKED for {container} — all traffic dropped")
+    shield.quarantine(container)
+    print(f"Shield QUARANTINED for {container} — all traffic dropped")
 
 
 def _handle_rules(shield: Shield, container: str) -> None:
@@ -215,7 +215,7 @@ COMMANDS: tuple[CommandDef, ...] = (
             ArgDef(
                 name="container",
                 nargs="?",
-                help="Container name — prints firewall state (up/down/down_all/inactive/error)",
+                help="Container name — prints firewall state (up/down/disengaged/offline/error)",
             ),
         ),
     ),
@@ -278,9 +278,9 @@ COMMANDS: tuple[CommandDef, ...] = (
         needs_container=True,
     ),
     CommandDef(
-        name="block",
-        help="Total network blackout (drop all, log for forensics)",
-        handler=_handle_block,
+        name="quarantine",
+        help="Total network blackout (drop all, log dropped traffic)",
+        handler=_handle_quarantine,
         needs_container=True,
     ),
     CommandDef(

--- a/src/terok_shield/config.py
+++ b/src/terok_shield/config.py
@@ -91,19 +91,19 @@ class ShieldMode(enum.Enum):
 class ShieldState(enum.Enum):
     """Per-container shield state, derived from the live nft ruleset.
 
-    BLOCK: Total network blackout — all traffic dropped, forensic logging only.
+    QUARANTINE: Total network blackout — all traffic dropped, dropped traffic logged.
     UP: Normal enforcing mode (deny-all with allowlists).
     DOWN: Bypass mode with private-range protection (RFC 1918 + RFC 4193).
-    DOWN_ALL: Bypass mode without private-range protection.
-    INACTIVE: No ruleset found (container stopped or unshielded).
+    DISENGAGED: Bypass mode without private-range protection.
+    OFFLINE: No ruleset found (container stopped or unshielded).
     ERROR: Ruleset present but unrecognised.
     """
 
-    BLOCK = "block"
+    QUARANTINE = "quarantine"
     UP = "up"
     DOWN = "down"
-    DOWN_ALL = "down_all"
-    INACTIVE = "inactive"
+    DISENGAGED = "disengaged"
+    OFFLINE = "offline"
     ERROR = "error"
 
 
@@ -227,7 +227,7 @@ class ShieldModeBackend(Protocol):
         """Switch a container to bypass mode."""
         ...
 
-    def shield_block(self, container: str) -> None:
+    def shield_quarantine(self, container: str) -> None:
         """Total network blackout — drop all traffic."""
         ...
 

--- a/src/terok_shield/hooks/mode.py
+++ b/src/terok_shield/hooks/mode.py
@@ -472,7 +472,7 @@ class HookMode:
         ruleset = self._container_ruleset(container)
         rs = ruleset.build_bypass(allow_all=allow_all)
         current = self.shield_state(container)
-        if current == ShieldState.INACTIVE:
+        if current == ShieldState.OFFLINE:
             stdin = rs
         else:
             stdin = f"delete table {NFT_TABLE}\n{rs}"
@@ -496,12 +496,18 @@ class HookMode:
         if errors:
             raise RuntimeError(f"Shield-down ruleset verification failed: {'; '.join(errors)}")
 
-    def shield_block(self, container: str) -> None:
-        """Total network blackout — drop all traffic, log for forensics."""
-        ruleset = self._container_ruleset(container)
-        rs = ruleset.build_block()
+    def shield_quarantine(self, container: str) -> None:
+        """Total network blackout — drop all traffic, log dropped traffic.
+
+        Reads no settings — no DNS, no allowlists, no loopback ports,
+        no gateway probe, no profile lookup.  ``build_quarantine`` /
+        ``verify_quarantine`` are static; the only inputs are the
+        container name and the live ruleset state (table-or-no-table).
+        Any config-conditional branch added here is a bug.
+        """
+        rs = RulesetBuilder.build_quarantine()
         current = self.shield_state(container)
-        stdin = rs if current == ShieldState.INACTIVE else f"delete table {NFT_TABLE}\n{rs}"
+        stdin = rs if current == ShieldState.OFFLINE else f"delete table {NFT_TABLE}\n{rs}"
         self._runner.nft_via_nsenter(container, stdin=stdin)
         output = self._runner.nft_via_nsenter(
             container,
@@ -510,7 +516,7 @@ class HookMode:
             "inet",
             NFT_TABLE_NAME,
         )
-        errors = ruleset.verify_block(output)
+        errors = RulesetBuilder.verify_quarantine(output)
         if errors:
             raise RuntimeError(f"Block ruleset verification failed: {'; '.join(errors)}")
 
@@ -521,7 +527,7 @@ class HookMode:
         ruleset = self._container_ruleset(container)
         rs = ruleset.build_hook()
         current = self.shield_state(container)
-        if current == ShieldState.INACTIVE:
+        if current == ShieldState.OFFLINE:
             stdin = rs
         else:
             stdin = f"delete table {NFT_TABLE}\n{rs}"
@@ -621,18 +627,18 @@ class HookMode:
         """Query the live nft ruleset to determine the container's shield state."""
         output = self.list_rules(container)
         if not output.strip():
-            return ShieldState.INACTIVE
+            return ShieldState.OFFLINE
 
         # verify_* returns a list of errors; empty list = ruleset is valid.
         # Block is checked first: its minimal ruleset (no sets, no DNS)
         # would fail all other verifiers.
-        if not self._ruleset.verify_block(output):
-            return ShieldState.BLOCK
+        if not self._ruleset.verify_quarantine(output):
+            return ShieldState.QUARANTINE
 
         if not self._ruleset.verify_bypass(output, allow_all=False):
             return ShieldState.DOWN
         if not self._ruleset.verify_bypass(output, allow_all=True):
-            return ShieldState.DOWN_ALL
+            return ShieldState.DISENGAGED
 
         if not self._ruleset.verify_hook(output):
             return ShieldState.UP

--- a/src/terok_shield/hooks/mode.py
+++ b/src/terok_shield/hooks/mode.py
@@ -518,7 +518,7 @@ class HookMode:
         )
         errors = RulesetBuilder.verify_quarantine(output)
         if errors:
-            raise RuntimeError(f"Block ruleset verification failed: {'; '.join(errors)}")
+            raise RuntimeError(f"Quarantine ruleset verification failed: {'; '.join(errors)}")
 
     def shield_up(self, container: str) -> None:
         """Restore normal deny-all mode for a running container."""

--- a/src/terok_shield/nft/rules.py
+++ b/src/terok_shield/nft/rules.py
@@ -165,7 +165,7 @@ class RulesetBuilder:
         """)
 
     @staticmethod
-    def build_block() -> str:
+    def build_quarantine() -> str:
         """Generate the block-mode (total blackout) ruleset.
 
         Drops all traffic except loopback and established connections.
@@ -271,7 +271,7 @@ class RulesetBuilder:
         return errors
 
     @staticmethod
-    def verify_block(nft_output: str) -> list[str]:
+    def verify_quarantine(nft_output: str) -> list[str]:
         """Check applied block ruleset invariants.  Returns errors (empty = OK).
 
         Expects output from ``nft list table inet terok_shield`` (scoped to the

--- a/src/terok_shield/nft/rules.py
+++ b/src/terok_shield/nft/rules.py
@@ -166,10 +166,11 @@ class RulesetBuilder:
 
     @staticmethod
     def build_quarantine() -> str:
-        """Generate the block-mode (total blackout) ruleset.
+        """Generate the quarantine-mode (total blackout) ruleset.
 
         Drops all traffic except loopback and established connections.
-        No DNS, no allowlists, no gateway ports.  Forensic logging only.
+        No DNS, no allowlists, no gateway ports.  All dropped packets
+        are tagged for the audit log.
         """
         blocked_log = f'        log group {NFLOG_GROUP} prefix "{BLOCKED_LOG_PREFIX}: " drop'
         return textwrap.dedent(f"""\
@@ -272,7 +273,7 @@ class RulesetBuilder:
 
     @staticmethod
     def verify_quarantine(nft_output: str) -> list[str]:
-        """Check applied block ruleset invariants.  Returns errors (empty = OK).
+        """Check applied quarantine ruleset invariants.  Returns errors (empty = OK).
 
         Expects output from ``nft list table inet terok_shield`` (scoped to the
         managed table), not ``nft list ruleset``.
@@ -294,9 +295,9 @@ class RulesetBuilder:
         if BLOCKED_LOG_PREFIX not in nft_output:
             errors.append("blocked nflog prefix missing")
         if "allow_v4" in nft_output:
-            errors.append("allow_v4 set present in block mode")
+            errors.append("allow_v4 set present in quarantine mode")
         if "allow_v6" in nft_output:
-            errors.append("allow_v6 set present in block mode")
+            errors.append("allow_v6 set present in quarantine mode")
         return errors
 
     # ── Set operations (instance) ──────────────────────

--- a/src/terok_shield/resources/nflog_reader.py
+++ b/src/terok_shield/resources/nflog_reader.py
@@ -424,7 +424,7 @@ class ReaderSession:
         re-trigger ``_emit_connection_blocked`` every NFLOG packet
         (because ``_last_emit`` stays unmarked), and *each* of those
         retries would currently re-write the same ``"blocked"`` line
-        to ``audit.jsonl`` — flooding the forensic log during the
+        to ``audit.jsonl`` — flooding the audit log during the
         very window where it's least helpful.
 
         Dossier resolution happens once per fresh tick; both the audit

--- a/tests/integration/bypass/README.md
+++ b/tests/integration/bypass/README.md
@@ -7,7 +7,7 @@ from deny-all to accept-all+log mode for traffic discovery.
 
 | File | What it tests |
 |------|---------------|
-| `test_state.py` | `shield_state()` detection: UP, DOWN, DOWN_ALL, INACTIVE |
+| `test_state.py` | `shield_state()` detection: UP, DOWN, DISENGAGED, OFFLINE |
 | `test_traffic.py` | Network behavior in bypass: traffic flows, RFC1918 protection, IPv6 drop |
 | `test_cli.py` | CLI `down`, `up`, `rules --state`, `preview --down` commands |
 | `test_lifecycle.py` | Full E2E lifecycle: state transitions, idempotency, IP restoration, audit trail |

--- a/tests/integration/bypass/test_cli.py
+++ b/tests/integration/bypass/test_cli.py
@@ -30,12 +30,12 @@ class TestBypassCLI:
         assert "Shield down" in captured.out
         assert _shield().state(shielded_container) == ShieldState.DOWN
 
-    def test_cli_down_all(self, shielded_container: str, capsys: pytest.CaptureFixture) -> None:
+    def test_cli_disengaged(self, shielded_container: str, capsys: pytest.CaptureFixture) -> None:
         """``main(["down", container, "--all"])`` enables full bypass."""
         main(["down", shielded_container, "--all"])
         captured = capsys.readouterr()
         assert "all traffic" in captured.out
-        assert _shield().state(shielded_container) == ShieldState.DOWN_ALL
+        assert _shield().state(shielded_container) == ShieldState.DISENGAGED
 
     def test_cli_up(self, shielded_container: str, capsys: pytest.CaptureFixture) -> None:
         """``main(["up", container])`` restores deny-all mode."""
@@ -85,7 +85,7 @@ class TestBypassPreviewCLI:
         assert "policy accept" in captured.out
         assert BYPASS_LOG_PREFIX in captured.out
 
-    def test_preview_down_all(self, capsys: pytest.CaptureFixture) -> None:
+    def test_preview_disengaged(self, capsys: pytest.CaptureFixture) -> None:
         """``preview --down --all`` omits private-range rules."""
         main(["preview", "--down", "--all"])
         captured = capsys.readouterr()

--- a/tests/integration/bypass/test_lifecycle.py
+++ b/tests/integration/bypass/test_lifecycle.py
@@ -66,11 +66,11 @@ class TestBypassBasicLifecycle:
         assert shield.state(shielded_container) == ShieldState.UP
         assert_blocked(shielded_container, BLOCKED_TARGET_HTTP)
 
-    def test_up_down_all_up_cycle(self, shielded_container: str) -> None:
-        """Full cycle with allow_all: UP -> DOWN_ALL -> UP."""
+    def test_up_disengaged_up_cycle(self, shielded_container: str) -> None:
+        """Full cycle with allow_all: UP -> DISENGAGED -> UP."""
         shield = _shield()
         shield.down(shielded_container, allow_all=True)
-        assert shield.state(shielded_container) == ShieldState.DOWN_ALL
+        assert shield.state(shielded_container) == ShieldState.DISENGAGED
 
         rules = shield.rules(shielded_container)
         assert "policy accept" in rules
@@ -124,26 +124,26 @@ class TestBypassIdempotency:
 @nft_missing
 @pytest.mark.usefixtures("nft_in_netns")
 class TestBypassModeSwitch:
-    """Verify switching between bypass modes (DOWN <-> DOWN_ALL)."""
+    """Verify switching between bypass modes (DOWN <-> DISENGAGED)."""
 
-    def test_down_to_down_all(self, shielded_container: str) -> None:
+    def test_down_to_disengaged(self, shielded_container: str) -> None:
         """Switch from protected bypass to full bypass."""
         shield = _shield()
         shield.down(shielded_container)
         assert shield.state(shielded_container) == ShieldState.DOWN
 
         shield.down(shielded_container, allow_all=True)
-        assert shield.state(shielded_container) == ShieldState.DOWN_ALL
+        assert shield.state(shielded_container) == ShieldState.DISENGAGED
 
         # Private-range rules should be gone
         rules = shield.rules(shielded_container)
         assert "TEROK_SHIELD_PRIVATE" not in rules
 
-    def test_down_all_to_down(self, shielded_container: str) -> None:
+    def test_disengaged_to_down(self, shielded_container: str) -> None:
         """Switch from full bypass back to protected bypass."""
         shield = _shield()
         shield.down(shielded_container, allow_all=True)
-        assert shield.state(shielded_container) == ShieldState.DOWN_ALL
+        assert shield.state(shielded_container) == ShieldState.DISENGAGED
 
         shield.down(shielded_container)
         assert shield.state(shielded_container) == ShieldState.DOWN
@@ -267,7 +267,7 @@ class TestBypassAuditTrail:
         up_idx = actions.index("shield_up")
         assert down_idx < up_idx
 
-    def test_down_all_logs_detail(self, shielded_container: str, shield_env: Path) -> None:
+    def test_disengaged_logs_detail(self, shielded_container: str, shield_env: Path) -> None:
         """shield.down(allow_all=True) logs the allow_all detail."""
         sd = shield_env / "containers" / shielded_container
         shield = Shield(ShieldConfig(state_dir=sd))
@@ -335,7 +335,7 @@ class TestBypassFullE2E:
 
             # Step 4: Switch to full bypass to also check RFC1918 destinations
             shield.down(name, allow_all=True)
-            assert shield.state(name) == ShieldState.DOWN_ALL
+            assert shield.state(name) == ShieldState.DISENGAGED
             assert_connectable(name, BLOCKED_TARGET_IP, BLOCKED_TARGET_DNS_PORT)
 
             # Step 5: Back to protected bypass

--- a/tests/integration/bypass/test_state.py
+++ b/tests/integration/bypass/test_state.py
@@ -4,7 +4,7 @@
 """Integration tests: shield state detection with real containers.
 
 Verifies ``Shield.state()`` correctly classifies live nft rulesets
-as UP, DOWN, DOWN_ALL, or INACTIVE by querying actual container
+as UP, DOWN, DISENGAGED, or OFFLINE by querying actual container
 network namespaces.
 """
 
@@ -37,11 +37,11 @@ class TestShieldState:
         shield.down(shielded_container)
         assert shield.state(shielded_container) == ShieldState.DOWN
 
-    def test_state_down_all_after_shield_down_all(self, shielded_container: str) -> None:
-        """State is DOWN_ALL after shield.down(allow_all=True)."""
+    def test_state_disengaged_after_shield_disengaged(self, shielded_container: str) -> None:
+        """State is DISENGAGED after shield.down(allow_all=True)."""
         shield = _shield()
         shield.down(shielded_container, allow_all=True)
-        assert shield.state(shielded_container) == ShieldState.DOWN_ALL
+        assert shield.state(shielded_container) == ShieldState.DISENGAGED
 
     def test_state_up_after_shield_up(self, shielded_container: str) -> None:
         """State returns to UP after shield.down() then shield.up()."""
@@ -57,13 +57,13 @@ class TestShieldState:
 @podman_missing
 @nft_missing
 class TestShieldStateInactive:
-    """Verify INACTIVE state for containers without rulesets."""
+    """Verify OFFLINE state for containers without rulesets."""
 
-    def test_state_inactive_for_stopped_container(self) -> None:
-        """A nonexistent/stopped container reports INACTIVE."""
+    def test_state_offline_for_stopped_container(self) -> None:
+        """A nonexistent/stopped container reports OFFLINE."""
         bogus = f"nonexistent-{uuid.uuid4().hex[:12]}"
-        assert _shield().state(bogus) == ShieldState.INACTIVE
+        assert _shield().state(bogus) == ShieldState.OFFLINE
 
-    def test_state_inactive_for_bare_container(self, container: str) -> None:
-        """A running container with no shield ruleset reports INACTIVE."""
-        assert _shield().state(container) == ShieldState.INACTIVE
+    def test_state_offline_for_bare_container(self, container: str) -> None:
+        """A running container with no shield ruleset reports OFFLINE."""
+        assert _shield().state(container) == ShieldState.OFFLINE

--- a/tests/integration/launch/test_restart.py
+++ b/tests/integration/launch/test_restart.py
@@ -94,7 +94,7 @@ class TestRestartPersistence:
             # Shield must still be active — the global hook fired on restart
             assert shield.state(name) == ShieldState.UP, (
                 "Shield should be UP after restart (fail-close guarantee). "
-                "If INACTIVE, the OCI hook did not fire on podman start — "
+                "If OFFLINE, the OCI hook did not fire on podman start — "
                 "the container is running without firewall protection."
             )
 

--- a/tests/unit/test_api_surface.py
+++ b/tests/unit/test_api_surface.py
@@ -72,14 +72,14 @@ class TestAPISurface:
         assert members == {"HOOK": "hook"}
 
     def test_shield_state_members(self):
-        """ShieldState has BLOCK, UP, DOWN, DOWN_ALL, INACTIVE, ERROR."""
+        """ShieldState has QUARANTINE, UP, DOWN, DISENGAGED, OFFLINE, ERROR."""
         members = {m.name: m.value for m in ShieldState}
         assert members == {
-            "BLOCK": "block",
+            "QUARANTINE": "quarantine",
             "UP": "up",
             "DOWN": "down",
-            "DOWN_ALL": "down_all",
-            "INACTIVE": "inactive",
+            "DISENGAGED": "disengaged",
+            "OFFLINE": "offline",
             "ERROR": "error",
         }
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -620,7 +620,7 @@ def test_rules_output_for_missing_rules(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     """rules prints a friendly message when the ruleset is empty."""
-    cli_dispatch.shield.state.return_value = ShieldState.INACTIVE
+    cli_dispatch.shield.state.return_value = ShieldState.OFFLINE
     cli_dispatch.shield.rules.return_value = ""
     main(["rules", _CONTAINER])
     assert "No rules found" in capsys.readouterr().out

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -85,11 +85,11 @@ class TestShieldState:
         """ShieldState has all expected members."""
         members = {m.name: m.value for m in ShieldState}
         assert members == {
-            "BLOCK": "block",
+            "QUARANTINE": "quarantine",
             "UP": "up",
             "DOWN": "down",
-            "DOWN_ALL": "down_all",
-            "INACTIVE": "inactive",
+            "DISENGAGED": "disengaged",
+            "OFFLINE": "offline",
             "ERROR": "error",
         }
 

--- a/tests/unit/test_hook_mode_class.py
+++ b/tests/unit/test_hook_mode_class.py
@@ -478,8 +478,8 @@ def test_shield_state_classifies_rulesets(
     assert harness.mode.shield_state("test") == expected
 
 
-def test_shield_state_detects_block(make_hook_mode: HookModeHarnessFactory) -> None:
-    """shield_state() returns BLOCK when verify_quarantine passes."""
+def test_shield_state_detects_quarantine(make_hook_mode: HookModeHarnessFactory) -> None:
+    """shield_state() returns QUARANTINE when verify_quarantine passes."""
     harness = make_hook_mode()
     harness.runner.nft_via_nsenter.return_value = "table inet terok_shield { policy drop }"
     harness.ruleset.verify_quarantine.return_value = []  # passes
@@ -490,7 +490,7 @@ def test_shield_state_detects_block(make_hook_mode: HookModeHarnessFactory) -> N
 def test_shield_quarantine_applies_block_ruleset(
     make_hook_mode: HookModeHarnessFactory, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """shield_quarantine() applies the block ruleset and verifies it.
+    """shield_quarantine() applies the quarantine ruleset and verifies it.
 
     ``build_quarantine`` / ``verify_quarantine`` are static class methods
     on ``RulesetBuilder`` (no config dependency by design — see
@@ -501,12 +501,12 @@ def test_shield_quarantine_applies_block_ruleset(
     harness = make_hook_mode()
     harness.runner.nft_via_nsenter.side_effect = [
         "table inet terok_shield {}",  # shield_state() → list_rules
-        "",  # apply block ruleset
+        "",  # apply quarantine ruleset
         "valid output",  # verify
     ]
     harness.ruleset.verify_bypass.return_value = ["not bypass"]
     harness.ruleset.verify_hook.return_value = ["not hook"]
-    build_mock = mock.Mock(return_value="block ruleset")
+    build_mock = mock.Mock(return_value="quarantine ruleset")
     verify_mock = mock.Mock(return_value=[])
     monkeypatch.setattr(RulesetBuilder, "build_quarantine", build_mock)
     monkeypatch.setattr(RulesetBuilder, "verify_quarantine", verify_mock)
@@ -530,12 +530,12 @@ def test_shield_quarantine_raises_on_verification_failure(
     ]
     harness.ruleset.verify_bypass.return_value = ["not bypass"]
     harness.ruleset.verify_hook.return_value = ["not hook"]
-    monkeypatch.setattr(RulesetBuilder, "build_quarantine", mock.Mock(return_value="block ruleset"))
+    monkeypatch.setattr(RulesetBuilder, "build_quarantine", mock.Mock(return_value="quarantine ruleset"))
     monkeypatch.setattr(
         RulesetBuilder, "verify_quarantine", mock.Mock(return_value=["policy is not drop"])
     )
 
-    with pytest.raises(RuntimeError, match="Block ruleset verification failed"):
+    with pytest.raises(RuntimeError, match="Quarantine ruleset verification failed"):
         harness.mode.shield_quarantine("test-ctr")
 
 
@@ -551,7 +551,7 @@ def test_shield_quarantine_on_offline_applies_without_delete(
         "",  # apply
         "valid output",  # verify
     ]
-    monkeypatch.setattr(RulesetBuilder, "build_quarantine", mock.Mock(return_value="block ruleset"))
+    monkeypatch.setattr(RulesetBuilder, "build_quarantine", mock.Mock(return_value="quarantine ruleset"))
     monkeypatch.setattr(RulesetBuilder, "verify_quarantine", mock.Mock(return_value=[]))
 
     harness.mode.shield_quarantine("test-ctr")

--- a/tests/unit/test_hook_mode_class.py
+++ b/tests/unit/test_hook_mode_class.py
@@ -530,7 +530,9 @@ def test_shield_quarantine_raises_on_verification_failure(
     ]
     harness.ruleset.verify_bypass.return_value = ["not bypass"]
     harness.ruleset.verify_hook.return_value = ["not hook"]
-    monkeypatch.setattr(RulesetBuilder, "build_quarantine", mock.Mock(return_value="quarantine ruleset"))
+    monkeypatch.setattr(
+        RulesetBuilder, "build_quarantine", mock.Mock(return_value="quarantine ruleset")
+    )
     monkeypatch.setattr(
         RulesetBuilder, "verify_quarantine", mock.Mock(return_value=["policy is not drop"])
     )
@@ -551,7 +553,9 @@ def test_shield_quarantine_on_offline_applies_without_delete(
         "",  # apply
         "valid output",  # verify
     ]
-    monkeypatch.setattr(RulesetBuilder, "build_quarantine", mock.Mock(return_value="quarantine ruleset"))
+    monkeypatch.setattr(
+        RulesetBuilder, "build_quarantine", mock.Mock(return_value="quarantine ruleset")
+    )
     monkeypatch.setattr(RulesetBuilder, "verify_quarantine", mock.Mock(return_value=[]))
 
     harness.mode.shield_quarantine("test-ctr")

--- a/tests/unit/test_hook_mode_class.py
+++ b/tests/unit/test_hook_mode_class.py
@@ -453,7 +453,7 @@ def test_shield_up_reapplies_hook_ruleset(
 @pytest.mark.parametrize(
     ("nft_output", "verify_bypass", "verify_hook", "expected"),
     [
-        pytest.param("", None, None, ShieldState.INACTIVE, id="inactive"),
+        pytest.param("", None, None, ShieldState.OFFLINE, id="offline"),
         pytest.param(RulesetBuilder().build_hook(), ["not bypass"], [], ShieldState.UP, id="up"),
         pytest.param(RulesetBuilder().build_bypass(), [], None, ShieldState.DOWN, id="down"),
         pytest.param(
@@ -468,7 +468,7 @@ def test_shield_state_classifies_rulesets(
     verify_hook: list[str] | None,
     expected: ShieldState,
 ) -> None:
-    """shield_state() distinguishes inactive, hook, bypass, and invalid rulesets."""
+    """shield_state() distinguishes offline, hook, bypass, and invalid rulesets."""
     harness = make_hook_mode()
     harness.runner.nft_via_nsenter.return_value = nft_output
     if verify_bypass is not None:
@@ -479,68 +479,82 @@ def test_shield_state_classifies_rulesets(
 
 
 def test_shield_state_detects_block(make_hook_mode: HookModeHarnessFactory) -> None:
-    """shield_state() returns BLOCK when verify_block passes."""
+    """shield_state() returns BLOCK when verify_quarantine passes."""
     harness = make_hook_mode()
     harness.runner.nft_via_nsenter.return_value = "table inet terok_shield { policy drop }"
-    harness.ruleset.verify_block.return_value = []  # passes
+    harness.ruleset.verify_quarantine.return_value = []  # passes
     harness.ruleset.verify_bypass.return_value = ["not bypass"]
-    assert harness.mode.shield_state("test") == ShieldState.BLOCK
+    assert harness.mode.shield_state("test") == ShieldState.QUARANTINE
 
 
-def test_shield_block_applies_block_ruleset(make_hook_mode: HookModeHarnessFactory) -> None:
-    """shield_block() applies the block ruleset and verifies it."""
+def test_shield_quarantine_applies_block_ruleset(
+    make_hook_mode: HookModeHarnessFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """shield_quarantine() applies the block ruleset and verifies it.
+
+    ``build_quarantine`` / ``verify_quarantine`` are static class methods
+    on ``RulesetBuilder`` (no config dependency by design — see
+    ``HookMode.shield_quarantine``).  Patch at the class to stub them.
+    """
+    from terok_shield.nft.rules import RulesetBuilder
+
     harness = make_hook_mode()
-    harness.mode._container_ruleset = lambda _c: harness.ruleset
     harness.runner.nft_via_nsenter.side_effect = [
         "table inet terok_shield {}",  # shield_state() → list_rules
         "",  # apply block ruleset
         "valid output",  # verify
     ]
-    harness.ruleset.build_block.return_value = "block ruleset"
-    harness.ruleset.verify_block.return_value = []
     harness.ruleset.verify_bypass.return_value = ["not bypass"]
     harness.ruleset.verify_hook.return_value = ["not hook"]
+    build_mock = mock.Mock(return_value="block ruleset")
+    verify_mock = mock.Mock(return_value=[])
+    monkeypatch.setattr(RulesetBuilder, "build_quarantine", build_mock)
+    monkeypatch.setattr(RulesetBuilder, "verify_quarantine", verify_mock)
 
-    harness.mode.shield_block("test-ctr")
+    harness.mode.shield_quarantine("test-ctr")
     assert harness.runner.nft_via_nsenter.call_count == 3
-    harness.ruleset.build_block.assert_called_once()
+    build_mock.assert_called_once()
 
 
-def test_shield_block_raises_on_verification_failure(
-    make_hook_mode: HookModeHarnessFactory,
+def test_shield_quarantine_raises_on_verification_failure(
+    make_hook_mode: HookModeHarnessFactory, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """shield_block() raises RuntimeError when verification fails."""
+    """shield_quarantine() raises RuntimeError when verification fails."""
+    from terok_shield.nft.rules import RulesetBuilder
+
     harness = make_hook_mode()
-    harness.mode._container_ruleset = lambda _c: harness.ruleset
     harness.runner.nft_via_nsenter.side_effect = [
         "table inet terok_shield {}",  # shield_state()
         "",  # apply
         "bad output",  # verify
     ]
-    harness.ruleset.build_block.return_value = "block ruleset"
-    harness.ruleset.verify_block.return_value = ["policy is not drop"]
     harness.ruleset.verify_bypass.return_value = ["not bypass"]
     harness.ruleset.verify_hook.return_value = ["not hook"]
+    monkeypatch.setattr(RulesetBuilder, "build_quarantine", mock.Mock(return_value="block ruleset"))
+    monkeypatch.setattr(
+        RulesetBuilder, "verify_quarantine", mock.Mock(return_value=["policy is not drop"])
+    )
 
     with pytest.raises(RuntimeError, match="Block ruleset verification failed"):
-        harness.mode.shield_block("test-ctr")
+        harness.mode.shield_quarantine("test-ctr")
 
 
-def test_shield_block_on_inactive_applies_without_delete(
-    make_hook_mode: HookModeHarnessFactory,
+def test_shield_quarantine_on_offline_applies_without_delete(
+    make_hook_mode: HookModeHarnessFactory, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """shield_block() on an inactive container applies ruleset without delete prefix."""
+    """shield_quarantine() on an offline container applies ruleset without delete prefix."""
+    from terok_shield.nft.rules import RulesetBuilder
+
     harness = make_hook_mode()
-    harness.mode._container_ruleset = lambda _c: harness.ruleset
     harness.runner.nft_via_nsenter.side_effect = [
-        "",  # shield_state() → INACTIVE
+        "",  # shield_state() → OFFLINE
         "",  # apply
         "valid output",  # verify
     ]
-    harness.ruleset.build_block.return_value = "block ruleset"
-    harness.ruleset.verify_block.return_value = []
+    monkeypatch.setattr(RulesetBuilder, "build_quarantine", mock.Mock(return_value="block ruleset"))
+    monkeypatch.setattr(RulesetBuilder, "verify_quarantine", mock.Mock(return_value=[]))
 
-    harness.mode.shield_block("test-ctr")
+    harness.mode.shield_quarantine("test-ctr")
 
     # Second call (apply) should NOT have "delete table" prefix
     apply_call = harness.runner.nft_via_nsenter.call_args_list[1]
@@ -893,16 +907,16 @@ def test_container_ruleset_returns_builder_with_dns(
     assert isinstance(ruleset, RulesetBuilder)
 
 
-def test_shield_up_on_inactive_applies_without_delete(
+def test_shield_up_on_offline_applies_without_delete(
     make_hook_mode: HookModeHarnessFactory,
     make_config: ConfigFactory,
 ) -> None:
-    """shield_up() on INACTIVE netns applies ruleset without delete table prefix."""
+    """shield_up() on OFFLINE netns applies ruleset without delete table prefix."""
     harness = make_hook_mode(config=make_config())
     harness.mode._container_ruleset = lambda _c: harness.ruleset
-    # shield_state() → list_rules returns empty (INACTIVE)
+    # shield_state() → list_rules returns empty (OFFLINE)
     harness.runner.nft_via_nsenter.side_effect = [
-        "",  # shield_state() → INACTIVE
+        "",  # shield_state() → OFFLINE
         "",  # apply ruleset (no delete prefix)
         "valid output",  # verify
     ]
@@ -917,15 +931,15 @@ def test_shield_up_on_inactive_applies_without_delete(
         assert "delete" not in call.kwargs.get("stdin", "")
 
 
-def test_shield_down_on_inactive_applies_without_delete(
+def test_shield_down_on_offline_applies_without_delete(
     make_hook_mode: HookModeHarnessFactory,
 ) -> None:
-    """shield_down() on INACTIVE netns applies bypass ruleset without delete table prefix."""
+    """shield_down() on OFFLINE netns applies bypass ruleset without delete table prefix."""
     harness = make_hook_mode()
     harness.mode._container_ruleset = lambda _c: harness.ruleset
-    # shield_state() → list_rules returns empty (INACTIVE)
+    # shield_state() → list_rules returns empty (OFFLINE)
     harness.runner.nft_via_nsenter.side_effect = [
-        "",  # shield_state() → INACTIVE
+        "",  # shield_state() → OFFLINE
         "",  # apply bypass ruleset (no delete prefix)
         "valid output",  # verify
     ]
@@ -1281,15 +1295,15 @@ def test_pre_start_includes_hooks_dir_when_persists(
     assert "--hooks-dir" in args
 
 
-def test_shield_state_returns_down_all(make_hook_mode: HookModeHarnessFactory) -> None:
-    """shield_state() returns DOWN_ALL when allow-all bypass is active but not simple bypass."""
+def test_shield_state_returns_disengaged(make_hook_mode: HookModeHarnessFactory) -> None:
+    """shield_state() returns DISENGAGED when allow-all bypass is active but not simple bypass."""
     harness = make_hook_mode()
     harness.runner.nft_via_nsenter.return_value = "some rules"
     # First call (allow_all=False): non-empty errors → not DOWN, continue
-    # Second call (allow_all=True): empty list → DOWN_ALL
+    # Second call (allow_all=True): empty list → DISENGAGED
     harness.ruleset.verify_bypass.side_effect = [["not bypass"], []]
 
-    assert harness.mode.shield_state("test-ctr") == ShieldState.DOWN_ALL
+    assert harness.mode.shield_state("test-ctr") == ShieldState.DISENGAGED
 
 
 @mock.patch("terok_shield.hooks.mode.has_global_hooks", return_value=True)

--- a/tests/unit/test_hub_events.py
+++ b/tests/unit/test_hub_events.py
@@ -100,11 +100,11 @@ class TestHubEventEmitter:
             "container": _CONTAINER,
         }
 
-    def test_shield_down_allow_all_maps_to_down_all(self, hub_socket: _SocketRecorder) -> None:
-        """``allow_all=True`` flips the event type to ``shield_down_all``."""
+    def test_shield_down_allow_all_maps_to_disengaged(self, hub_socket: _SocketRecorder) -> None:
+        """``allow_all=True`` flips the event type to ``shield_disengaged``."""
         HubEventEmitter(hub_socket.path).shield_down(_CONTAINER, allow_all=True)
         assert json.loads(_received_one_line(hub_socket)) == {
-            "type": "shield_down_all",
+            "type": "shield_disengaged",
             "container": _CONTAINER,
         }
 

--- a/tests/unit/test_nflog_reader.py
+++ b/tests/unit/test_nflog_reader.py
@@ -957,7 +957,7 @@ class TestAuditBlockAppend:
         """Hub down (emitter returns False) → audit entry is still recorded.
 
         Auditing should be terminal-end, not best-effort: the operator
-        can lose a popup to a hub restart and still need the forensic
+        can lose a popup to a hub restart and still need the audit
         record of which destination got blocked when.
         """
 
@@ -1009,7 +1009,7 @@ class TestAuditBlockAppend:
         would re-trigger ``_emit_connection_blocked`` on every NFLOG
         packet (because ``_last_emit`` stays unmarked while the wire
         keeps failing) and *each* of those retries would re-write the
-        same ``"blocked"`` line — flooding the forensic log during the
+        same ``"blocked"`` line — flooding the audit log during the
         very window where it's least helpful.  ``_last_audit`` is the
         knob that prevents that without giving up wire-side retries.
         """

--- a/tests/unit/test_nft.py
+++ b/tests/unit/test_nft.py
@@ -752,7 +752,7 @@ def test_verify_bypass_reports_errors_for_empty_input() -> None:
     ],
 )
 def test_quarantine_ruleset_contains_required_fragments(fragment: str) -> None:
-    """The block ruleset preserves the expected security invariants."""
+    """The quarantine ruleset preserves the expected security invariants."""
     assert fragment in RulesetBuilder.build_quarantine()
 
 
@@ -793,7 +793,7 @@ def test_quarantine_ruleset_does_not_include_bypass_or_deny_prefixes() -> None:
 
 
 def test_verify_quarantine_accepts_generated_block_ruleset() -> None:
-    """verify_quarantine() returns no errors for a valid block ruleset."""
+    """verify_quarantine() returns no errors for a valid quarantine ruleset."""
     assert RulesetBuilder.verify_quarantine(RulesetBuilder.build_quarantine()) == []
 
 
@@ -827,7 +827,7 @@ def test_verify_quarantine_reports_missing_prefix() -> None:
 
 
 def test_verify_quarantine_reports_errors_for_empty_input() -> None:
-    """Empty nft output should fail block-mode verification."""
+    """Empty nft output should fail quarantine-mode verification."""
     assert RulesetBuilder.verify_quarantine("")
 
 

--- a/tests/unit/test_nft.py
+++ b/tests/unit/test_nft.py
@@ -737,7 +737,7 @@ def test_verify_bypass_reports_errors_for_empty_input() -> None:
     assert _builder.verify_bypass("")
 
 
-# ── build_block() ─────────────────────────────────────────
+# ── build_quarantine() ─────────────────────────────────────────
 
 
 @pytest.mark.parametrize(
@@ -751,84 +751,84 @@ def test_verify_bypass_reports_errors_for_empty_input() -> None:
         pytest.param(BLOCKED_LOG_PREFIX, id="blocked-log-prefix"),
     ],
 )
-def test_block_ruleset_contains_required_fragments(fragment: str) -> None:
+def test_quarantine_ruleset_contains_required_fragments(fragment: str) -> None:
     """The block ruleset preserves the expected security invariants."""
-    assert fragment in RulesetBuilder.build_block()
+    assert fragment in RulesetBuilder.build_quarantine()
 
 
-def test_block_ruleset_has_no_allow_sets() -> None:
+def test_quarantine_ruleset_has_no_allow_sets() -> None:
     """Block mode must have no allowlists -- total blackout."""
-    rs = RulesetBuilder.build_block()
+    rs = RulesetBuilder.build_quarantine()
     assert "allow_v4" not in rs
     assert "allow_v6" not in rs
 
 
-def test_block_ruleset_has_no_deny_sets() -> None:
+def test_quarantine_ruleset_has_no_deny_sets() -> None:
     """Block mode needs no deny sets -- everything is dropped anyway."""
-    rs = RulesetBuilder.build_block()
+    rs = RulesetBuilder.build_quarantine()
     assert "deny_v4" not in rs
     assert "deny_v6" not in rs
 
 
-def test_block_ruleset_has_no_dns_rules() -> None:
+def test_quarantine_ruleset_has_no_dns_rules() -> None:
     """Block mode drops DNS -- no external resolution allowed."""
-    rs = RulesetBuilder.build_block()
+    rs = RulesetBuilder.build_quarantine()
     assert "dport 53" not in rs
 
 
-def test_block_ruleset_has_no_port_accept_rules() -> None:
+def test_quarantine_ruleset_has_no_port_accept_rules() -> None:
     """Block mode allows only loopback + established -- no port-specific accepts."""
-    rs = RulesetBuilder.build_block()
+    rs = RulesetBuilder.build_quarantine()
     assert "tcp dport" not in rs
 
 
-def test_block_ruleset_does_not_include_bypass_or_deny_prefixes() -> None:
+def test_quarantine_ruleset_does_not_include_bypass_or_deny_prefixes() -> None:
     """Block mode uses only the BLOCKED prefix, not BYPASS or DENIED."""
-    rs = RulesetBuilder.build_block()
+    rs = RulesetBuilder.build_quarantine()
     assert _DENY_LOG_PREFIX not in rs
     assert BYPASS_LOG_PREFIX not in rs
 
 
-# ── verify_block() ─────────────────────────────────────────
+# ── verify_quarantine() ─────────────────────────────────────────
 
 
-def test_verify_block_accepts_generated_block_ruleset() -> None:
-    """verify_block() returns no errors for a valid block ruleset."""
-    assert RulesetBuilder.verify_block(RulesetBuilder.build_block()) == []
+def test_verify_quarantine_accepts_generated_block_ruleset() -> None:
+    """verify_quarantine() returns no errors for a valid block ruleset."""
+    assert RulesetBuilder.verify_quarantine(RulesetBuilder.build_quarantine()) == []
 
 
-def test_verify_block_rejects_hook_ruleset() -> None:
+def test_verify_quarantine_rejects_hook_ruleset() -> None:
     """Hook (deny-all with allowlists) must not satisfy block verification."""
-    errors = RulesetBuilder.verify_block(_builder.build_hook())
+    errors = RulesetBuilder.verify_quarantine(_builder.build_hook())
     assert errors
     assert any("allow_v4" in e for e in errors)
 
 
-def test_verify_block_rejects_bypass_ruleset() -> None:
+def test_verify_quarantine_rejects_bypass_ruleset() -> None:
     """Bypass (accept-all) must not satisfy block verification."""
-    errors = RulesetBuilder.verify_block(_builder.build_bypass())
+    errors = RulesetBuilder.verify_quarantine(_builder.build_bypass())
     assert errors
 
 
-def test_verify_block_reports_missing_chain() -> None:
+def test_verify_quarantine_reports_missing_chain() -> None:
     """Missing chains are reported."""
     minimal = f"table {NFT_TABLE} {{ chain output {{ policy drop; {BLOCKED_LOG_PREFIX} }} }}"
-    errors = RulesetBuilder.verify_block(minimal)
+    errors = RulesetBuilder.verify_quarantine(minimal)
     assert "input chain missing" in errors
 
 
-def test_verify_block_reports_missing_prefix() -> None:
+def test_verify_quarantine_reports_missing_prefix() -> None:
     """Missing blocked log prefix is reported."""
     minimal = (
         f"table {NFT_TABLE} {{ chain output {{ policy drop; }} chain input {{ policy drop; }} }}"
     )
-    errors = RulesetBuilder.verify_block(minimal)
+    errors = RulesetBuilder.verify_quarantine(minimal)
     assert "blocked nflog prefix missing" in errors
 
 
-def test_verify_block_reports_errors_for_empty_input() -> None:
+def test_verify_quarantine_reports_errors_for_empty_input() -> None:
     """Empty nft output should fail block-mode verification."""
-    assert RulesetBuilder.verify_block("")
+    assert RulesetBuilder.verify_quarantine("")
 
 
 # ── Gateway sets and port rules ──────────────────────────

--- a/tests/unit/test_registry.py
+++ b/tests/unit/test_registry.py
@@ -13,11 +13,11 @@ from terok_shield.cli.registry import (
     COMMANDS,
     ArgDef,
     _handle_allow,
-    _handle_block,
     _handle_deny,
     _handle_logs,
     _handle_preview,
     _handle_profiles,
+    _handle_quarantine,
     _handle_status,
     _handle_watch,
 )
@@ -127,13 +127,15 @@ class TestHandlers:
             _handle_watch(shield, "ctr")
         mock_run.assert_called_once_with(shield.config.state_dir, "ctr")
 
-    def test_handle_block_delegates_and_prints(self, capsys: pytest.CaptureFixture[str]) -> None:
-        """_handle_block calls shield.block() and prints confirmation."""
+    def test_handle_quarantine_delegates_and_prints(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """_handle_quarantine calls shield.quarantine() and prints confirmation."""
         shield = mock.MagicMock()
-        _handle_block(shield, "test-ctr")
-        shield.block.assert_called_once_with("test-ctr")
+        _handle_quarantine(shield, "test-ctr")
+        shield.quarantine.assert_called_once_with("test-ctr")
         output = capsys.readouterr().out
-        assert "BLOCKED" in output
+        assert "QUARANTINED" in output
         assert "test-ctr" in output
 
     def test_handle_preview_all_without_down_raises(self) -> None:

--- a/tests/unit/test_ruleset_builder.py
+++ b/tests/unit/test_ruleset_builder.py
@@ -87,24 +87,24 @@ class TestRulesetBuilderBuildBypass:
 
 
 class TestRulesetBuilderBuildBlock:
-    """Test RulesetBuilder.build_block()."""
+    """Test RulesetBuilder.build_quarantine()."""
 
     def test_produces_drop_policy(self) -> None:
         """Block ruleset has drop policy."""
         builder = RulesetBuilder()
-        rs = builder.build_block()
+        rs = builder.build_quarantine()
         assert "policy drop" in rs
 
     def test_includes_blocked_log(self) -> None:
         """Block ruleset includes blocked nflog prefix."""
         builder = RulesetBuilder()
-        rs = builder.build_block()
+        rs = builder.build_quarantine()
         assert BLOCKED_LOG_PREFIX in rs
 
     def test_has_no_allow_sets(self) -> None:
         """Block ruleset has no allowlist sets."""
         builder = RulesetBuilder()
-        rs = builder.build_block()
+        rs = builder.build_quarantine()
         assert "allow_v4" not in rs
         assert "allow_v6" not in rs
 
@@ -112,17 +112,17 @@ class TestRulesetBuilderBuildBlock:
 class TestRulesetBuilderVerify:
     """Test RulesetBuilder verification methods."""
 
-    def test_verify_block_passes(self) -> None:
-        """verify_block returns empty for valid block ruleset."""
+    def test_verify_quarantine_passes(self) -> None:
+        """verify_quarantine returns empty for valid block ruleset."""
         builder = RulesetBuilder()
-        rs = builder.build_block()
-        assert builder.verify_block(rs) == []
+        rs = builder.build_quarantine()
+        assert builder.verify_quarantine(rs) == []
 
-    def test_verify_block_fails_on_hook(self) -> None:
-        """verify_block fails on hook ruleset (has allow sets)."""
+    def test_verify_quarantine_fails_on_hook(self) -> None:
+        """verify_quarantine fails on hook ruleset (has allow sets)."""
         builder = RulesetBuilder()
         rs = builder.build_hook()
-        assert len(builder.verify_block(rs)) > 0
+        assert len(builder.verify_quarantine(rs)) > 0
 
     def test_verify_hook_passes(self) -> None:
         """verify_hook returns empty for valid hook ruleset."""

--- a/tests/unit/test_ruleset_builder.py
+++ b/tests/unit/test_ruleset_builder.py
@@ -90,19 +90,19 @@ class TestRulesetBuilderBuildBlock:
     """Test RulesetBuilder.build_quarantine()."""
 
     def test_produces_drop_policy(self) -> None:
-        """Block ruleset has drop policy."""
+        """Quarantine ruleset has drop policy."""
         builder = RulesetBuilder()
         rs = builder.build_quarantine()
         assert "policy drop" in rs
 
     def test_includes_blocked_log(self) -> None:
-        """Block ruleset includes blocked nflog prefix."""
+        """Quarantine ruleset includes blocked nflog prefix."""
         builder = RulesetBuilder()
         rs = builder.build_quarantine()
         assert BLOCKED_LOG_PREFIX in rs
 
     def test_has_no_allow_sets(self) -> None:
-        """Block ruleset has no allowlist sets."""
+        """Quarantine ruleset has no allowlist sets."""
         builder = RulesetBuilder()
         rs = builder.build_quarantine()
         assert "allow_v4" not in rs
@@ -113,7 +113,7 @@ class TestRulesetBuilderVerify:
     """Test RulesetBuilder verification methods."""
 
     def test_verify_quarantine_passes(self) -> None:
-        """verify_quarantine returns empty for valid block ruleset."""
+        """verify_quarantine returns empty for valid quarantine ruleset."""
         builder = RulesetBuilder()
         rs = builder.build_quarantine()
         assert builder.verify_quarantine(rs) == []

--- a/tests/unit/test_shield_facade.py
+++ b/tests/unit/test_shield_facade.py
@@ -307,12 +307,12 @@ def test_down_resolves_dossier_via_meta_path(
     )
 
 
-def test_block_delegates_and_logs(make_shield: ShieldHarnessFactory) -> None:
+def test_quarantine_delegates_and_logs(make_shield: ShieldHarnessFactory) -> None:
     """block() delegates to the backend and logs the transition."""
     harness = make_shield()
-    harness.shield.block("test-ctr")
-    harness.mode.shield_block.assert_called_once_with("test-ctr")
-    harness.audit.log_event.assert_called_once_with("test-ctr", "shield_block")
+    harness.shield.quarantine("test-ctr")
+    harness.mode.shield_quarantine.assert_called_once_with("test-ctr")
+    harness.audit.log_event.assert_called_once_with("test-ctr", "shield_quarantine")
 
 
 def test_state_delegates_to_mode(make_shield: ShieldHarnessFactory) -> None:

--- a/tests/unit/test_shield_facade.py
+++ b/tests/unit/test_shield_facade.py
@@ -308,7 +308,7 @@ def test_down_resolves_dossier_via_meta_path(
 
 
 def test_quarantine_delegates_and_logs(make_shield: ShieldHarnessFactory) -> None:
-    """block() delegates to the backend and logs the transition."""
+    """quarantine() delegates to the backend and logs the transition."""
     harness = make_shield()
     harness.shield.quarantine("test-ctr")
     harness.mode.shield_quarantine.assert_called_once_with("test-ctr")


### PR DESCRIPTION
Closes #874 (the rename half) and tightens the panic codepath while we're here.

## Summary

Three renames in the public ``ShieldState`` enum before the v0.8 PyPI cut locks the surface:

| was | becomes | meaning |
|---|---|---|
| `DOWN_ALL` (`"down_all"`) | `DISENGAGED` (`"disengaged"`) | full bypass — no private-range protection |
| `INACTIVE` (`"inactive"`) | `OFFLINE` (`"offline"`) | shield not present on container |
| `BLOCK` (`"block"`) | `QUARANTINE` (`"quarantine"`) | total network blackout (panic) |

The `BLOCK→QUARANTINE` one is load-bearing: per-packet "blocked" vocabulary is all over the audit / NFLOG layer (`BLOCKED_LOG_PREFIX`, "blocked target" tests). The *state name* and the *per-request action* are now distinct words.

Renamed in lockstep:

- `Shield.block` → `Shield.quarantine` (public facade)
- `ShieldModeBackend.shield_block` → `shield_quarantine`
- `RulesetBuilder.{build,verify}_block` → `{build,verify}_quarantine`
- CLI subcommand `terok-shield block` → `terok-shield quarantine`
- Audit event `"shield_block"` → `"shield_quarantine"`
- Hub event wire string `"shield_down_all"` → `"shield_disengaged"`

No deprecation aliases — first PyPI release is exactly the moment to lock the surface. Sibling repos ship matching renames on the same branch name.

## Panic tightening (issue #874 part two)

`HookMode.shield_quarantine` no longer constructs a `RulesetBuilder` via `_container_ruleset` (which reads DNS tier, loopback ports, gateway probe — all discarded by the static `build_quarantine` / `verify_quarantine`). Direct static calls so the function literally reads no settings; any future `if config.X` branch will stand out.

Drive-by: stripped "forensic" from log/audit phrasing — these are plain logs.

## Sibling PRs

- terok-clearance: rename `ShieldDownAll` signal/callback/event-type → `ShieldDisengaged`
- terok-sandbox: rename `Shield.block` adapter → `Shield.quarantine`; branch-pin shield
- terok-executor: branch-pin sandbox (no source changes)
- terok: full consumer rewrite + branch-pin all three

## Test plan

- [x] `poetry run pytest tests/unit` — 1176 pass
- [x] `poetry run ruff check && poetry run ruff format --check` — clean
- [ ] full matrix run on dev host

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a quarantine command to enforce complete network isolation for a container.

* **Documentation**
  * Updated CLI help and docs to reflect new firewall state terms and examples.

* **Changes**
  * Replaced the prior "block" operation with "quarantine".
  * Firewall state names updated (now include "disengaged" and "offline" alongside up/down/error).
  * CLI/status output and emitted event terminology updated to match new state names.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok-shield/pull/307)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->