### PR TITLE
test: regression guards for the sys.executable PYTHONPATH shim

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,9 @@ docs/module_map.md
 docs/test_map.md
 site/
 /tmp/
+
+# Sibling repo checkouts that earlier agent sessions stashed inside the work
+# tree.  Not part of shield; leave them untracked.
+/terok/
+/terok-clearance/
+/terok-sandbox/

--- a/src/terok_shield/simple_clearance.py
+++ b/src/terok_shield/simple_clearance.py
@@ -29,6 +29,8 @@ from pathlib import Path
 
 from terok_shield.resources import __file__ as _resources_init  # pragma: no cover
 
+from .subprocess_env import child_process_env
+
 _RESOURCES_DIR = Path(_resources_init).parent
 _READER_SCRIPT = _RESOURCES_DIR / "nflog_reader.py"
 _HUB_BUS_NAME = "org.terok.Shield1"
@@ -219,15 +221,14 @@ class ClearanceSession:
         # that normally rewrites the env on startup) spawning ``python -m
         # terok_shield.cli`` from inside a running terok_shield process
         # bypasses that wrapper, and the child can't find the ``terok_shield``
-        # package on its import path.  Passing the parent's ``sys.path``
-        # through as ``PYTHONPATH`` lets the subprocess resolve the same
-        # install this process is running from.  See #242 by Franz Pöschel.
-        env = {**os.environ, "PYTHONPATH": os.pathsep.join(sys.path)}
+        # package on its import path.  ``child_process_env`` threads the
+        # parent's ``sys.path`` through as ``PYTHONPATH`` so the subprocess
+        # resolves the same install this process is running from.
         result = subprocess.run(  # nosec B603
             [sys.executable, "-m", "terok_shield.cli", action, self._container, pending.dest],
             check=False,
             capture_output=True,
-            env=env,
+            env=child_process_env(),
         )
         return result.returncode == 0
 

--- a/src/terok_shield/subprocess_env.py
+++ b/src/terok_shield/subprocess_env.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Environment helper for spawned ``terok_shield`` child processes.
+
+Centralises the ``PYTHONPATH`` shim every ``subprocess.run`` /
+``Popen`` of ``sys.executable`` must use, so adding a new spawn site
+can't silently regress the Nix-wrapped-Python fix.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+
+def child_process_env(overrides: dict[str, str] | None = None) -> dict[str, str]:
+    """Build the environment for a spawned ``terok_shield`` child process.
+
+    Threads the parent's ``sys.path`` through as ``PYTHONPATH`` so the
+    child can import ``terok_shield`` regardless of how the parent was
+    launched.  Under Nix, ``sys.executable`` is a wrapper script that
+    rewrites the env on startup — but spawning it directly via
+    ``subprocess`` / ``create_subprocess_exec`` bypasses that wrapper,
+    leaving the child unable to find the ``terok_shield`` package.
+    This shim restores it.
+
+    *overrides* are applied on top of the parent env; ``PYTHONPATH``
+    always wins so a stray ambient value can't shadow the parent's
+    real import path.
+    """
+    return {**os.environ, **(overrides or {}), "PYTHONPATH": os.pathsep.join(sys.path)}

