### PR TITLE
chore: cut dead dnsmasq lifecycle + version-history prose

### DIFF
--- a/src/terok_shield/_hub_events.py
+++ b/src/terok_shield/_hub_events.py
@@ -60,7 +60,7 @@ class HubEventEmitter:
         events; passing it through here keeps the clearance UI's
         rendering of every event for the same container consistent
         (``project/task · name`` rather than the bare container slug).
-        Empty / omitted dossier degrades to the pre-v12 wire shape.
+        Empty / omitted dossier omits the key entirely.
         """
         self._send({"type": "shield_up", "container": container}, dossier)
 
@@ -82,9 +82,9 @@ class HubEventEmitter:
         """Write one JSON line to the hub socket, swallowing all I/O errors.
 
         *dossier* is folded into the payload only when non-empty —
-        keeps the wire identical to the pre-v12 shape on standalone
-        containers (``podman run`` without orchestrator annotations),
-        so old ingesters never see a key they don't understand.
+        keeps the wire flat for standalone containers (``podman run``
+        without orchestrator annotations) so the ingester only has
+        to handle the dossier key when one is actually populated.
 
         Every string value is run through the producer-side sanitiser
         (``WIRE_SPEC(safe-string)``) before serialisation so the wire

--- a/src/terok_shield/dns/dnsmasq.py
+++ b/src/terok_shield/dns/dnsmasq.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
-"""Per-container dnsmasq lifecycle: launch, reload, cleanup, and domain management.
+"""Per-container dnsmasq config generation, reload, and domain management.
 
 dnsmasq runs inside the container's network namespace (via ``nsenter``)
 on a runtime-dependent listen address — ``127.0.0.1:53`` for ordinary
@@ -10,7 +10,10 @@ krun whose guest can't reach netns 127.0.0.1.  ``--nftset``
 auto-populates nft allow sets on every DNS resolution to handle IP
 rotation that static pre-start resolution cannot.
 
