### PR TITLE
fix(cli): add __main__.py so `python -m terok_shield.cli` works

### DIFF
--- a/src/terok_shield/cli/__main__.py
+++ b/src/terok_shield/cli/__main__.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Package entry point so ``python -m terok_shield.cli`` works.
+
+[`simple_clearance`][terok_shield.simple_clearance] shells out to
+``python -m terok_shield.cli`` to apply operator verdicts, threading
+the parent's ``sys.path`` through
+[`child_process_env`][terok_shield.subprocess_env.child_process_env]
+so Nix-wrapped interpreters still resolve the package.  Without an
+explicit ``__main__`` module the ``-m`` switch refuses to execute the
+package and every verdict fails as ``! verdict failed for <dest>``.
+
+Delegates verbatim to [`main`][terok_shield.cli.main.main]; the
+launch round-trip is regression-tested in
+``tests/unit/test_cli_main_module.py``.
+"""
+
+from terok_shield.cli.main import main
+
+main()

--- a/tests/unit/test_cli_main_module.py
+++ b/tests/unit/test_cli_main_module.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression guard: ``python -m terok_shield.cli`` is launchable.
+
+[`simple_clearance`][terok_shield.simple_clearance] spawns the verdict
+subprocess via ``[sys.executable, "-m", "terok_shield.cli", action, ...]``
+with [`child_process_env`][terok_shield.subprocess_env.child_process_env]
+threading the parent's ``sys.path``.  If the ``__main__`` module ever
+disappears (or never lands), every operator allow / deny in the
+terminal-fallback flow silently regresses to ``! verdict failed``.
+The launch shape verified here mirrors that call site exactly.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+from terok_shield.subprocess_env import child_process_env
+
+
+def test_cli_module_runs_via_dash_m() -> None:
+    """``python -m terok_shield.cli --help`` exits 0 and prints usage text."""
+    result = subprocess.run(  # nosec B603 — fixed argv, no shell
+        [sys.executable, "-m", "terok_shield.cli", "--help"],
+        capture_output=True,
+        env=child_process_env(),
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"`python -m terok_shield.cli --help` failed (rc={result.returncode}): "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    assert "usage" in result.stdout.lower()


### PR DESCRIPTION
## Summary

- Fix B2: `simple_clearance` shells out to `[sys.executable, "-m", "terok_shield.cli", action, container, dest]` to apply operator verdicts, but the `terok_shield.cli` package had no `__main__.py` — every spawn failed with `'terok_shield.cli' is a package and cannot be directly executed` and the operator saw `! verdict failed for <dest>` on every click.
- Adds `src/terok_shield/cli/__main__.py` that delegates verbatim to `terok_shield.cli.main.main` — the one missing piece.
- The verdict subprocess hop and its `child_process_env` shim (sys.path → PYTHONPATH, so Nix-wrapped interpreters still resolve `terok_shield`) stay exactly as introduced in #257 / #310 — only the missing package entry point is added.
- New regression test `tests/unit/test_cli_main_module.py` spawns `python -m terok_shield.cli --help` through `child_process_env()` and asserts exit 0, mirroring `simple_clearance`'s call shape.

## Test plan

- [x] `make lint` — clean
- [x] `make test-unit` — all tests pass; new test passes via real subprocess
- [x] `make check` — lint + test + tach + security + docstrings + reuse all green
- [x] Manual smoke: `python -m terok_shield.cli --help` exits 0 (was: `'terok_shield.cli' is a package and cannot be directly executed`)
- [ ] Manual operator smoke: stop the D-Bus hub, trigger a block via `terok-shield`, run `terok-shield simple-clearance`, type `a` — verify the verdict actually lands (no `! verdict failed`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)