### PR TITLE
chore: collapse hook install/uninstall onto HooksInstaller (W5.D)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ packages = [
 include = [
   { path = "src/terok_shield/resources/nflog_reader.py", format = ["sdist", "wheel"] },
 ]
-version = "0.6.42a8"
+version = "0.6.42a9"
 
 [tool.poetry.group.dev.dependencies]
 ruff = ">=0.15.10"

--- a/src/terok_shield/__init__.py
+++ b/src/terok_shield/__init__.py
@@ -38,7 +38,6 @@ from .config import (
 from .paths import HOOK_ENTRYPOINT_NAME
 from .podman_info import (
     USER_HOOKS_DIR,
-    ensure_containers_conf_hooks_dir,
     find_hooks_dirs,
     global_hooks_hint,
     has_global_hooks,
@@ -55,6 +54,7 @@ if TYPE_CHECKING:
     from .audit import AuditLogger
     from .commands import COMMANDS
     from .dns.resolver import DnsResolver
+    from .hooks.install import HooksInstaller
     from .nft.rules import RulesetBuilder
     from .profiles import ProfileLoader
     from .run import CommandRunner, ExecError
@@ -66,11 +66,11 @@ if TYPE_CHECKING:
 _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "BinaryCheck": ("terok_shield.prereqs", "BinaryCheck"),
     "ExecError": ("terok_shield.run", "ExecError"),
+    "HooksInstaller": ("terok_shield.hooks.install", "HooksInstaller"),
     "NftNotFoundError": ("terok_shield.run", "NftNotFoundError"),
     "ShieldNeedsSetup": ("terok_shield.run", "ShieldNeedsSetup"),
     "check_firewall_binaries": ("terok_shield.prereqs", "check_firewall_binaries"),
     "check_krun_binaries": ("terok_shield.prereqs", "check_krun_binaries"),
-    "setup_global_hooks": ("terok_shield.hooks.install", "setup_global_hooks"),
     # Command registry — re-exported for the terok integration layer.
     # ArgDef/CommandDef now live in terok-util; we route through it so
     # existing consumers (terok.lib.integrations.shield) keep working.
@@ -446,6 +446,7 @@ __all__ = [
     "EnvironmentCheck",
     "ExecError",
     "HOOK_ENTRYPOINT_NAME",
+    "HooksInstaller",
     "NftNotFoundError",
     "Shield",
     "ShieldConfig",
@@ -456,7 +457,4 @@ __all__ = [
     "USER_HOOKS_DIR",
     "check_firewall_binaries",
     "check_krun_binaries",
-    "ensure_containers_conf_hooks_dir",
-    "setup_global_hooks",
-    "system_hooks_dir",
 ]

--- a/src/terok_shield/cli/main.py
+++ b/src/terok_shield/cli/main.py
@@ -364,27 +364,19 @@ def _collect_all_audit_entries(state_root: Path, n: int) -> list[dict]:
 
 def _cmd_setup(*, root: bool, user: bool) -> None:
     """Install global OCI hooks for podman < 5.6.0 restart persistence."""
-    from ..hooks.install import setup_global_hooks
-    from ..podman_info import (
-        USER_HOOKS_DIR,
-        _user_containers_conf,
-        ensure_containers_conf_hooks_dir,
-        system_hooks_dir,
-    )
-
-    sys_dir = system_hooks_dir()
-    usr_dir = USER_HOOKS_DIR.expanduser()
-    conf_path = _user_containers_conf()
+    from ..hooks.install import HooksInstaller
+    from ..podman_info import _user_containers_conf
 
     if root and user:
         raise ValueError("--root and --user are mutually exclusive")
 
     if not root and not user:
-        # Interactive: present options
+        # Interactive: present options.
+        system, user_installer = HooksInstaller.system(), HooksInstaller.user()
         print("terok-shield setup: install global OCI hooks\n")
-        print(f"  [r] System-wide (sudo) -> {sys_dir}")
-        print(f"  [u] User-local         -> {usr_dir}")
-        print(f"      (+ update {conf_path})")
+        print(f"  [r] System-wide (sudo) -> {system.target_dir}")
+        print(f"  [u] User-local         -> {user_installer.target_dir}")
+        print(f"      (+ update {_user_containers_conf()})")
         print()
         choice = input("Choose [r/u]: ").strip().lower()
         if choice == "r":
@@ -395,15 +387,11 @@ def _cmd_setup(*, root: bool, user: bool) -> None:
             print("Cancelled.")
             return
 
-    if root:
-        print(f"Installing hooks to {sys_dir} (sudo)...")
-        setup_global_hooks(sys_dir, use_sudo=True)
-        print("Done. Global hooks installed.")
-    elif user:
-        print(f"Installing hooks to {usr_dir}...")
-        setup_global_hooks(usr_dir)
-        ensure_containers_conf_hooks_dir(usr_dir)
-        print("Done. Global hooks installed.")
+    installer = HooksInstaller.system() if root else HooksInstaller.user()
+    scope = "sudo" if installer.use_sudo else "user"
+    print(f"Installing hooks to {installer.target_dir} ({scope})...")
+    installer.install()
+    print("Done. Global hooks installed.")
 
 
 # ── Config construction ──────────────────────────────────

--- a/src/terok_shield/hooks/install.py
+++ b/src/terok_shield/hooks/install.py
@@ -8,18 +8,32 @@ Writes two role-specific entrypoint scripts (``nft-hook`` and
 target hooks directory, alongside the JSON descriptors that tell
 podman to invoke each one at ``createRuntime`` and ``poststop``.
 
-Two entry points: [`install_hooks`][terok_shield.hooks.install.install_hooks] for per-container setup
-during pre_start, and [`setup_global_hooks`][terok_shield.hooks.install.setup_global_hooks] for one-time
-system-wide installation.
+Public entry points:
+
+- [`HooksInstaller`][terok_shield.hooks.install.HooksInstaller] — global
+  installation lifecycle (install + uninstall) at system or user scope.
+- [`install_hooks`][terok_shield.hooks.install.install_hooks] — per-container
+  install used by ``HookMode.pre_start``.
 
 Pure file I/O — no runtime container interaction.
 """
 # WAYPOINT: HookMode (hooks.mode)
 
+from __future__ import annotations
+
 import json
+import subprocess  # nosec B404 — sudo escalation for system-wide installs
+import tempfile
+from dataclasses import dataclass
 from pathlib import Path
 
 from ..config import ANNOTATION_KEY
+from ..podman_info import (
+    USER_HOOKS_DIR,
+    _parse_hooks_dir_from_conf,
+    _user_containers_conf,
+    system_hooks_dir,
+)
 from .reader_install import install_reader_resource
 
 #: File name for the shared OCI-state ballast module.  Both role
@@ -52,7 +66,134 @@ def _bridge_hook_json(stage: str) -> str:
     return f"terok-shield-bridge-{stage}.json"
 
 
-# ── Public API ──────────────────────────────────────────
+#: Every file ``HooksInstaller.install`` writes to ``target_dir``.
+#: Drives ``uninstall`` so the symmetric cleanup never drifts from
+#: the install layout.
+_INSTALLED_FILES: tuple[str, ...] = (
+    _BALLAST_NAME,
+    _NFT_ENTRYPOINT_NAME,
+    _READER_ENTRYPOINT_NAME,
+    *(_nft_hook_json(stage) for stage in _HOOK_STAGES),
+    *(_bridge_hook_json(stage) for stage in _HOOK_STAGES),
+)
+
+
+# ── Global installer ────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class HooksInstaller:
+    """Persistent installation of terok-shield's OCI hook pair.
+
+    The createRuntime/poststop hook pair must persist across container
+    restarts: podman ≥ 5.x drops per-container ``--hooks-dir`` on
+    stop/start (containers/podman#17935), so global hooks are the
+    only reliable activation path until that upstream regression is
+    fixed.  Two scopes, exposed as classmethod factories:
+
+    - [`HooksInstaller.system`][terok_shield.hooks.install.HooksInstaller.system] —
+      `/etc/containers/oci/hooks.d` (or the existing equivalent);
+      escalates writes through ``sudo``, visible to root and every user.
+    - [`HooksInstaller.user`][terok_shield.hooks.install.HooksInstaller.user] —
+      `~/.local/share/containers/oci/hooks.d`; rootless, also patches
+      ``hooks_dir`` into the user's ``containers.conf`` so podman
+      discovers it.
+
+    The lifecycle is symmetric: [`install`][terok_shield.hooks.install.HooksInstaller.install]
+    writes, [`uninstall`][terok_shield.hooks.install.HooksInstaller.uninstall]
+    removes.  Both are idempotent.
+    """
+
+    target_dir: Path
+    """Directory the hook files (entrypoints, ballast, JSON descriptors) live in."""
+
+    use_sudo: bool = False
+    """Escalate file writes and removals through ``sudo`` (system scope)."""
+
+    register_in_containers_conf: bool = False
+    """Patch ``hooks_dir`` into the user's ``containers.conf`` on install.
+
+    Only meaningful for the user scope — system hooks dirs are
+    discovered by podman without registration.
+    """
+
+    @classmethod
+    def system(cls) -> HooksInstaller:
+        """Installer for the canonical system hooks directory (sudo-escalated).
+
+        Targets the best-existing of ``/etc/containers/oci/hooks.d``
+        and ``/usr/share/containers/oci/hooks.d`` — see
+        [`system_hooks_dir`][terok_shield.podman_info.system_hooks_dir]
+        for the resolution rule.
+        """
+        return cls(target_dir=system_hooks_dir(), use_sudo=True)
+
+    @classmethod
+    def user(cls) -> HooksInstaller:
+        """Installer for the rootless per-user hooks directory.
+
+        Writes to ``~/.local/share/containers/oci/hooks.d`` and
+        registers that directory in the user's ``containers.conf`` so
+        podman scans it on the next container start.
+        """
+        return cls(
+            target_dir=USER_HOOKS_DIR.expanduser(),
+            use_sudo=False,
+            register_in_containers_conf=True,
+        )
+
+    def install(self) -> None:
+        """Write entrypoints, ballast, and JSON descriptors into ``target_dir``.
+
+        Both hook pairs (nft + reader) and the shared ballast are
+        written unconditionally — the reader hook soft-fails on
+        missing clearance, so installing it on a shield-only host
+        costs nothing and removes a configuration knob.  The
+        standalone NFLOG reader resource is copied to its canonical
+        per-user path regardless of scope.
+
+        For [`HooksInstaller.user`][terok_shield.hooks.install.HooksInstaller.user]
+        installs (``register_in_containers_conf=True``), also patches
+        ``hooks_dir`` into the user's ``containers.conf``.
+        """
+        # Reader resource is per-user, never under target_dir; install it
+        # before the hook JSONs so the path the JSONs reference is already
+        # populated when the first container fires.
+        install_reader_resource()
+        if self.use_sudo:
+            _install_via_sudo(self.target_dir)
+        else:
+            self.target_dir.mkdir(parents=True, exist_ok=True)
+            _write_role_files(self.target_dir, self.target_dir)
+        if self.register_in_containers_conf:
+            _register_hooks_dir_in_containers_conf(self.target_dir)
+
+    def uninstall(self) -> None:
+        """Remove every hook file [`install`][terok_shield.hooks.install.HooksInstaller.install] would write.
+
+        Idempotent — missing files are tolerated.  When ``use_sudo``
+        is set, deletion runs under ``sudo`` so the calling process
+        stays unprivileged.  Containers.conf is left untouched: the
+        user's other hook directories may still need the entry.
+        """
+        paths = [self.target_dir / name for name in _INSTALLED_FILES]
+        if self.use_sudo:
+            _remove_via_sudo(paths)
+        else:
+            for path in paths:
+                path.unlink(missing_ok=True)
+
+    def is_installed(self) -> bool:
+        """True when ``target_dir`` carries the canonical createRuntime hook JSON.
+
+        A presence probe, not a version check — the
+        [`Shield.check_environment`][terok_shield.Shield.check_environment]
+        path compares the ballast's ``BUNDLE_VERSION`` separately.
+        """
+        return (self.target_dir / _nft_hook_json("createRuntime")).is_file()
+
+
+# ── Per-container install (used by HookMode.pre_start) ──
 
 
 def install_hooks(*, hook_entrypoint: Path, hooks_dir: Path) -> None:
@@ -83,44 +224,11 @@ def install_hooks(*, hook_entrypoint: Path, hooks_dir: Path) -> None:
     _write_role_files(hook_entrypoint.parent, hooks_dir, nft_entrypoint_name=hook_entrypoint.name)
 
 
-def setup_global_hooks(target_dir: Path, *, use_sudo: bool = False) -> None:
-    """Install OCI hooks system-wide for restart persistence.
-
-    Called by the ``setup`` CLI command.  When *use_sudo* is True,
-    writes to a temp directory first and copies via ``sudo cp`` —
-    avoids needing the Python process itself to run as root.
-
-    Both hook pairs (nft + reader) and the shared ballast are written
-    unconditionally, and the standalone NFLOG reader resource is
-    copied out of the package to its canonical on-disk path.  The
-    reader hook soft-fails on missing clearance (no socket to deliver
-    events to) rather than blocking container starts, so installing
-    it unconditionally costs nothing on shield-only deployments and
-    removes a configuration knob.
-
-    Args:
-        target_dir: Global hooks directory to install into.
-        use_sudo: Copy files via ``sudo`` instead of writing directly.
-    """
-    # Reader resource is per-user, never under target_dir; install it
-    # before the hook JSONs so the path the JSONs reference is already
-    # populated when the first container fires.
-    install_reader_resource()
-    if use_sudo:
-        _install_via_sudo(target_dir)
-    else:
-        target_dir.mkdir(parents=True, exist_ok=True)
-        _write_role_files(target_dir, target_dir)
-
-
 # ── Installation mechanics ──────────────────────────────
 
 
 def _install_via_sudo(target_dir: Path) -> None:
     """Write hooks to a temp dir, then sudo-copy to the target."""
-    import subprocess
-    import tempfile
-
     with tempfile.TemporaryDirectory() as tmp:
         tmp_path = Path(tmp)
         # JSONs must reference the final script paths, not the temp
@@ -131,11 +239,7 @@ def _install_via_sudo(target_dir: Path) -> None:
             ["sudo", "mkdir", "-p", str(target_dir)],
             check=True,  # noqa: S603, S607
         )
-        scripts = (_BALLAST_NAME, _NFT_ENTRYPOINT_NAME, _READER_ENTRYPOINT_NAME)
-        descriptors = [
-            fn(stage) for stage in _HOOK_STAGES for fn in (_nft_hook_json, _bridge_hook_json)
-        ]
-        files = [str(tmp_path / name) for name in (*scripts, *descriptors)]
+        files = [str(tmp_path / name) for name in _INSTALLED_FILES]
         subprocess.run(
             ["sudo", "cp", *files, str(target_dir) + "/"],
             check=True,  # noqa: S603, S607
@@ -150,6 +254,16 @@ def _install_via_sudo(target_dir: Path) -> None:
             ],  # noqa: S603, S607
             check=True,
         )
+
+
+def _remove_via_sudo(paths: list[Path]) -> None:
+    """Remove *paths* via ``sudo rm -f`` — idempotent, no error on missing files."""
+    if not paths:
+        return
+    subprocess.run(
+        ["sudo", "rm", "-f", *(str(p) for p in paths)],
+        check=True,  # noqa: S603, S607
+    )
 
 
 def _write_role_files(
@@ -200,6 +314,55 @@ def _write_role_files(
         (hooks_dir / _bridge_hook_json(stage)).write_text(
             _generate_hook_json(reader_path, stage, _READER_ENTRYPOINT_NAME)
         )
+
+
+# ── containers.conf registration (user scope only) ──────
+
+
+def _register_hooks_dir_in_containers_conf(hooks_dir: Path) -> None:
+    """Ensure ``~/.config/containers/containers.conf`` lists *hooks_dir*.
+
+    Creates the file if absent.  Inserts ``hooks_dir`` into the
+    existing ``[engine]`` section or appends a new section if none
+    exists.  Warns (does not fail) when ``hooks_dir`` is already set
+    to a different value — the operator owns containers.conf and may
+    have intentionally pinned a different location.
+
+    Pure line-based editing — comments and formatting are preserved.
+    """
+    conf_path = _user_containers_conf()
+    hooks_str = str(hooks_dir)
+    hooks_line = f'hooks_dir = ["{hooks_str}"]'
+
+    if not conf_path.is_file():
+        conf_path.parent.mkdir(parents=True, exist_ok=True)
+        conf_path.write_text(f"[engine]\n{hooks_line}\n")
+        return
+
+    existing = _parse_hooks_dir_from_conf(conf_path)
+    if not existing:
+        _insert_hooks_line(conf_path, hooks_line)
+        return
+
+    if hooks_str in existing or str(hooks_dir.expanduser()) in existing:
+        return  # already configured
+    print(
+        f"Warning: {conf_path} already has hooks_dir = {existing}\n"
+        f"Add {hooks_str!r} to the list manually if needed."
+    )
+
+
+def _insert_hooks_line(conf_path: Path, hooks_line: str) -> None:
+    """Insert *hooks_line* after ``[engine]`` in *conf_path*, or append a new section."""
+    lines = conf_path.read_text().splitlines(keepends=True)
+    for i, line in enumerate(lines):
+        if line.strip() == "[engine]":
+            lines.insert(i + 1, hooks_line + "\n")
+            conf_path.write_text("".join(lines))
+            return
+    # No [engine] section — append one.
+    with conf_path.open("a") as f:
+        f.write(f"\n[engine]\n{hooks_line}\n")
 
 
 # ── Generators ──────────────────────────────────────────

--- a/src/terok_shield/podman_info.py
+++ b/src/terok_shield/podman_info.py
@@ -185,37 +185,6 @@ def system_hooks_dir() -> Path:
     return _SYSTEM_HOOKS_DIRS[-1]
 
 
-def ensure_containers_conf_hooks_dir(hooks_dir: Path) -> None:
-    """Ensure ``~/.config/containers/containers.conf`` includes *hooks_dir*.
-
-    Creates the file if absent.  Inserts ``hooks_dir`` into the existing
-    ``[engine]`` section, or appends a new section if none exists.
-    Warns (does not fail) if ``hooks_dir`` is already set differently.
-
-    Uses line-based text manipulation to preserve comments and formatting.
-    """
-    conf_path = _user_containers_conf()
-    hooks_str = str(hooks_dir)
-    hooks_line = f'hooks_dir = ["{hooks_str}"]'
-
-    if not conf_path.is_file():
-        conf_path.parent.mkdir(parents=True, exist_ok=True)
-        conf_path.write_text(f"[engine]\n{hooks_line}\n")
-        return
-
-    existing = _parse_hooks_dir_from_conf(conf_path)
-    if not existing:
-        _insert_hooks_line(conf_path, hooks_line)
-        return
-
-    if hooks_str in existing or str(hooks_dir.expanduser()) in existing:
-        return  # already configured
-    print(
-        f"Warning: {conf_path} already has hooks_dir = {existing}\n"
-        f"Add {hooks_str!r} to the list manually if needed."
-    )
-
-
 def global_hooks_hint() -> str:
     """Short hint telling the user to run ``terok-shield setup``."""
     return (
@@ -252,19 +221,6 @@ def _parse_hooks_dir_from_conf(path: Path) -> list[str]:
     if isinstance(hooks, str) and hooks:
         return [hooks]
     return []
-
-
-def _insert_hooks_line(conf_path: Path, hooks_line: str) -> None:
-    """Insert *hooks_line* after ``[engine]`` in *conf_path*, or append a new section."""
-    lines = conf_path.read_text().splitlines(keepends=True)
-    for i, line in enumerate(lines):
-        if line.strip() == "[engine]":
-            lines.insert(i + 1, hooks_line + "\n")
-            conf_path.write_text("".join(lines))
-            return
-    # No [engine] section — append one
-    with conf_path.open("a") as f:
-        f.write(f"\n[engine]\n{hooks_line}\n")
 
 
 # ── slirp4netns gateway ────────────────────────────────

--- a/tach.toml
+++ b/tach.toml
@@ -139,7 +139,7 @@ layer = "core"
 depends_on = []
 
 # Hook file generation and installation — also installs the reader
-# resource so a single ``setup_global_hooks`` call lands every artefact
+# resource so a single ``HooksInstaller.install()`` lands every artefact
 # the OCI hook needs (entrypoint, both hook-JSON pairs, reader script).
 [[modules]]
 path = "terok_shield.hooks.install"

--- a/tests/integration/setup/test_environment.py
+++ b/tests/integration/setup/test_environment.py
@@ -80,6 +80,7 @@ class TestGlobalHooksSetup:
 
     def test_setup_user_hooks(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """``HooksInstaller`` (user scope) installs hooks and updates containers.conf."""
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "share"))
         hooks_dir = tmp_path / "hooks.d"
         conf_dir = tmp_path / "config" / "containers"
         monkeypatch.setattr(
@@ -103,15 +104,19 @@ class TestGlobalHooksSetup:
         assert str(hooks_dir) in text
         assert text.count("[engine]") == 1
 
-    def test_has_global_hooks_after_setup(self, tmp_path: Path) -> None:
+    def test_has_global_hooks_after_setup(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """``has_global_hooks`` flips True once ``HooksInstaller.install()`` runs."""
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "share"))
         hooks_dir = tmp_path / "hooks.d"
         assert not has_global_hooks([hooks_dir])
         HooksInstaller(target_dir=hooks_dir).install()
         assert has_global_hooks([hooks_dir])
 
-    def test_setup_idempotent(self, tmp_path: Path) -> None:
+    def test_setup_idempotent(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """Running install twice doesn't break anything — file contents stay stable."""
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "share"))
         hooks_dir = tmp_path / "hooks.d"
         installer = HooksInstaller(target_dir=hooks_dir)
         installer.install()

--- a/tests/integration/setup/test_environment.py
+++ b/tests/integration/setup/test_environment.py
@@ -11,10 +11,8 @@ from pathlib import Path
 
 import pytest
 
-from terok_shield import EnvironmentCheck, Shield, ShieldConfig
-from terok_shield.hooks.install import setup_global_hooks
+from terok_shield import EnvironmentCheck, HooksInstaller, Shield, ShieldConfig
 from terok_shield.podman_info import (
-    ensure_containers_conf_hooks_dir,
     find_hooks_dirs,
     has_global_hooks,
     parse_podman_info,
@@ -81,16 +79,15 @@ class TestGlobalHooksSetup:
     """Test global hooks installation with real filesystem."""
 
     def test_setup_user_hooks(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        """setup --user installs hooks and updates containers.conf."""
+        """``HooksInstaller`` (user scope) installs hooks and updates containers.conf."""
         hooks_dir = tmp_path / "hooks.d"
         conf_dir = tmp_path / "config" / "containers"
         monkeypatch.setattr(
-            "terok_shield.podman_info._user_containers_conf",
+            "terok_shield.hooks.install._user_containers_conf",
             lambda: conf_dir / "containers.conf",
         )
 
-        # Install hooks
-        setup_global_hooks(hooks_dir)
+        HooksInstaller(target_dir=hooks_dir, register_in_containers_conf=True).install()
         assert (hooks_dir / "terok-shield-createRuntime.json").is_file()
         assert (hooks_dir / "terok-shield-poststop.json").is_file()
         assert (hooks_dir / "terok-shield-hook").is_file()
@@ -99,8 +96,7 @@ class TestGlobalHooksSetup:
         hook = hooks_dir / "terok-shield-hook"
         assert hook.stat().st_mode & 0o100
 
-        # Update containers.conf
-        ensure_containers_conf_hooks_dir(hooks_dir)
+        # containers.conf was patched as part of the user-scope install.
         conf = conf_dir / "containers.conf"
         assert conf.is_file()
         text = conf.read_text()
@@ -108,16 +104,17 @@ class TestGlobalHooksSetup:
         assert text.count("[engine]") == 1
 
     def test_has_global_hooks_after_setup(self, tmp_path: Path) -> None:
-        """has_global_hooks() returns True after setup_global_hooks()."""
+        """``has_global_hooks`` flips True once ``HooksInstaller.install()`` runs."""
         hooks_dir = tmp_path / "hooks.d"
         assert not has_global_hooks([hooks_dir])
-        setup_global_hooks(hooks_dir)
+        HooksInstaller(target_dir=hooks_dir).install()
         assert has_global_hooks([hooks_dir])
 
     def test_setup_idempotent(self, tmp_path: Path) -> None:
-        """Running setup twice does not break anything."""
+        """Running install twice doesn't break anything — file contents stay stable."""
         hooks_dir = tmp_path / "hooks.d"
-        setup_global_hooks(hooks_dir)
+        installer = HooksInstaller(target_dir=hooks_dir)
+        installer.install()
         first_content = (hooks_dir / "terok-shield-hook").read_text()
-        setup_global_hooks(hooks_dir)
+        installer.install()
         assert (hooks_dir / "terok-shield-hook").read_text() == first_content

--- a/tests/testfs.py
+++ b/tests/testfs.py
@@ -71,3 +71,9 @@ READER_EVENTS_SOCK_FILENAME = "events.sock"
 READER_SCRIPT_FILENAME = "reader.py"
 READER_PID_FILENAME = "reader.pid"
 HOOK_ENTRYPOINT_PATH = "/opt/terok-shield-hook"
+
+# ── Placeholder hooks_dir literal (for containers.conf parser tests) ──
+# Tests insert this string into ``hooks_dir = [...]`` lines so the
+# assertion sites can reference one canonical literal.
+PLACEHOLDER_HOOKS_DIR = "/my/hooks"
+PLACEHOLDER_ALT_HOOKS_DIR = "/other/hooks"

--- a/tests/unit/test_api_surface.py
+++ b/tests/unit/test_api_surface.py
@@ -30,6 +30,7 @@ EXPECTED_ALL = [
     "EnvironmentCheck",
     "ExecError",
     "HOOK_ENTRYPOINT_NAME",
+    "HooksInstaller",
     "NftNotFoundError",
     "Shield",
     "ShieldConfig",
@@ -40,9 +41,6 @@ EXPECTED_ALL = [
     "USER_HOOKS_DIR",
     "check_firewall_binaries",
     "check_krun_binaries",
-    "ensure_containers_conf_hooks_dir",
-    "setup_global_hooks",
-    "system_hooks_dir",
 ]
 
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1047,32 +1047,31 @@ def test_build_config_uses_resolved_state_root_when_no_container(
 class TestSetupCommand:
     """Tests for the setup CLI command."""
 
-    @mock.patch("terok_shield.hooks.install.setup_global_hooks")
-    @mock.patch("terok_shield.podman_info.ensure_containers_conf_hooks_dir")
+    @mock.patch("terok_shield.hooks.install.HooksInstaller.install")
     def test_setup_user(
         self,
-        mock_ensure: mock.Mock,
-        mock_setup: mock.Mock,
+        install: mock.Mock,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
-        """setup --user calls setup_global_hooks and ensure_containers_conf."""
+        """``setup --user`` dispatches to the user-scope installer."""
         main(["setup", "--user"])
-        mock_setup.assert_called_once()
-        mock_ensure.assert_called_once()
-        assert "Done" in capsys.readouterr().out
+        install.assert_called_once()
+        out = capsys.readouterr().out
+        assert "Done" in out
+        assert "user" in out
 
-    @mock.patch("terok_shield.hooks.install.setup_global_hooks")
+    @mock.patch("terok_shield.hooks.install.HooksInstaller.install")
     def test_setup_root(
         self,
-        mock_setup: mock.Mock,
+        install: mock.Mock,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
-        """setup --root calls setup_global_hooks with use_sudo=True."""
+        """``setup --root`` dispatches to the system-scope installer with sudo."""
         main(["setup", "--root"])
-        mock_setup.assert_called_once()
-        _, kwargs = mock_setup.call_args
-        assert kwargs.get("use_sudo") is True
-        assert "Done" in capsys.readouterr().out
+        install.assert_called_once()
+        out = capsys.readouterr().out
+        assert "Done" in out
+        assert "sudo" in out
 
     def test_setup_root_and_user_rejected(self) -> None:
         """setup --root --user raises."""
@@ -1145,21 +1144,17 @@ def test_version_flag_podman_missing(
 class TestSetupInteractive:
     """Tests for interactive setup mode."""
 
-    @mock.patch("terok_shield.hooks.install.setup_global_hooks")
+    @mock.patch("terok_shield.hooks.install.HooksInstaller.install")
     @mock.patch("builtins.input", return_value="u")
     def test_interactive_user_choice(
         self,
         _input: mock.Mock,
-        mock_setup: mock.Mock,
+        install: mock.Mock,
         capsys: pytest.CaptureFixture[str],
-        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Interactive setup with 'u' choice installs user hooks."""
-        monkeypatch.setattr(
-            "terok_shield.podman_info.ensure_containers_conf_hooks_dir", lambda _d: None
-        )
         main(["setup"])
-        mock_setup.assert_called_once()
+        install.assert_called_once()
         assert "Done" in capsys.readouterr().out
 
     @mock.patch("builtins.input", return_value="x")
@@ -1172,19 +1167,18 @@ class TestSetupInteractive:
         main(["setup"])
         assert "Cancelled" in capsys.readouterr().out
 
-    @mock.patch("terok_shield.hooks.install.setup_global_hooks")
+    @mock.patch("terok_shield.hooks.install.HooksInstaller.install")
     @mock.patch("builtins.input", return_value="r")
     def test_interactive_root_choice(
         self,
         _input: mock.Mock,
-        mock_setup: mock.Mock,
+        install: mock.Mock,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
         """Interactive setup with 'r' choice uses sudo."""
         main(["setup"])
-        mock_setup.assert_called_once()
-        _, kwargs = mock_setup.call_args
-        assert kwargs.get("use_sudo") is True
+        install.assert_called_once()
+        assert "sudo" in capsys.readouterr().out
 
 
 def test_simple_clearance_command_routes_to_handler(cli_dispatch: CliDispatchHarness) -> None:

--- a/tests/unit/test_hook_mode_class.py
+++ b/tests/unit/test_hook_mode_class.py
@@ -696,15 +696,15 @@ def test_pre_start_writes_ruleset_nft(
     assert "terok_shield" in content
 
 
-def test_setup_global_hooks_non_sudo(tmp_path: Path, monkeypatch) -> None:
-    """``setup_global_hooks()`` lays down nft + reader hooks + ballast + reader resource."""
-    from terok_shield.hooks.install import setup_global_hooks
+def test_hooks_installer_non_sudo_writes_role_files(tmp_path: Path, monkeypatch) -> None:
+    """A non-sudo install lays down nft + reader hooks, ballast, and reader resource."""
+    from terok_shield.hooks.install import HooksInstaller
 
     # Reader resource lands at ``$XDG_DATA_HOME/terok/shield/nflog-reader.py``;
     # redirect it under tmp_path so the test stays hermetic.
     monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "share"))
     target = tmp_path / "hooks.d"
-    setup_global_hooks(target)
+    HooksInstaller(target_dir=target).install()
 
     # Shared ballast lands once — both role scripts import from it.
     assert (target / "_oci_state.py").is_file()
@@ -766,16 +766,16 @@ def test_install_hooks_honors_custom_entrypoint_name(tmp_path: Path) -> None:
     assert bridge_json["hook"]["path"] == str(target / "terok-shield-bridge-hook")
 
 
-def test_setup_global_hooks_sudo_uses_subprocess(tmp_path: Path, monkeypatch) -> None:
-    """setup_global_hooks(use_sudo=True) calls sudo subprocess for hook install."""
+def test_hooks_installer_sudo_uses_subprocess(tmp_path: Path, monkeypatch) -> None:
+    """``HooksInstaller(use_sudo=True).install()`` escalates writes via sudo."""
     from unittest import mock
 
-    from terok_shield.hooks.install import setup_global_hooks
+    from terok_shield.hooks.install import HooksInstaller
 
     monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "share"))
     target = tmp_path / "system-hooks"
-    with mock.patch("subprocess.run") as mock_run:
-        setup_global_hooks(target, use_sudo=True)
+    with mock.patch("terok_shield.hooks.install.subprocess.run") as mock_run:
+        HooksInstaller(target_dir=target, use_sudo=True).install()
         # sudo mkdir + sudo cp + sudo chmod (reader install runs in-process).
         assert mock_run.call_count == 3
         cmds = [call.args[0] for call in mock_run.call_args_list]

--- a/tests/unit/test_hook_mode_class.py
+++ b/tests/unit/test_hook_mode_class.py
@@ -696,7 +696,9 @@ def test_pre_start_writes_ruleset_nft(
     assert "terok_shield" in content
 
 
-def test_hooks_installer_non_sudo_writes_role_files(tmp_path: Path, monkeypatch) -> None:
+def test_hooks_installer_non_sudo_writes_role_files(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """A non-sudo install lays down nft + reader hooks, ballast, and reader resource."""
     from terok_shield.hooks.install import HooksInstaller
 
@@ -766,7 +768,9 @@ def test_install_hooks_honors_custom_entrypoint_name(tmp_path: Path) -> None:
     assert bridge_json["hook"]["path"] == str(target / "terok-shield-bridge-hook")
 
 
-def test_hooks_installer_sudo_uses_subprocess(tmp_path: Path, monkeypatch) -> None:
+def test_hooks_installer_sudo_uses_subprocess(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """``HooksInstaller(use_sudo=True).install()`` escalates writes via sudo."""
     from unittest import mock
 

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -22,6 +22,8 @@ from terok_shield.hooks.install import (
     _register_hooks_dir_in_containers_conf,
 )
 
+from ..testfs import PLACEHOLDER_ALT_HOOKS_DIR, PLACEHOLDER_HOOKS_DIR
+
 # ── Factory constructors ─────────────────────────────────
 
 
@@ -159,9 +161,9 @@ class TestRegisterHooksDir:
             "terok_shield.hooks.install._user_containers_conf",
             lambda: conf_dir / "containers.conf",
         )
-        _register_hooks_dir_in_containers_conf(Path("/my/hooks"))
+        _register_hooks_dir_in_containers_conf(Path(PLACEHOLDER_HOOKS_DIR))
         text = (conf_dir / "containers.conf").read_text()
-        assert 'hooks_dir = ["/my/hooks"]' in text
+        assert f'hooks_dir = ["{PLACEHOLDER_HOOKS_DIR}"]' in text
         assert text.count("[engine]") == 1
 
     def test_inserts_into_existing_engine_section(
@@ -174,10 +176,10 @@ class TestRegisterHooksDir:
             "terok_shield.hooks.install._user_containers_conf",
             lambda: conf,
         )
-        _register_hooks_dir_in_containers_conf(Path("/my/hooks"))
+        _register_hooks_dir_in_containers_conf(Path(PLACEHOLDER_HOOKS_DIR))
         text = conf.read_text()
         assert text.count("[engine]") == 1
-        assert 'hooks_dir = ["/my/hooks"]' in text
+        assert f'hooks_dir = ["{PLACEHOLDER_HOOKS_DIR}"]' in text
         assert 'image_copy_tmp_dir = "/data/tmp"' in text
 
     def test_preserves_comments(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -188,7 +190,7 @@ class TestRegisterHooksDir:
             "terok_shield.hooks.install._user_containers_conf",
             lambda: conf,
         )
-        _register_hooks_dir_in_containers_conf(Path("/my/hooks"))
+        _register_hooks_dir_in_containers_conf(Path(PLACEHOLDER_HOOKS_DIR))
         text = conf.read_text()
         assert "# My config" in text
         assert "# temp dir" in text
@@ -203,7 +205,7 @@ class TestRegisterHooksDir:
             "terok_shield.hooks.install._user_containers_conf",
             lambda: conf,
         )
-        _register_hooks_dir_in_containers_conf(Path("/my/hooks"))
+        _register_hooks_dir_in_containers_conf(Path(PLACEHOLDER_HOOKS_DIR))
         text = conf.read_text()
         assert text.count("[engine]") == 2  # one in comment, one real
         assert text.count("hooks_dir") == 1
@@ -213,12 +215,12 @@ class TestRegisterHooksDir:
     ) -> None:
         """No-op when hooks_dir already points to the right path."""
         conf = tmp_path / "containers.conf"
-        conf.write_text('[engine]\nhooks_dir = ["/my/hooks"]\n')
+        conf.write_text(f'[engine]\nhooks_dir = ["{PLACEHOLDER_HOOKS_DIR}"]\n')
         monkeypatch.setattr(
             "terok_shield.hooks.install._user_containers_conf",
             lambda: conf,
         )
-        _register_hooks_dir_in_containers_conf(Path("/my/hooks"))
+        _register_hooks_dir_in_containers_conf(Path(PLACEHOLDER_HOOKS_DIR))
         assert conf.read_text().count("hooks_dir") == 1
 
     def test_appends_engine_when_no_section(
@@ -231,23 +233,23 @@ class TestRegisterHooksDir:
             "terok_shield.hooks.install._user_containers_conf",
             lambda: conf,
         )
-        _register_hooks_dir_in_containers_conf(Path("/my/hooks"))
+        _register_hooks_dir_in_containers_conf(Path(PLACEHOLDER_HOOKS_DIR))
         text = conf.read_text()
         assert "[containers]" in text
         assert "[engine]" in text
-        assert 'hooks_dir = ["/my/hooks"]' in text
+        assert f'hooks_dir = ["{PLACEHOLDER_HOOKS_DIR}"]' in text
 
     def test_warns_when_different_hooks_dir_configured(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
     ) -> None:
         """Warns (does not modify) when hooks_dir is already set differently."""
         conf = tmp_path / "containers.conf"
-        conf.write_text('[engine]\nhooks_dir = ["/other/hooks"]\n')
+        conf.write_text(f'[engine]\nhooks_dir = ["{PLACEHOLDER_ALT_HOOKS_DIR}"]\n')
         monkeypatch.setattr(
             "terok_shield.hooks.install._user_containers_conf",
             lambda: conf,
         )
-        _register_hooks_dir_in_containers_conf(Path("/my/hooks"))
+        _register_hooks_dir_in_containers_conf(Path(PLACEHOLDER_HOOKS_DIR))
         assert "Warning" in capsys.readouterr().out
         assert conf.read_text().count("hooks_dir") == 1  # unchanged
 

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -1,0 +1,284 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for HooksInstaller and the containers.conf patcher.
+
+Covers the system/user factory pair, the symmetric install/uninstall
+lifecycle, and the line-based containers.conf editing that user-scope
+installs trigger.  The per-container [`install_hooks`][terok_shield.hooks.install.install_hooks]
+path and the role-file generators are exercised by ``test_hook_mode_class``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from terok_shield.hooks.install import (
+    _INSTALLED_FILES,
+    HooksInstaller,
+    _register_hooks_dir_in_containers_conf,
+)
+
+# ── Factory constructors ─────────────────────────────────
+
+
+class TestFactories:
+    """The ``system`` / ``user`` classmethods bind the right scope defaults."""
+
+    def test_system_uses_sudo(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``system()`` escalates writes and skips containers.conf registration."""
+        monkeypatch.setattr(
+            "terok_shield.hooks.install.system_hooks_dir",
+            lambda: Path("/fake/system"),
+        )
+        installer = HooksInstaller.system()
+        assert installer.target_dir == Path("/fake/system")
+        assert installer.use_sudo is True
+        assert installer.register_in_containers_conf is False
+
+    def test_user_does_not_use_sudo(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``user()`` writes directly and registers in containers.conf."""
+        monkeypatch.setattr(
+            "terok_shield.hooks.install.USER_HOOKS_DIR",
+            Path("/fake/user"),
+        )
+        installer = HooksInstaller.user()
+        assert installer.target_dir == Path("/fake/user")
+        assert installer.use_sudo is False
+        assert installer.register_in_containers_conf is True
+
+
+# ── Install / uninstall lifecycle ────────────────────────
+
+
+class TestInstallLifecycle:
+    """End-to-end install + uninstall against a tmp directory."""
+
+    def test_install_writes_every_hook_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A fresh non-sudo install lays down every name in ``_INSTALLED_FILES``."""
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "share"))
+        installer = HooksInstaller(target_dir=tmp_path / "hooks.d")
+        installer.install()
+        for name in _INSTALLED_FILES:
+            assert (installer.target_dir / name).is_file(), f"missing {name}"
+
+    def test_install_marks_entrypoints_executable(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The two role scripts get the executable bit; the ballast does not."""
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "share"))
+        installer = HooksInstaller(target_dir=tmp_path / "hooks.d")
+        installer.install()
+        assert (installer.target_dir / "terok-shield-hook").stat().st_mode & 0o100
+        assert (installer.target_dir / "terok-shield-bridge-hook").stat().st_mode & 0o100
+
+    def test_install_is_idempotent(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A second install overwrites without raising; file contents stay stable."""
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "share"))
+        installer = HooksInstaller(target_dir=tmp_path / "hooks.d")
+        installer.install()
+        first = (installer.target_dir / "terok-shield-hook").read_text()
+        installer.install()
+        assert (installer.target_dir / "terok-shield-hook").read_text() == first
+
+    def test_uninstall_removes_every_hook_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``uninstall`` clears what ``install`` wrote — symmetric cleanup."""
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "share"))
+        installer = HooksInstaller(target_dir=tmp_path / "hooks.d")
+        installer.install()
+        installer.uninstall()
+        for name in _INSTALLED_FILES:
+            assert not (installer.target_dir / name).exists()
+
+    def test_uninstall_tolerates_missing_files(self, tmp_path: Path) -> None:
+        """Uninstall against a never-installed target raises nothing — idempotent."""
+        HooksInstaller(target_dir=tmp_path / "never-installed").uninstall()
+
+    def test_is_installed_reflects_state(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The presence probe flips True after install, False after uninstall."""
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "share"))
+        installer = HooksInstaller(target_dir=tmp_path / "hooks.d")
+        assert not installer.is_installed()
+        installer.install()
+        assert installer.is_installed()
+        installer.uninstall()
+        assert not installer.is_installed()
+
+
+# ── Sudo escalation path ─────────────────────────────────
+
+
+class TestSudoEscalation:
+    """``use_sudo=True`` routes writes and removals through ``sudo``."""
+
+    def test_install_runs_sudo_subprocess_chain(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """sudo mkdir + sudo cp + sudo chmod fire in that order."""
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "share"))
+        target = tmp_path / "system-hooks"
+        installer = HooksInstaller(target_dir=target, use_sudo=True)
+        with mock.patch("terok_shield.hooks.install.subprocess.run") as run:
+            installer.install()
+        argv0s = [call.args[0][0] for call in run.call_args_list]
+        assert argv0s == ["sudo", "sudo", "sudo"]
+        verbs = [call.args[0][1] for call in run.call_args_list]
+        assert verbs == ["mkdir", "cp", "chmod"]
+
+    def test_uninstall_runs_sudo_rm(self, tmp_path: Path) -> None:
+        """Sudo uninstall fires a single ``sudo rm -f`` listing every hook file."""
+        target = tmp_path / "system-hooks"
+        installer = HooksInstaller(target_dir=target, use_sudo=True)
+        with mock.patch("terok_shield.hooks.install.subprocess.run") as run:
+            installer.uninstall()
+        [(call,)] = [(c,) for c in run.call_args_list]
+        argv = call.args[0]
+        assert argv[:3] == ["sudo", "rm", "-f"]
+        assert {Path(p).name for p in argv[3:]} == set(_INSTALLED_FILES)
+
+
+# ── containers.conf registration ─────────────────────────
+
+
+class TestRegisterHooksDir:
+    """Editing the user's containers.conf to list our hooks_dir."""
+
+    def test_creates_new_file(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Creates containers.conf when absent, parent dirs and all."""
+        conf_dir = tmp_path / "containers"
+        monkeypatch.setattr(
+            "terok_shield.hooks.install._user_containers_conf",
+            lambda: conf_dir / "containers.conf",
+        )
+        _register_hooks_dir_in_containers_conf(Path("/my/hooks"))
+        text = (conf_dir / "containers.conf").read_text()
+        assert 'hooks_dir = ["/my/hooks"]' in text
+        assert text.count("[engine]") == 1
+
+    def test_inserts_into_existing_engine_section(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Inserts hooks_dir into existing [engine] without duplicating the section."""
+        conf = tmp_path / "containers.conf"
+        conf.write_text('[engine]\nimage_copy_tmp_dir = "/data/tmp"\n')
+        monkeypatch.setattr(
+            "terok_shield.hooks.install._user_containers_conf",
+            lambda: conf,
+        )
+        _register_hooks_dir_in_containers_conf(Path("/my/hooks"))
+        text = conf.read_text()
+        assert text.count("[engine]") == 1
+        assert 'hooks_dir = ["/my/hooks"]' in text
+        assert 'image_copy_tmp_dir = "/data/tmp"' in text
+
+    def test_preserves_comments(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Comments in the file are preserved across the insert."""
+        conf = tmp_path / "containers.conf"
+        conf.write_text('# My config\n[engine]\n# temp dir\nimage_copy_tmp_dir = "/data"\n')
+        monkeypatch.setattr(
+            "terok_shield.hooks.install._user_containers_conf",
+            lambda: conf,
+        )
+        _register_hooks_dir_in_containers_conf(Path("/my/hooks"))
+        text = conf.read_text()
+        assert "# My config" in text
+        assert "# temp dir" in text
+
+    def test_ignores_engine_in_comment(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A literal ``[engine]`` inside a comment doesn't trigger the insert."""
+        conf = tmp_path / "containers.conf"
+        conf.write_text('# see [engine] docs\n[engine]\nfoo = "bar"\n')
+        monkeypatch.setattr(
+            "terok_shield.hooks.install._user_containers_conf",
+            lambda: conf,
+        )
+        _register_hooks_dir_in_containers_conf(Path("/my/hooks"))
+        text = conf.read_text()
+        assert text.count("[engine]") == 2  # one in comment, one real
+        assert text.count("hooks_dir") == 1
+
+    def test_skips_if_already_configured(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No-op when hooks_dir already points to the right path."""
+        conf = tmp_path / "containers.conf"
+        conf.write_text('[engine]\nhooks_dir = ["/my/hooks"]\n')
+        monkeypatch.setattr(
+            "terok_shield.hooks.install._user_containers_conf",
+            lambda: conf,
+        )
+        _register_hooks_dir_in_containers_conf(Path("/my/hooks"))
+        assert conf.read_text().count("hooks_dir") == 1
+
+    def test_appends_engine_when_no_section(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Appends [engine] when the file has other sections but no [engine]."""
+        conf = tmp_path / "containers.conf"
+        conf.write_text("[containers]\nlabel = false\n")
+        monkeypatch.setattr(
+            "terok_shield.hooks.install._user_containers_conf",
+            lambda: conf,
+        )
+        _register_hooks_dir_in_containers_conf(Path("/my/hooks"))
+        text = conf.read_text()
+        assert "[containers]" in text
+        assert "[engine]" in text
+        assert 'hooks_dir = ["/my/hooks"]' in text
+
+    def test_warns_when_different_hooks_dir_configured(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Warns (does not modify) when hooks_dir is already set differently."""
+        conf = tmp_path / "containers.conf"
+        conf.write_text('[engine]\nhooks_dir = ["/other/hooks"]\n')
+        monkeypatch.setattr(
+            "terok_shield.hooks.install._user_containers_conf",
+            lambda: conf,
+        )
+        _register_hooks_dir_in_containers_conf(Path("/my/hooks"))
+        assert "Warning" in capsys.readouterr().out
+        assert conf.read_text().count("hooks_dir") == 1  # unchanged
+
+
+# ── User-scope install registers in containers.conf ──────
+
+
+def test_user_install_registers_in_containers_conf(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``register_in_containers_conf=True`` patches containers.conf as part of install."""
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "share"))
+    conf = tmp_path / "containers.conf"
+    monkeypatch.setattr(
+        "terok_shield.hooks.install._user_containers_conf",
+        lambda: conf,
+    )
+    installer = HooksInstaller(target_dir=tmp_path / "hooks.d", register_in_containers_conf=True)
+    installer.install()
+    assert str(installer.target_dir) in conf.read_text()
+
+
+def test_non_user_install_skips_containers_conf(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``register_in_containers_conf=False`` leaves containers.conf untouched."""
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "share"))
+    conf = tmp_path / "containers.conf"
+    monkeypatch.setattr(
+        "terok_shield.hooks.install._user_containers_conf",
+        lambda: conf,
+    )
+    HooksInstaller(target_dir=tmp_path / "hooks.d").install()
+    assert not conf.exists()

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -147,6 +147,14 @@ class TestSudoEscalation:
         assert argv[:3] == ["sudo", "rm", "-f"]
         assert {Path(p).name for p in argv[3:]} == set(_INSTALLED_FILES)
 
+    def test_remove_via_sudo_empty_list_short_circuits(self) -> None:
+        """Empty paths list returns without shelling out — defensive guard."""
+        from terok_shield.hooks.install import _remove_via_sudo
+
+        with mock.patch("terok_shield.hooks.install.subprocess.run") as run:
+            _remove_via_sudo([])
+        run.assert_not_called()
+
 
 # ── containers.conf registration ─────────────────────────
 

--- a/tests/unit/test_podman_info.py
+++ b/tests/unit/test_podman_info.py
@@ -13,7 +13,6 @@ from terok_shield.podman_info import (
     _parse_hooks_dir_from_conf,
     _parse_network_cmd_options,
     _parse_version,
-    ensure_containers_conf_hooks_dir,
     find_hooks_dirs,
     global_hooks_hint,
     has_global_hooks,
@@ -290,94 +289,6 @@ class TestHasGlobalHooks:
     def test_empty_dirs_list(self) -> None:
         """Returns False with no dirs to check."""
         assert not has_global_hooks([])
-
-
-# ── ensure_containers_conf_hooks_dir tests ───────────────
-
-
-class TestEnsureContainersConf:
-    """Tests for containers.conf modification."""
-
-    def test_creates_new_file(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Creates containers.conf when absent."""
-        conf_dir = tmp_path / "containers"
-        monkeypatch.setattr(
-            "terok_shield.podman_info._user_containers_conf",
-            lambda: conf_dir / "containers.conf",
-        )
-        ensure_containers_conf_hooks_dir(Path("/my/hooks"))
-        text = (conf_dir / "containers.conf").read_text()
-        assert 'hooks_dir = ["/my/hooks"]' in text
-        assert text.count("[engine]") == 1
-
-    def test_inserts_into_existing_engine_section(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """Inserts hooks_dir into existing [engine] without duplicating the section."""
-        conf = tmp_path / "containers.conf"
-        conf.write_text('[engine]\nimage_copy_tmp_dir = "/data/tmp"\n')
-        monkeypatch.setattr("terok_shield.podman_info._user_containers_conf", lambda: conf)
-        ensure_containers_conf_hooks_dir(Path("/my/hooks"))
-        text = conf.read_text()
-        assert text.count("[engine]") == 1
-        assert 'hooks_dir = ["/my/hooks"]' in text
-        assert 'image_copy_tmp_dir = "/data/tmp"' in text
-
-    def test_preserves_comments(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Comments in the file are preserved."""
-        conf = tmp_path / "containers.conf"
-        conf.write_text('# My config\n[engine]\n# temp dir\nimage_copy_tmp_dir = "/data"\n')
-        monkeypatch.setattr("terok_shield.podman_info._user_containers_conf", lambda: conf)
-        ensure_containers_conf_hooks_dir(Path("/my/hooks"))
-        text = conf.read_text()
-        assert "# My config" in text
-        assert "# temp dir" in text
-
-    def test_ignores_engine_in_comment(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """Does not match [engine] inside a comment."""
-        conf = tmp_path / "containers.conf"
-        conf.write_text('# see [engine] docs\n[engine]\nfoo = "bar"\n')
-        monkeypatch.setattr("terok_shield.podman_info._user_containers_conf", lambda: conf)
-        ensure_containers_conf_hooks_dir(Path("/my/hooks"))
-        text = conf.read_text()
-        assert text.count("[engine]") == 2  # one in comment, one real
-        assert text.count("hooks_dir") == 1
-
-    def test_skips_if_already_configured(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """No-op when hooks_dir already points to the right path."""
-        conf = tmp_path / "containers.conf"
-        conf.write_text('[engine]\nhooks_dir = ["/my/hooks"]\n')
-        monkeypatch.setattr("terok_shield.podman_info._user_containers_conf", lambda: conf)
-        ensure_containers_conf_hooks_dir(Path("/my/hooks"))
-        assert conf.read_text().count("hooks_dir") == 1
-
-    def test_appends_engine_when_no_section(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """Appends [engine] section when file exists but has no [engine]."""
-        conf = tmp_path / "containers.conf"
-        conf.write_text("[containers]\nlabel = false\n")
-        monkeypatch.setattr("terok_shield.podman_info._user_containers_conf", lambda: conf)
-        ensure_containers_conf_hooks_dir(Path("/my/hooks"))
-        text = conf.read_text()
-        assert "[containers]" in text
-        assert "[engine]" in text
-        assert 'hooks_dir = ["/my/hooks"]' in text
-
-    def test_warns_when_different_hooks_dir_configured(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
-    ) -> None:
-        """Warns and does not modify when hooks_dir is already set differently."""
-        conf = tmp_path / "containers.conf"
-        conf.write_text('[engine]\nhooks_dir = ["/other/hooks"]\n')
-        monkeypatch.setattr("terok_shield.podman_info._user_containers_conf", lambda: conf)
-        ensure_containers_conf_hooks_dir(Path("/my/hooks"))
-        assert "Warning" in capsys.readouterr().out
-        assert conf.read_text().count("hooks_dir") == 1  # unchanged
 
 
 # ── _parse_version edge cases ────────────────────────────

--- a/tests/unit/test_reader_install.py
+++ b/tests/unit/test_reader_install.py
@@ -11,8 +11,8 @@ is the one place that does that copy.
 
 Bridge-hook JSON generation is no longer a separate API surface — the
 two role scripts (nft + reader) are written together by
-``setup_global_hooks``; integration coverage for that lives in
-``test_hook_mode_class.py``.
+[`HooksInstaller`][terok_shield.hooks.install.HooksInstaller]; integration
+coverage for that lives in ``test_hook_mode_class.py``.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

W5.D collapses three loose verb-form helpers (`setup_global_hooks`, `ensure_containers_conf_hooks_dir`, `system_hooks_dir`) onto a `HooksInstaller` dataclass that owns the persistent-hooks lifecycle.

Factory classmethods bind the two scopes:

| Factory | Target dir | use_sudo | register_in_containers_conf |
|---|---|---|---|
| `HooksInstaller.system()` | `/etc/containers/oci/hooks.d` (or existing equivalent) | True | False |
| `HooksInstaller.user()`   | `~/.local/share/containers/oci/hooks.d` | False | True |

The class also gains an `uninstall` symmetric to `install` — previously the sandbox adapter carried that lifecycle with its own hard-coded `_HOOK_FILES` tuple that mirrored the shield-side install layout. Shield now owns the file-name vocabulary; the sandbox-side duplicate is removed in the W5.B companion PR.

## Architectural cleanup

- **Single ownership** of the install-file list (`_INSTALLED_FILES`) drives both `install` and `uninstall` — symmetric cleanup never drifts from the install layout.
- **`containers.conf` editing** moves from `podman_info.py` into `hooks/install.py` as a single private patcher (`_register_hooks_dir_in_containers_conf`) used only by user-scope installs. `podman_info.py` keeps its more general state-query surface (`find_hooks_dirs`, `has_global_hooks`, `system_hooks_dir`, `global_hooks_hint`) which feed `Shield.check_environment` and stay independent of install lifecycle.
- **Symmetric `is_installed()` probe** for callers that want to query state without performing an install.

## API surface

`__all__` shrinks 20 → 18 entries:

- removed: `setup_global_hooks`, `ensure_containers_conf_hooks_dir`, `system_hooks_dir`
- added: `HooksInstaller`

## Test plan

- [x] `make check` — ruff lint, ruff format, tach, bandit, docstr-coverage (100%), vulture, reuse — all clean
- [x] `poetry run pytest tests/unit` — 1198 passed
- [x] `poetry run properdocs build --strict` — clean
- [x] New `tests/unit/test_install.py` covers HooksInstaller factories, install/uninstall lifecycle (incl. idempotence), sudo escalation, and the containers.conf patcher

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Setup command now clearly indicates user vs elevated (sudo) installs and reports installation status.

* **Refactor**
  * Hook installation reworked into a single installer abstraction covering user/system flows, with unified install/uninstall semantics.

* **Bug Fixes**
  * Install/uninstall made idempotent; registration of hook directory in containers.conf handled more robustly (creation, insertion, and duplicate detection).

* **Tests**
  * Unit and integration tests updated and expanded to cover installer behavior and containers.conf editing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok-shield/pull/333?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->