### PR TITLE
chore: release 0.6.42a3 Better Diagnostics

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ packages = [
 include = [
   { path = "src/terok_shield/resources/nflog_reader.py", format = ["sdist", "wheel"] },
 ]
-version = "0.6.42a2"
+version = "0.6.42a3"
 
 [tool.poetry.group.dev.dependencies]
 ruff = ">=0.15.10"


### PR DESCRIPTION
Automated release bump to v0.6.42a3.