-This module is the single owner of dnsmasq config format and CLI args.
+This module is the single package-side owner of dnsmasq config format
+and CLI args; the per-container start/stop dance is owned by the OCI
+hook resource (``resources/nft_hook.py``), which has its own stdlib-
+only copy because hook scripts run outside the package venv.
 """
 # WAYPOINT: HookMode (hooks.mode)
 
@@ -23,7 +26,7 @@ from pathlib import Path
 
 from .. import state
 from ..nft.constants import DNSMASQ_BIND_DEFAULT, NFT_TABLE_NAME
-from ..run import CommandRunner, ExecError
+from ..run import CommandRunner
 
 logger = logging.getLogger(__name__)
 
@@ -32,96 +35,6 @@ _DOMAIN_RE = re.compile(r"^(\*\.)?([a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?\.)+[a-
 
 
 # ── Lifecycle ──────────────────────────────────────────
-
-
-def launch(
-    runner: CommandRunner,
-    pid: str,
-    state_dir: Path,
-    upstream_dns: str,
-    domains: list[str],
-    *,
-    listen_address: str,
-) -> None:
-    """Generate config and launch dnsmasq in the container's network namespace.
-
-    dnsmasq daemonizes and writes its PID to the state directory.
-    If dnsmasq lacks ``--nftset`` support, it will fail immediately with
-    a clear "bad command line options" error (fail-closed).
-
-    Args:
-        runner: Command runner for subprocess calls.
-        pid: Container PID (for nsenter).
-        state_dir: Per-container state directory.
-        upstream_dns: Upstream DNS forwarder address.
-        domains: Domain names for nftset auto-population.
-        listen_address: Bind address for dnsmasq (required, keyword-only).
-            ``127.0.0.1`` for shared-loopback runtimes; a link-local
-            address for the krun microVM where the guest cannot reach
-            netns loopback.  See
-            [`DNSMASQ_BIND_DEFAULT`][terok_shield.nft.constants.DNSMASQ_BIND_DEFAULT]
-            and
-            [`DNSMASQ_BIND_KRUN`][terok_shield.nft.constants.DNSMASQ_BIND_KRUN].
-
-    Raises:
-        RuntimeError: If dnsmasq fails to start or PID file is not written.
-    """
-    conf_path = state.dnsmasq_conf_path(state_dir)
-    pid_path = state.dnsmasq_pid_path(state_dir)
-
-    # Remove any PID file left by a previous run so the post-launch
-    # existence check is not fooled by a stale file from a reused state dir.
-    _clear_pid_file(state_dir)
-
-    config = generate_config(upstream_dns, domains, pid_path, listen_address=listen_address)
-    conf_path.write_text(config)
-
-    # Launch dnsmasq inside the container's network namespace.
-    # --keep-in-foreground is NOT used: dnsmasq daemonizes and writes PID.
-    cmd = [
-        "nsenter",
-        "-t",
-        pid,
-        "-n",
-        "--",
-        "dnsmasq",
-        f"--conf-file={conf_path}",
-    ]
-    try:
-        runner.run(cmd, check=True)
-    except ExecError as e:
-        raise RuntimeError(f"dnsmasq failed to start: {e}") from e
-
-    if not pid_path.is_file():
-        raise RuntimeError(
-            f"dnsmasq started but PID file not written at {pid_path}. "
-            "The container's DNS may not be functional."
-        )
-
-
-def kill(state_dir: Path) -> None:
-    """Kill dnsmasq for a container (best-effort cleanup).
-
-    Reads the PID from the state directory and sends SIGTERM.
-    Silently ignores missing PID files, stale PIDs, and permission errors.
-    Verifies PID identity before signaling to avoid killing unrelated
-    processes.
-
-    Needed because dnsmasq runs in the host PID namespace (we only
-    ``nsenter -n`` into the network namespace).  When the container stops,
-    podman kills container-PID-namespace processes, but dnsmasq is NOT
-    among them — it becomes an orphan with a broken network socket.
-    """
-    pid_int = _read_pid(state_dir)
-    if pid_int is None:
-        return
-    if not _is_our_dnsmasq(pid_int, state_dir):
-        _clear_pid_file(state_dir)
-        return
-    try:
-        os.kill(pid_int, signal.SIGTERM)
-    except (ProcessLookupError, PermissionError):
-        pass
 
 
 def reload(state_dir: Path, upstream_dns: str, domains: list[str]) -> None:
@@ -281,26 +194,6 @@ def read_merged_domains(state_dir: Path) -> list[str]:
 
 
 # ── Container DNS setup ────────────────────────────────
-
-
-def write_resolv_conf(pid: str, nameserver: str = DNSMASQ_BIND_DEFAULT) -> None:
-    """Overwrite the container's resolv.conf to point to dnsmasq.
-
-    Safety measure backing up the ``--dns`` podman flag.  Writes directly
-    to ``/proc/{pid}/root/etc/resolv.conf`` from the host side.
-
-    Raises:
-        ValueError: If *pid* is not a numeric string or *nameserver* is not
-            a valid IPv4 or IPv6 address.
-    """
-    if not pid.isdigit():
-        raise ValueError(f"pid must be numeric, got {pid!r}")
-    try:
-        ipaddress.ip_address(nameserver)
-    except ValueError:
-        raise ValueError(f"nameserver must be a valid IP address, got {nameserver!r}") from None
-    resolv_path = Path(f"/proc/{pid}/root/etc/resolv.conf")
-    resolv_path.write_text(f"nameserver {nameserver}\n")
 
 
 # ── Config generation ──────────────────────────────────

--- a/src/terok_shield/podman_info.py
+++ b/src/terok_shield/podman_info.py
@@ -326,23 +326,3 @@ def parse_resolv_conf(text: str) -> str:
         if len(parts) >= 2 and parts[0] == "nameserver":
             return parts[1]
     return ""
-
-
-def parse_proc_net_route(text: str) -> str:
-    """Extract the default gateway IP from ``/proc/{pid}/net/route`` content.
-
-    The gateway field is a 32-bit hex integer in host byte order.
-    Returns an empty string if no default route is found.
-    """
-    import socket
-    import struct
-
-    for line in text.splitlines()[1:]:  # skip header
-        fields = line.split()
-        if len(fields) >= 3 and fields[1] == "00000000":  # default route
-            try:
-                gw_int = int(fields[2], 16)
-                return socket.inet_ntoa(struct.pack("=I", gw_int))
-            except (ValueError, struct.error):
-                continue
-    return ""

--- a/src/terok_shield/state.py
+++ b/src/terok_shield/state.py
@@ -47,44 +47,11 @@ stale on-disk entrypoint — bump it whenever the entrypoint *protocol*
 changes even if the file layout itself is unchanged, so that
 ``terok setup`` rewrites the script instead of short-circuiting.
 
-Version history:
-    13 — ``dnsmasq.conf`` ``listen-address`` is runtime-dependent
-        (``127.0.0.1`` by default, link-local under krun); the OCI
-        hook now runs ``ip addr add`` inside the netns for non-loopback
-        binds before launching dnsmasq.
-    12 — bridge ``createRuntime`` hook persists the OCI-extracted
-        dossier under ``state_dir/dossier.json`` so host-side
-        ``Shield.up()`` / ``Shield.down()`` can attach the same
-        identity bundle to their hub events that block events already
-        carry.  Pre-v12 state bundles work fine on a v12 reader; v12
-        bundles need a v12 reader (the JSON file is the only new
-        file).
-    11 — bridge hook extracts ``dossier.*`` OCI annotations and
-        forwards them to the reader as a JSON-encoded
-        ``--annotations=…`` argv element; reader resolves a per-emit
-        dossier (static annotations merged with optional meta-path
-        JSON) and ships it on the wire and in the audit log.  Old
-        readers reject the new flag; bumping forces ``terok setup``
-        to rewrite the on-disk reader script.
-    10 — reader appends ``"action": "blocked"`` entries to
-        ``audit.jsonl`` before each wire emit, closing the
-        block→verdict timeline gap (verdicts were already audited
-        by the host-side ``allow``/``deny`` path; blocks were not).
-        Same on-disk layout; new action keyword in an existing file.
-    9 — pre_start on dnsmasq tier seeds profile.allowed with resolved
-        domains so the initial allow set has permanent entries before
-        dnsmasq starts.  Reader swaps lifetime-dedup for a 30 s rolling
-        window so dismissed notifications can re-surface.
-    8 — reader emits JSON over a unix socket to the host-userns hub
-        (``--emit=socket``) instead of ``dbus-send`` from NS_ROOTLESS;
-        hook spawn line and reader script both need refreshing.
-    7 — bridge hook captures reader stdout+stderr into ``reader.log``
-        under the state dir; reader splits into host-userns outer and
-        container-netns inner.  File layout adds ``reader.log``.
-    6 — hook-argv dispatch protocol: bridge hook adds ``--bridge`` flag
-        between ``args[0]`` and the stage; file layout unchanged.
-    5 — add the optional bridge hook pair and ``reader.pid`` lifecycle file.
-    4 — previous stable shape (nft + dnsmasq only).
+Current shape (v13): ``dnsmasq.conf`` ``listen-address`` is runtime-
+dependent (``127.0.0.1`` by default, link-local under krun); the OCI
+hook runs ``ip addr add`` inside the netns for non-loopback binds
+before launching dnsmasq.  Earlier shapes are recoverable via
+``git log -L /^BUNDLE_VERSION/:src/terok_shield/state.py``.
 """
 
 