--- a/tests/unit/test_subprocess_env.py
+++ b/tests/unit/test_subprocess_env.py
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Behavioural tests for the ``child_process_env`` Nix-wrapped-Python shim.
+
+The wrapped-Python failure mode (Nix, some Conda envs):
+
+* The parent process has its ``sys.path`` augmented at import time by a
+  wrapper script or ``.pth`` file — terok_shield lives at a path the
+  bare interpreter doesn't auto-discover.
+* That augmentation is *not* reflected in ``os.environ['PYTHONPATH']``.
+* A subprocess started directly via ``[sys.executable, '-m',
+  'terok_shield.…']`` inherits the empty/wrong ``PYTHONPATH`` and
+  can't ``import terok_shield``.
+
+These tests prove ``child_process_env`` actually fixes that path
+without needing real Nix.  They drop a stub module into a tmpdir, add
+the dir to the *parent's* ``sys.path`` only, then exercise both the
+broken (naive) and fixed (via the helper) subprocess patterns and
+assert the expected outcomes.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from terok_shield.subprocess_env import child_process_env
+
+_STUB_MODULE_NAME = "_terok_shield_nix_regression_stub"
+
+
+@pytest.fixture
+def parent_only_sys_path_module(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Drop a stub package into *tmp_path* and add it to the parent's sys.path only.
+
+    Simulates the Nix-wrapped-Python setup where a directory is added to
+    the parent's ``sys.path`` via wrapper magic (not via ``PYTHONPATH``),
+    so a naive subprocess can't see it.
+    """
+    stub = tmp_path / f"{_STUB_MODULE_NAME}.py"
+    stub.write_text(f"VALUE = 'imported-from-{tmp_path.name}'\n")
+    monkeypatch.syspath_prepend(str(tmp_path))
+    # PYTHONPATH must *not* contain tmp_path — that's the whole point.
+    # ``monkeypatch.syspath_prepend`` only touches the in-process
+    # ``sys.path``, never the env var, so this invariant is automatic.
+    return stub
+
+
+def _subprocess_can_import(env: dict[str, str]) -> tuple[int, str]:
+    """Return ``(returncode, stdout)`` of a subprocess trying to import the stub."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            f"import {_STUB_MODULE_NAME}; print({_STUB_MODULE_NAME}.VALUE)",
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+    return result.returncode, result.stdout.strip()
+
+
+def test_naive_subprocess_cannot_import_parent_only_module(
+    parent_only_sys_path_module: Path,
+) -> None:
+    """Without the helper, the child can't see the parent's wrapped sys.path.
+
+    This *is* the bug pattern: a fresh Python subprocess started from a
+    Nix-wrapped parent doesn't inherit the wrapper's sys.path adjustments.
+    """
+    rc, _stdout = _subprocess_can_import({"PATH": "/usr/bin:/bin"})
+    assert rc != 0, (
+        "Test fixture is broken: the child found the stub module without "
+        "PYTHONPATH forwarding.  Check that the parent's sys.path "
+        "augmentation isn't leaking into PYTHONPATH."
+    )
+
+
+def test_child_process_env_fixes_wrapped_python_import(
+    parent_only_sys_path_module: Path,
+) -> None:
+    """With ``child_process_env``, the child finds the parent-only module."""
+    rc, stdout = _subprocess_can_import(child_process_env())
+    assert rc == 0, "child_process_env() failed to forward parent sys.path"
+    assert stdout.startswith("imported-from-"), (
+        f"unexpected child stdout: {stdout!r} — the stub module rendered "
+        "differently than expected; check the fixture."
+    )
+
+
+def test_child_process_env_threads_sys_path_as_pythonpath() -> None:
+    """The child env carries the parent's ``sys.path`` as ``PYTHONPATH``."""
+    env = child_process_env()
+    assert env["PYTHONPATH"] == os.pathsep.join(sys.path)
+    # And it still inherits the parent environment.
+    assert "PATH" in env
+
+
+def test_child_process_env_pythonpath_wins_over_overrides() -> None:
+    """An ambient/override ``PYTHONPATH`` can never shadow the parent's real path."""
+    env = child_process_env({"FOO": "bar", "PYTHONPATH": "ambient-junk"})
+    assert env["FOO"] == "bar"
+    assert env["PYTHONPATH"] == os.pathsep.join(sys.path)

--- a/tests/unit/test_subprocess_pythonpath_call_sites.py
+++ b/tests/unit/test_subprocess_pythonpath_call_sites.py
@@ -1,0 +1,118 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Static check: every ``[sys.executable, ...]`` spawn must thread ``PYTHONPATH``.
+
+Walks ``src/terok_shield/`` looking for ``subprocess.run`` /
+``subprocess.Popen`` / ``asyncio.create_subprocess_exec`` calls whose
+argv starts with ``sys.executable``.  Each such site must pass
+``env=child_process_env(...)`` — otherwise terok_shield crashes under
+wrapped-Python setups (Nix, some Conda environments) where the parent's
+``sys.path`` is hidden from the child's default import-path discovery.
+
+Failing this test means someone added a new spawn site without going
+through the helper.  Fix it by importing
+``from terok_shield.subprocess_env import child_process_env`` and
+passing ``env=child_process_env()`` on the call.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_SRC_ROOT = Path(__file__).resolve().parents[2] / "src" / "terok_shield"
+_SPAWN_CALLABLES = {
+    ("subprocess", "run"),
+    ("subprocess", "Popen"),
+    ("subprocess", "check_call"),
+    ("subprocess", "check_output"),
+    ("asyncio", "create_subprocess_exec"),
+}
+
+
+def _is_module_run(call: ast.Call) -> bool:
+    """Return True when *call*'s argv looks like ``[sys.executable, "-m", "<mod>", ...]``.
+
+    Only ``python -m module`` invocations need the ``PYTHONPATH`` shim —
+    they import the module and so depend on ``sys.path``.  Script-path
+    invocations (``python /path/to/script.py``) get their script dir
+    on ``sys.path[0]`` automatically, so they don't need the helper
+    (and stdlib-only scripts shouldn't pretend to).
+    """
+    if not call.args:
+        return False
+    argv = call.args[0]
+    if not isinstance(argv, ast.List) or len(argv.elts) < 3:
+        return False
+    first, second = argv.elts[0], argv.elts[1]
+    is_sys_executable = (
+        isinstance(first, ast.Attribute)
+        and isinstance(first.value, ast.Name)
+        and first.value.id == "sys"
+        and first.attr == "executable"
+    )
+    is_dash_m = isinstance(second, ast.Constant) and second.value == "-m"
+    return is_sys_executable and is_dash_m
+
+
+def _is_spawn_call(call: ast.Call) -> bool:
+    """Return True when *call* invokes a known subprocess-spawning function."""
+    func = call.func
+    if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name):
+        return (func.value.id, func.attr) in _SPAWN_CALLABLES
+    return False
+
+
+def _env_kwarg_uses_helper(call: ast.Call) -> bool:
+    """Return True when *call* has ``env=child_process_env(...)``."""
+    for kw in call.keywords:
+        if kw.arg != "env":
+            continue
+        value = kw.value
+        if isinstance(value, ast.Call):
+            func = value.func
+            if isinstance(func, ast.Name) and func.id == "child_process_env":
+                return True
+            if isinstance(func, ast.Attribute) and func.attr == "child_process_env":
+                return True
+    return False
+
+
+def _iter_python_files(root: Path):
+    """Yield every ``.py`` file under *root*, excluding ``__pycache__`` etc."""
+    for path in root.rglob("*.py"):
+        if "__pycache__" in path.parts:
+            continue
+        yield path
+
+
+def test_every_sys_executable_spawn_uses_child_process_env() -> None:
+    """Every ``[sys.executable, ...]`` spawn must pass ``env=child_process_env(...)``.
+
+    Regression guard for the Nix-wrapped-Python failure mode: a
+    subprocess that doesn't inherit the parent's ``sys.path`` via
+    ``PYTHONPATH`` can't ``import terok_shield``.
+    """
+    offenders: list[str] = []
+    for path in _iter_python_files(_SRC_ROOT):
+        tree = ast.parse(path.read_text())
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            if not _is_spawn_call(node):
+                continue
+            if not _is_module_run(node):
+                continue
+            if _env_kwarg_uses_helper(node):
+                continue
+            offenders.append(
+                f"  {path.relative_to(_SRC_ROOT.parents[1])}:{node.lineno} — "
+                "missing env=child_process_env(...)"
+            )
+
+    assert not offenders, (
+        "Found subprocess spawns of ``sys.executable`` that don't go through "
+        "``child_process_env`` — these will fail to import terok_shield under "
+        "wrapped-Python setups (Nix):\n" + "\n".join(offenders)
+    )


