### PR TITLE
refactor: move command registry to top-level terok_shield.commands

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.poetry]
 name = "terok-shield"
-version = "0.6.41"
+version = "0.6.42a1"
 description = "nftables-based egress firewalling for Podman containers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/terok_shield/__init__.py
+++ b/src/terok_shield/__init__.py
@@ -51,6 +51,7 @@ from .util import is_ip as _is_ip
 if TYPE_CHECKING:
     from ._hub_events import HubEventEmitter
     from .audit import AuditLogger
+    from .commands import COMMANDS, ArgDef, CommandDef
     from .dns.resolver import DnsResolver
     from .nft.rules import RulesetBuilder
     from .profiles import ProfileLoader

--- a/src/terok_shield/__init__.py
+++ b/src/terok_shield/__init__.py
@@ -55,7 +55,7 @@ if TYPE_CHECKING:
     from .dns.resolver import DnsResolver
     from .nft.rules import RulesetBuilder
     from .profiles import ProfileLoader
-    from .run import CommandRunner
+    from .run import CommandRunner, ExecError
 
 # ── Lazy: core + support layer ──────────────────────────
 # Re-exported names from __all__ that are deferred until first access.

--- a/src/terok_shield/__init__.py
+++ b/src/terok_shield/__init__.py
@@ -74,10 +74,10 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "SubprocessRunner": ("terok_shield.run", "SubprocessRunner"),
     "check_firewall_binaries": ("terok_shield.prereqs", "check_firewall_binaries"),
     "setup_global_hooks": ("terok_shield.hooks.install", "setup_global_hooks"),
-    # CLI registry — re-exported for terok integration layer
-    "ArgDef": ("terok_shield.cli.registry", "ArgDef"),
-    "COMMANDS": ("terok_shield.cli.registry", "COMMANDS"),
-    "CommandDef": ("terok_shield.cli.registry", "CommandDef"),
+    # Command registry — re-exported for the terok integration layer
+    "ArgDef": ("terok_shield.commands", "ArgDef"),
+    "COMMANDS": ("terok_shield.commands", "COMMANDS"),
+    "CommandDef": ("terok_shield.commands", "CommandDef"),
 }
 
 

--- a/src/terok_shield/cli/main.py
+++ b/src/terok_shield/cli/main.py
@@ -5,7 +5,7 @@
 
 Constructs ``ShieldConfig`` from ``config.yml``, XDG conventions, and
 environment variables, then routes each subcommand through the
-``COMMANDS`` registry (``cli.registry``).  Five commands with standalone
+``COMMANDS`` registry (``terok_shield.commands``).  Five commands with standalone
 CLI logic are handled directly by ``_dispatch`` — ``setup`` and ``logs``
 (which bypass Shield entirely) and ``prepare``, ``run``, ``resolve``
 (which need Shield but carry extra CLI concerns).  All others delegate
@@ -22,11 +22,11 @@ from pathlib import Path
 from typing import Any
 
 from .. import Shield, ShieldConfig, ShieldMode
+from ..commands import COMMANDS, ArgDef, CommandDef
 from ..config import ShieldFileConfig
 from ..container import resolve_state_dir as resolve_container_state_dir
 from ..run import ExecError
 from ..validation import validate_container_name
-from .registry import COMMANDS, ArgDef, CommandDef
 
 # ── Entry point ──────────────────────────────────────────
 

--- a/src/terok_shield/commands.py
+++ b/src/terok_shield/commands.py
@@ -15,7 +15,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
-from .. import EnvironmentCheck, Shield
+from . import EnvironmentCheck, Shield
 
 
 @dataclass(frozen=True)