--- a/tests/unit/test_dnsmasq.py
+++ b/tests/unit/test_dnsmasq.py
@@ -14,13 +14,10 @@ from terok_shield.dns.dnsmasq import (
     add_domain,
     generate_config,
     has_nftset_support,
-    kill,
-    launch,
     nftset_entry,
     read_merged_domains,
     reload,
     remove_domain,
-    write_resolv_conf,
 )
 from terok_shield.nft.constants import (
     DNSMASQ_BIND_DEFAULT,
@@ -176,63 +173,6 @@ def test_generate_config_without_log_path(tmp_path: Path) -> None:
     assert "log-facility" not in config
 
 
-# ── launch ───────────────────────────────────────────────
-
-
-def test_launch_writes_config_and_runs_nsenter(tmp_path: Path) -> None:
-    """launch() writes config file and calls runner with nsenter command."""
-    state.ensure_state_dirs(tmp_path)
-    runner = mock.MagicMock()
-
-    # Simulate dnsmasq daemonising and writing its PID file as a side effect
-    # of the nsenter run call (matches real behaviour; pre-seeding would be
-    # cleared by launch()'s stale-PID cleanup).
-    def _write_pid(_cmd, **_kw):
-        state.dnsmasq_pid_path(tmp_path).write_text("12345\n")
-
-    runner.run.side_effect = _write_pid
-
-    launch(runner, "42", tmp_path, PASTA_DNS, [TEST_DOMAIN], listen_address=DNSMASQ_BIND_DEFAULT)
-
-    # Config was written
-    conf = state.dnsmasq_conf_path(tmp_path)
-    assert conf.is_file()
-    assert TEST_DOMAIN in conf.read_text()
-
-    # nsenter command was called
-    runner.run.assert_called_once()
-    cmd = runner.run.call_args[0][0]
-    assert cmd[0] == "nsenter"
-    assert "-t" in cmd
-    assert "42" in cmd
-    assert "-n" in cmd
-    assert "dnsmasq" in cmd
-
-
-def test_launch_raises_when_pid_file_missing(tmp_path: Path) -> None:
-    """launch() raises RuntimeError if dnsmasq doesn't write PID file."""
-    state.ensure_state_dirs(tmp_path)
-    runner = mock.MagicMock()
-    runner.run.return_value = ""
-
-    with pytest.raises(RuntimeError, match="PID file not written"):
-        launch(runner, "42", tmp_path, PASTA_DNS, [], listen_address=DNSMASQ_BIND_DEFAULT)
-
-
-def test_launch_maps_exec_error_to_runtime_error(tmp_path: Path) -> None:
-    """launch() converts ExecError from runner into RuntimeError."""
-    from terok_shield.run import ExecError
-
-    state.ensure_state_dirs(tmp_path)
-    runner = mock.MagicMock()
-    runner.run.side_effect = ExecError(["dnsmasq"], 1, "bad option")
-
-    with pytest.raises(RuntimeError, match="dnsmasq failed to start"):
-        launch(
-            runner, "42", tmp_path, PASTA_DNS, [TEST_DOMAIN], listen_address=DNSMASQ_BIND_DEFAULT
-        )
-
-
 # ── _is_our_dnsmasq / _clear_pid_file ────────────────────
 
 
@@ -322,56 +262,6 @@ def test_clear_pid_file_ignores_missing(tmp_path: Path) -> None:
     from terok_shield.dns.dnsmasq import _clear_pid_file
 
     _clear_pid_file(tmp_path)  # should not raise
-
-
-# ── kill ─────────────────────────────────────────────────
-
-
-def test_kill_sends_sigterm(tmp_path: Path) -> None:
-    """kill() reads PID file, verifies identity, and sends SIGTERM."""
-    state.dnsmasq_pid_path(tmp_path).write_text("12345\n")
-
-    with (
-        mock.patch("terok_shield.dns.dnsmasq._is_our_dnsmasq", return_value=True),
-        mock.patch("terok_shield.dns.dnsmasq.os.kill") as mock_kill,
-    ):
-        kill(tmp_path)
-
-    import signal
-
-    mock_kill.assert_called_once_with(12345, signal.SIGTERM)
-
-
-def test_kill_silently_ignores_missing_pid_file(tmp_path: Path) -> None:
-    """kill() does nothing if PID file is absent."""
-    kill(tmp_path)  # should not raise
-
-
-def test_kill_silently_ignores_stale_pid(tmp_path: Path) -> None:
-    """kill() silently handles ProcessLookupError (already dead)."""
-    state.dnsmasq_pid_path(tmp_path).write_text("99999\n")
-
-    with (
-        mock.patch("terok_shield.dns.dnsmasq._is_our_dnsmasq", return_value=True),
-        mock.patch("terok_shield.dns.dnsmasq.os.kill", side_effect=ProcessLookupError),
-    ):
-        kill(tmp_path)  # should not raise
-
-
-def test_kill_clears_stale_pid_file(tmp_path: Path) -> None:
-    """kill() clears PID file when PID is not a dnsmasq process."""
-    state.dnsmasq_pid_path(tmp_path).write_text("12345\n")
-
-    with mock.patch("terok_shield.dns.dnsmasq._is_our_dnsmasq", return_value=False):
-        kill(tmp_path)
-
-    assert not state.dnsmasq_pid_path(tmp_path).is_file()
-
-
-def test_kill_silently_ignores_invalid_pid_content(tmp_path: Path) -> None:
-    """kill() silently handles non-numeric PID content."""
-    state.dnsmasq_pid_path(tmp_path).write_text("not-a-number\n")
-    kill(tmp_path)  # should not raise
 
 
 # ── add_domain / remove_domain ────────────────────────────
@@ -652,29 +542,3 @@ def test_has_nftset_support_missing_dnsmasq() -> None:
         ""  # SubprocessRunner returns "" on FileNotFoundError with check=False
     )
     assert has_nftset_support(runner) is False
