### PR TITLE
chore: shrink public API surface (W4.D)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ packages = [
 include = [
   { path = "src/terok_shield/resources/nflog_reader.py", format = ["sdist", "wheel"] },
 ]
-version = "0.6.42a7"
+version = "0.6.42a8"
 
 [tool.poetry.group.dev.dependencies]
 ruff = ">=0.15.10"

--- a/src/terok_shield/__init__.py
+++ b/src/terok_shield/__init__.py
@@ -27,17 +27,15 @@ from typing import TYPE_CHECKING
 
 # ── Eager: foundation layer (zero-cost, pure data) ─────
 from .config import (
-    AuditFileConfig,
     DnsTier,
     ShieldConfig,
-    ShieldFileConfig,
     ShieldMode,
     ShieldModeBackend,
     ShieldRuntime,
     ShieldState,
     detect_dns_tier,
 )
-from .paths import HOOK_ENTRYPOINT_NAME, reader_script_path
+from .paths import HOOK_ENTRYPOINT_NAME
 from .podman_info import (
     USER_HOOKS_DIR,
     ensure_containers_conf_hooks_dir,
@@ -66,17 +64,10 @@ if TYPE_CHECKING:
 # Keeps ``from terok_shield import ShieldConfig`` lightweight.
 
 _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
-    "AuditLogger": ("terok_shield.audit", "AuditLogger"),
     "BinaryCheck": ("terok_shield.prereqs", "BinaryCheck"),
-    "CommandRunner": ("terok_shield.run", "CommandRunner"),
-    "DigNotFoundError": ("terok_shield.run", "DigNotFoundError"),
-    "DnsResolver": ("terok_shield.dns.resolver", "DnsResolver"),
     "ExecError": ("terok_shield.run", "ExecError"),
     "NftNotFoundError": ("terok_shield.run", "NftNotFoundError"),
-    "ProfileLoader": ("terok_shield.profiles", "ProfileLoader"),
-    "RulesetBuilder": ("terok_shield.nft.rules", "RulesetBuilder"),
     "ShieldNeedsSetup": ("terok_shield.run", "ShieldNeedsSetup"),
-    "SubprocessRunner": ("terok_shield.run", "SubprocessRunner"),
     "check_firewall_binaries": ("terok_shield.prereqs", "check_firewall_binaries"),
     "check_krun_binaries": ("terok_shield.prereqs", "check_krun_binaries"),
     "setup_global_hooks": ("terok_shield.hooks.install", "setup_global_hooks"),
@@ -449,34 +440,23 @@ class Shield:
 
 __all__ = [
     "ArgDef",
-    "AuditFileConfig",
-    "AuditLogger",
     "BinaryCheck",
     "COMMANDS",
     "CommandDef",
-    "CommandRunner",
-    "DigNotFoundError",
-    "DnsResolver",
-    "DnsTier",
     "EnvironmentCheck",
     "ExecError",
     "HOOK_ENTRYPOINT_NAME",
     "NftNotFoundError",
-    "ProfileLoader",
-    "RulesetBuilder",
     "Shield",
     "ShieldConfig",
-    "ShieldFileConfig",
     "ShieldMode",
     "ShieldNeedsSetup",
     "ShieldRuntime",
     "ShieldState",
-    "SubprocessRunner",
     "USER_HOOKS_DIR",
     "check_firewall_binaries",
     "check_krun_binaries",
     "ensure_containers_conf_hooks_dir",
-    "reader_script_path",
     "setup_global_hooks",
     "system_hooks_dir",
 ]

--- a/tests/unit/test_api_surface.py
+++ b/tests/unit/test_api_surface.py
@@ -14,7 +14,6 @@ import pytest
 
 import terok_shield
 from terok_shield import (
-    DigNotFoundError,
     ExecError,
     NftNotFoundError,
     ShieldConfig,
@@ -25,34 +24,23 @@ from terok_shield import (
 
 EXPECTED_ALL = [
     "ArgDef",
-    "AuditFileConfig",
-    "AuditLogger",
     "BinaryCheck",
     "COMMANDS",
     "CommandDef",
-    "CommandRunner",
-    "DigNotFoundError",
-    "DnsResolver",
-    "DnsTier",
     "EnvironmentCheck",
     "ExecError",
     "HOOK_ENTRYPOINT_NAME",
     "NftNotFoundError",
-    "ProfileLoader",
-    "RulesetBuilder",
     "Shield",
     "ShieldConfig",
-    "ShieldFileConfig",
     "ShieldMode",
     "ShieldNeedsSetup",
     "ShieldRuntime",
     "ShieldState",
-    "SubprocessRunner",
     "USER_HOOKS_DIR",
     "check_firewall_binaries",
     "check_krun_binaries",
     "ensure_containers_conf_hooks_dir",
-    "reader_script_path",
     "setup_global_hooks",
     "system_hooks_dir",
 ]
@@ -145,13 +133,6 @@ class TestAPISurface:
     def test_nft_not_found_error_is_runtime_error(self):
         """NftNotFoundError is a RuntimeError subclass for backwards compat."""
         err = NftNotFoundError("nft missing")
-        assert isinstance(err, RuntimeError)
-
-    # ── DigNotFoundError ─────────────────────────────────
-
-    def test_dig_not_found_error_is_runtime_error(self):
-        """DigNotFoundError is a RuntimeError subclass."""
-        err = DigNotFoundError("dig missing")
         assert isinstance(err, RuntimeError)
 
     # ── ExecError ────────────────────────────────────────


### PR DESCRIPTION
## Summary

W4.D in the multi-repo W4 chain (alongside terok-ai/terok-sandbox#354, terok-ai/terok-executor#366, terok-ai/terok#1023, terok-ai/terok-clearance W4.E).

Trim 11 internal collaborators from the published API surface. All are injected once by ``Shield.__init__`` and never referenced by downstream consumers — confirmed by full grep of terok-sandbox and terok integration adapters.

## Changes

**Dropped from ``__all__`` + ``_LAZY_IMPORTS``:**

- ``AuditLogger``, ``AuditFileConfig`` — log infrastructure
- ``CommandRunner``, ``SubprocessRunner`` — subprocess boundary
- ``DnsResolver`` — name resolution collaborator
- ``RulesetBuilder`` — nft ruleset assembly
- ``ProfileLoader`` — allowlist composer
- ``DigNotFoundError`` — downstream only catches ``ExecError`` / ``NftNotFoundError``
- ``DnsTier`` — enum used internally by ``detect_dns_tier()``
- ``ShieldFileConfig`` — YAML parser dataclass (never instantiated externally)
- ``reader_script_path`` — only used internally by hooks install

The api-surface snapshot test (``tests/unit/test_api_surface.py``) catches drift; both ``EXPECTED_ALL`` and the stale ``DigNotFoundError`` import-check are updated.

Internal ``Shield.__init__`` type hints still reference the trimmed collaborator classes via ``TYPE_CHECKING`` imports — those are unaffected by ``__all__`` membership.

## Out of scope

- **Empty package roots** (``nft/``, ``dns/``, ``hooks/``) stay as organizational boundaries — tach declares them as separate layers and the lazy ``__getattr__`` path resolves consumer imports through them.
- **``make_shield()`` factory** stays — it encapsulates non-trivial ``loopback_ports`` resolution from auto-allocated ``SandboxConfig`` (terok-sandbox#156 regression hook).
- **No method-ification candidates** — every public free function is a stateless utility or probe; the Shield class already absorbed the W3.D method-ification pass.

## Test plan

- [x] ``make check`` — lint, tests (1186 passed), tach, security, docstrings, dead-code, REUSE
- [x] Cross-repo grep verified no downstream consumer reaches a trimmed symbol via top-level

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Significantly narrowed the module's public API by removing multiple previously exported classes and utilities.

* **Tests**
  * Updated API surface tests to reflect the reduced set of public exports.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok-shield/pull/332?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->