--- a/src/terok_shield/simple_clearance.py
+++ b/src/terok_shield/simple_clearance.py
@@ -82,7 +82,7 @@ class ClearanceSession:
     """
 
     def __init__(self, *, state_dir: Path, container: str) -> None:
-        """Prepare the session — the reader is spawned in [`run`][terok_shield.cli.simple_clearance.ClearanceSession.run]."""
+        """Prepare the session — the reader is spawned in [`run`][terok_shield.simple_clearance.ClearanceSession.run]."""
         self._state_dir = state_dir
         self._container = container
         self._queue: list[_Pending] = []

--- a/src/terok_shield/watch.py
+++ b/src/terok_shield/watch.py
@@ -13,9 +13,9 @@ import signal
 import sys
 from pathlib import Path
 
-from .. import state
-from ..config import DnsTier
-from ..watchers import AuditLogWatcher, DnsLogWatcher, DomainCache, NflogWatcher, WatchEvent
+from . import state
+from .config import DnsTier
+from .watchers import AuditLogWatcher, DnsLogWatcher, DomainCache, NflogWatcher, WatchEvent
 
 _running = True
 

--- a/tach.toml
+++ b/tach.toml
@@ -199,6 +199,7 @@ layer = "support"
 depends_on = [
     "terok_shield.audit",
     "terok_shield.profiles",
+    "terok_shield.watchers",
 ]
 
 # ── CLI ────────────────────────────────────────────────────

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1164,6 +1164,6 @@ class TestSetupInteractive:
 
 def test_simple_clearance_command_routes_to_handler(cli_dispatch: CliDispatchHarness) -> None:
     """simple-clearance subcommand dispatches to the terminal fallback handler."""
-    with mock.patch("terok_shield.cli.simple_clearance.run_simple_clearance") as mock_run:
+    with mock.patch("terok_shield.simple_clearance.run_simple_clearance") as mock_run:
         main(["simple-clearance", _CONTAINER])
     mock_run.assert_called_once()

--- a/tests/unit/test_commands.py
+++ b/tests/unit/test_commands.py
@@ -9,7 +9,7 @@ from unittest import mock
 
 import pytest
 
-from terok_shield.cli.registry import (
+from terok_shield.commands import (
     COMMANDS,
     ArgDef,
     _handle_allow,
@@ -123,7 +123,7 @@ class TestHandlers:
     def test_handle_watch_delegates_to_run_watch(self) -> None:
         """_handle_watch calls run_watch with state_dir and container."""
         shield = mock.MagicMock()
-        with mock.patch("terok_shield.cli.watch.run_watch") as mock_run:
+        with mock.patch("terok_shield.watch.run_watch") as mock_run:
             _handle_watch(shield, "ctr")
         mock_run.assert_called_once_with(shield.config.state_dir, "ctr")
 

--- a/tests/unit/test_simple_clearance.py
+++ b/tests/unit/test_simple_clearance.py
@@ -13,7 +13,7 @@ from unittest import mock
 
 import pytest
 
-from terok_shield.cli import simple_clearance
+from terok_shield import simple_clearance
 
 from ..testnet import TEST_DOMAIN, TEST_IP1, TEST_IP2
 

--- a/tests/unit/test_watch.py
+++ b/tests/unit/test_watch.py
@@ -14,13 +14,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-import terok_shield.cli.watch as _cli_watch_mod
-from terok_shield.cli.watch import (
-    _enrich_nflog,
-    _ensure_log_file,
-    _handle_signal,
-    run_watch,
-)
+import terok_shield.watch as _cli_watch_mod
 from terok_shield.config import DnsTier
 from terok_shield.nft.constants import (
     ALLOWED_LOG_PREFIX,
@@ -29,6 +23,12 @@ from terok_shield.nft.constants import (
     DENIED_LOG_PREFIX,
     NFLOG_GROUP,
     PRIVATE_LOG_PREFIX,
+)
+from terok_shield.watch import (
+    _enrich_nflog,
+    _ensure_log_file,
+    _handle_signal,
+    run_watch,
 )
 from terok_shield.watchers import (
     AuditLogWatcher,
@@ -65,7 +65,7 @@ _CONTAINER = "test-container"
 
 @pytest.fixture(autouse=False)
 def _restore_running() -> Generator[None, None, None]:
-    """Capture and restore ``terok_shield.cli.watch._running`` around tests that mutate it."""
+    """Capture and restore ``terok_shield.watch._running`` around tests that mutate it."""
     original = _cli_watch_mod._running
     yield
     _cli_watch_mod._running = original
@@ -996,8 +996,8 @@ class TestRunWatchHappyPath:
             return ([], [], [])
 
         with (
-            patch("terok_shield.cli.watch.select.select", side_effect=_stop_immediately),
-            patch("terok_shield.cli.watch.NflogWatcher.create", return_value=None),
+            patch("terok_shield.watch.select.select", side_effect=_stop_immediately),
+            patch("terok_shield.watch.NflogWatcher.create", return_value=None),
         ):
             run_watch(dnsmasq_state, _CONTAINER)
 
@@ -1025,8 +1025,8 @@ class TestRunWatchHappyPath:
             return ([], [], [])
 
         with (
-            patch("terok_shield.cli.watch.select.select", side_effect=_select_then_stop),
-            patch("terok_shield.cli.watch.NflogWatcher.create", return_value=None),
+            patch("terok_shield.watch.select.select", side_effect=_select_then_stop),
+            patch("terok_shield.watch.NflogWatcher.create", return_value=None),
         ):
             run_watch(dnsmasq_state, _CONTAINER)
 
@@ -1055,8 +1055,8 @@ class TestRunWatchHappyPath:
             return ([], [], [])
 
         with (
-            patch("terok_shield.cli.watch.select.select", side_effect=_select_then_stop),
-            patch("terok_shield.cli.watch.NflogWatcher.create", return_value=None),
+            patch("terok_shield.watch.select.select", side_effect=_select_then_stop),
+            patch("terok_shield.watch.NflogWatcher.create", return_value=None),
         ):
             run_watch(dnsmasq_state, _CONTAINER)
 
@@ -1089,8 +1089,8 @@ class TestRunWatchHappyPath:
             return ([], [], [])
 
         with (
-            patch("terok_shield.cli.watch.select.select", side_effect=_select_then_stop),
-            patch("terok_shield.cli.watch.NflogWatcher.create", return_value=None),
+            patch("terok_shield.watch.select.select", side_effect=_select_then_stop),
+            patch("terok_shield.watch.NflogWatcher.create", return_value=None),
         ):
             run_watch(dnsmasq_state, _CONTAINER)
 
@@ -1130,8 +1130,8 @@ class TestRunWatchHappyPath:
             return ([], [], [])
 
         with (
-            patch("terok_shield.cli.watch.select.select", side_effect=_select_then_stop),
-            patch("terok_shield.cli.watch.NflogWatcher.create", return_value=mock_nflog),
+            patch("terok_shield.watch.select.select", side_effect=_select_then_stop),
+            patch("terok_shield.watch.NflogWatcher.create", return_value=mock_nflog),
         ):
             run_watch(dnsmasq_state, _CONTAINER)
 
@@ -1180,8 +1180,8 @@ class TestRunWatchHappyPath:
             return ([], [], [])
 
         with (
-            patch("terok_shield.cli.watch.select.select", side_effect=_select_then_stop),
-            patch("terok_shield.cli.watch.NflogWatcher.create", return_value=mock_nflog),
+            patch("terok_shield.watch.select.select", side_effect=_select_then_stop),
+            patch("terok_shield.watch.NflogWatcher.create", return_value=mock_nflog),
         ):
             run_watch(dnsmasq_state, _CONTAINER)
 


### PR DESCRIPTION
## Summary

Part of a coordinated **command-registry normalization** across the terok-ai ecosystem: every sibling package exposes its `COMMANDS` registry from a top-level module (not buried in `cli/`), so terok's integration adapters can consume the public package API instead of reaching into internal submodules.

This PR — **terok-shield** (a leaf in the dependency DAG):

- moves `cli/registry.py` → top-level `commands.py`, and its `watch.py` / `simple_clearance.py` runners alongside it; `cli/` keeps only the argparse frontend
- repoints the package `__init__` lazy re-exports of `COMMANDS` / `CommandDef` / `ArgDef` at `terok_shield.commands`
- types the `COMMANDS` / `CommandDef` / `ArgDef` / `ExecError` lazy re-exports (added to the `TYPE_CHECKING` block) so downstream consumers see real types, not `object`
- updates `cli/main.py`, the tests, and `tach.toml`

## Chain

`clearance` + `shield` (leaves) → `sandbox` → `executor` → `terok`. The consuming PRs branch-pin this branch; the release script flips the pin back to a wheel on merge.

## Test plan

- [x] `make check` — lint, tests, tach, typecheck, security, docstrings, deadcode, reuse — all green