-
-
-# ── write_resolv_conf ────────────────────────────────────
-
-
-def test_write_resolv_conf(tmp_path: Path) -> None:
-    """write_resolv_conf() overwrites the resolv.conf file."""
-    resolv_path = tmp_path / "resolv.conf"
-    resolv_path.write_text("nameserver 169.254.1.1\n")
-
-    with mock.patch("terok_shield.dns.dnsmasq.Path", return_value=resolv_path):
-        write_resolv_conf("42")
-
-    assert resolv_path.read_text() == f"nameserver {DNSMASQ_BIND_DEFAULT}\n"
-
-
-def test_write_resolv_conf_rejects_non_numeric_pid() -> None:
-    """write_resolv_conf() raises ValueError for non-numeric PID."""
-    with pytest.raises(ValueError, match="numeric"):
-        write_resolv_conf("../../etc")
-
-
-def test_write_resolv_conf_rejects_invalid_nameserver() -> None:
-    """write_resolv_conf() raises ValueError for a non-IP nameserver."""
-    with pytest.raises(ValueError, match="valid IP address"):
-        write_resolv_conf("42", nameserver="not-an-ip")

--- a/tests/unit/test_podman_info.py
+++ b/tests/unit/test_podman_info.py
@@ -18,7 +18,6 @@ from terok_shield.podman_info import (
     global_hooks_hint,
     has_global_hooks,
     parse_podman_info,
-    parse_proc_net_route,
     parse_resolv_conf,
     parse_slirp4netns_cidr,
     slirp4netns_gateway,
@@ -194,45 +193,6 @@ class TestHooksDirPersists:
 
 
 # ── parse_resolv_conf tests ──────────────────────────────
-
-
-class TestParseProcNetRoute:
-    """Tests for /proc/net/route gateway parsing."""
-
-    def test_slirp4netns_default(self) -> None:
-        """Standard slirp4netns default route (10.0.2.2)."""
-        text = (
-            "Iface\tDestination\tGateway\tFlags\tRefCnt\tUse\tMetric\tMask\n"
-            "tap0\t00000000\t0202000A\t0003\t0\t0\t0\t00000000\n"
-            "tap0\t0002000A\t00000000\t0001\t0\t0\t0\t00FFFFFF\n"
-        )
-        assert parse_proc_net_route(text) == "10.0.2.2"
-
-    def test_custom_cidr(self) -> None:
-        """Custom CIDR (192.168.42.0/24) gateway is 192.168.42.2."""
-        # 192.168.42.2 = 0xC0A82A02, in little-endian hex: 022AA8C0
-        text = (
-            "Iface\tDestination\tGateway\tFlags\tRefCnt\tUse\tMetric\tMask\n"
-            "tap0\t00000000\t022AA8C0\t0003\t0\t0\t0\t00000000\n"
-        )
-        assert parse_proc_net_route(text) == "192.168.42.2"
-
-    def test_no_default_route(self) -> None:
-        """No default route returns empty string (e.g. pasta mode)."""
-        text = (
-            "Iface\tDestination\tGateway\tFlags\tRefCnt\tUse\tMetric\tMask\n"
-            "eth0\t0002000A\t00000000\t0001\t0\t0\t0\t00FFFFFF\n"
-        )
-        assert parse_proc_net_route(text) == ""
-
-    def test_empty_input(self) -> None:
-        """Empty input returns empty string."""
-        assert parse_proc_net_route("") == ""
-
-    def test_header_only(self) -> None:
-        """Header-only input returns empty string."""
-        text = "Iface\tDestination\tGateway\tFlags\tRefCnt\tUse\tMetric\tMask\n"
-        assert parse_proc_net_route(text) == ""
 
 
 class TestParseResolvConf:


### PR DESCRIPTION
## Summary

Three pre-public dead-code clusters in shield — no production consumers anywhere in the six terok repos. Net **−336 LoC**.

### Removed

- **`dnsmasq.launch` / `kill` / `write_resolv_conf`** with their unit tests. The OCI hook resource (`resources/nft_hook.py`) re-implements the start/stop dance in stdlib-only form because hooks run outside the package venv; production uses that copy. The package-side functions were referenced only by their own tests.
- **`podman_info.parse_proc_net_route`** + its unit tests. Only its own tests called it; gateway resolution now reads `containers.conf` + `nft.constants` via `_gateways_for_mode`.
- **Multi-version history blocks** in `state.BUNDLE_VERSION` (v4–v13) and `_hub_events` "pre-v12 wire shape" prose. `git log -L` carries the history; the docstring only needs to name the current contract.

### Kept (live or load-bearing)

- `dnsmasq.reload` and helpers (`_read_pid`, `_is_our_dnsmasq`, `_clear_pid_file`, `_extract_listen_address`) — live, called from `hooks/mode.py:362`.
- All domain-management functions (`add_domain`, `remove_domain`, `read_merged_domains`, etc.) — live.
- Config-generation API (`generate_config`, `nftset_entry`, `has_nftset_support`) — live.

Also drops the now-unused `ExecError` import from `dns/dnsmasq.py` and tightens the module docstring to reflect that lifecycle ownership lives in the OCI hook resource.

## Test plan

- [x] `make lint` clean (formatter ran on two files)
- [x] All affected unit tests pass: `test_dnsmasq.py` (58 tests), `test_podman_info.py` (59 tests)
- [x] `make check` — lint + tach + security + docstrings + reuse + deadcode all green
- [ ] Manual smoke: launch a shielded container, verify `Shield.pre_start` + `allow` + `deny` still work end-to-end (`reload` path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed DNS lifecycle management functions; core DNS configuration and reload capabilities remain available.
  * Removed network gateway detection functionality.

* **Documentation**
  * Clarified event emission behavior for empty dossier values.
  * Updated DNS module documentation and state bundle version notes for accuracy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok-shield/pull/329?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->