### PR TITLE
feat(profiles): bundle krun_guest egress profile

### DIFF
--- a/src/terok_shield/resources/dns/krun_guest.txt
+++ b/src/terok_shield/resources/dns/krun_guest.txt
@@ -1,0 +1,25 @@
+# Tight egress allowlist for terok krun microVM guests.
+#
+# Krun guests run unmodified OCI workloads inside KVM microVMs and talk
+# to the host exclusively over vsock — ingress hardening is therefore
+# structural (sshd binds AF_VSOCK only; no TCP listen at all), not an
+# nftables matter.  This file constrains the *egress* side: a compromised
+# guest should not be able to call out to arbitrary hosts even if the
+# in-VM workload tries to.
+#
+# Membership rule: only what the guest itself needs to boot, sync time,
+# and refresh its own package metadata.  Workload egress is granted
+# per-task via the user/project profile, layered on top of this.
+
+# NTP time synchronization (clock skew breaks key auth)
+pool.ntp.org
+time.google.com
+time.cloudflare.com
+
+# Distro security update channels (mirroring base.txt; krun guests share
+# the same minimal-base image lineage so the same hosts apply)
+archive.ubuntu.com
+security.ubuntu.com
+deb.debian.org
+mirrors.fedoraproject.org
+dl.fedoraproject.org

--- a/tests/testnet.py
+++ b/tests/testnet.py
@@ -25,6 +25,10 @@ CUSTOM_DOMAIN = "custom.example.com"  # Fixture domain for user-override profile
 BLOCKED_DOMAIN = "evil.example.com"  # Domain NOT in any allowlist (for watch tests)
 BLOCKED_SUBDOMAIN = "api.evil.example.com"  # Subdomain of BLOCKED_DOMAIN
 
+# Developer-grade egress probe used to assert tight allowlists (e.g.
+# ``krun_guest``) have not silently grown a developer-class destination.
+DEV_PYPI_DOMAIN = "pypi.org"
+
 # Adversarial domain shapes used by the wire-format sanitiser tests.
 # Centralised here so SonarCloud only flags the constant definitions,
 # not every call site that needs to verify defence against them.

--- a/tests/unit/test_profile_loader.py
+++ b/tests/unit/test_profile_loader.py
@@ -10,7 +10,7 @@ import pytest
 from terok_shield.profiles import ProfileLoader
 
 from ..testfs import FAKE_PROFILES_DIR, FORBIDDEN_TRAVERSAL, NONEXISTENT_DIR
-from ..testnet import CUSTOM_DOMAIN, TEST_DOMAIN, TEST_IP1
+from ..testnet import CUSTOM_DOMAIN, DEV_PYPI_DOMAIN, TEST_DOMAIN, TEST_IP1
 from .helpers import write_lines
 
 
@@ -90,8 +90,8 @@ def test_krun_guest_profile_minimal() -> None:
     assert any("ntp" in entry for entry in entries)
     # Sanity: it must not have grown to include developer-grade egress.
     # If this fails, ask whether the addition really belongs on krun guests.
-    assert "github.com" not in entries
-    assert "pypi.org" not in entries
+    assert TEST_DOMAIN not in entries
+    assert DEV_PYPI_DOMAIN not in entries
 
 
 def test_list_profiles_includes_user_profiles(tmp_path: Path) -> None:

--- a/tests/unit/test_profile_loader.py
+++ b/tests/unit/test_profile_loader.py
@@ -81,6 +81,17 @@ def test_list_profiles_includes_bundled_profiles() -> None:
     profiles = ProfileLoader(user_dir=NONEXISTENT_DIR).list_profiles()
     assert "base" in profiles
     assert "dev-standard" in profiles
+    assert "krun_guest" in profiles
+
+
+def test_krun_guest_profile_minimal() -> None:
+    """krun_guest profile is intentionally tight — NTP + distro updates only."""
+    entries = ProfileLoader(user_dir=NONEXISTENT_DIR).load_profile("krun_guest")
+    assert any("ntp" in entry for entry in entries)
+    # Sanity: it must not have grown to include developer-grade egress.
+    # If this fails, ask whether the addition really belongs on krun guests.
+    assert "github.com" not in entries
+    assert "pypi.org" not in entries
 
 
 def test_list_profiles_includes_user_profiles(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Adds `src/terok_shield/resources/dns/krun_guest.txt` — a tight egress allowlist for terok krun microVM guests.
- Membership: NTP for clock sync + distro security update channels. Nothing else.
- Per-task workload egress is layered on top via the user/project profile, exactly like every other guest.

## Design note: no ingress rules

Ingress hardening for krun guests is **structural** — sshd binds `AF_VSOCK` only, with no TCP listen surface at all (Phase 3 transport design). There is therefore no inbound network attack surface for nftables to filter, and this profile carries no inbound rules.

## Test plan

- [x] `pytest tests/unit/test_profile_loader.py` — 14 cases including new `test_krun_guest_profile_minimal` that asserts NTP presence and that the profile has not silently grown to include developer-grade egress (e.g. `github.com`, `pypi.org`).
- [x] `test_all_bundled_profiles_load` (integration/setup) picks up the new file automatically via `list_profiles()` discovery.
- [x] `make lint` clean.
- [x] `make reuse` clean.

## Context

Part of Phase 3 KrunRuntime (terok-ai/terok#767). Fully independent of the sibling sandbox / executor PRs — can land on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new security profile that restricts outbound network traffic to essential services (NTP and Linux distribution security updates).

* **Tests**
  * Added tests to validate the new profile configuration and security constraints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok-shield/pull/318?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->