### PR DESCRIPTION
Mirrors the regression guards going into terok and terok-sandbox. Captures the wrapped-Python `[sys.executable, "-m", ...]` failure mode (Nix, some Conda envs) as automation so it can't silently come back here either.

## What was inline

`cli/simple_clearance.py:225` had its own copy of the
``env = {**os.environ, "PYTHONPATH": os.pathsep.join(sys.path)}``
shim from the same fix family. Now factored to a single helper at `terok_shield.subprocess_env.child_process_env`.

## Two layers

1. **`tests/unit/test_subprocess_pythonpath_call_sites.py`** — AST scan over `src/terok_shield/`. Asserts every `subprocess.run` / `Popen` of `[sys.executable, "-m", "<module>", ...]` passes `env=child_process_env(...)`. Catches "someone added a new spawn site without the helper". Targeted at the `-m` form because that's the one that depends on `sys.path` — `nflog_reader.py` is intentionally stdlib-only and spawned by script path, so it correctly stays out of scope.

2. **`tests/unit/test_subprocess_env.py`** — behavioural test. Synthesises the wrapped-Python failure mode (parent's `sys.path` augmented in-process, `PYTHONPATH` deliberately empty), exercises both the naive subprocess pattern (asserts failure) and the helper-fixed one (asserts success). Catches "the helper itself regressed".

Self-contained — no cross-repo dependency.

## Test plan

- [x] `poetry run pytest tests/unit/test_subprocess_pythonpath_call_sites.py tests/unit/test_subprocess_env.py` — 5 pass
- [x] `poetry run ruff check && ruff format --check` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated .gitignore to ignore stashed sibling checkout directories.
  * Centralized child-process environment handling for spawned Python subprocesses.

* **Tests**
  * Added regression tests validating child-process environment behavior and PYTHONPATH propagation.
  * Added static validation to ensure subprocess spawns include the standardized environment helper.

* **Bug Fixes**
  * Fixed subprocess import failures when parent Python is wrapped, ensuring child processes can import project modules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok-shield/pull/310)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->