### PR TITLE
feat: per-container shield state; single user-owned install layout

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2162,17 +2162,18 @@ description = "Shared utility library for the terok-* sibling packages"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = [
-    {file = "terok_util-0.0.2a1-py3-none-any.whl", hash = "sha256:00506d9720bba29755fc01bf91a0a63999a92373750545acd4b459d6290502b7"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 platformdirs = ">=4.9.6"
 "ruamel.yaml" = ">=0.18"
 
 [package.source]
-type = "url"
-url = "https://github.com/terok-ai/terok-util/releases/download/v0.0.2a1/terok_util-0.0.2a1-py3-none-any.whl"
+type = "git"
+url = "https://github.com/sliwowitz/terok-util.git"
+reference = "feat/per-container-supervisor"
+resolved_reference = "19a1927c73a26fa3c9a5aa85928b8ff89f696ce5"
 
 [[package]]
 name = "tomli"
@@ -2428,4 +2429,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "5d1d66169d3716bd81ab2c0b47da9e37fda856ca7b0ad96d769c773d338ccb52"
+content-hash = "1096d8debeed9d38d2379cb7a4c282c27d6e6711d798cf1656e70cd1671bdad6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dynamic = ["version", "classifiers"]
 dependencies = [
     "PyYAML>=6.0",
     "pydantic>=2.0",
-    "terok-util @ https://github.com/terok-ai/terok-util/releases/download/v0.0.2a1/terok_util-0.0.2a1-py3-none-any.whl",
+    "terok-util @ git+https://github.com/sliwowitz/terok-util.git@feat/per-container-supervisor",
 ]
 
 [project.urls]

--- a/src/terok_shield/__init__.py
+++ b/src/terok_shield/__init__.py
@@ -37,12 +37,10 @@ from .config import (
 )
 from .paths import HOOK_ENTRYPOINT_NAME
 from .podman_info import (
-    USER_HOOKS_DIR,
     find_hooks_dirs,
     global_hooks_hint,
     has_global_hooks,
     parse_podman_info,
-    system_hooks_dir,
 )
 from .state import StateBundle
 from .util import is_ip as _is_ip
@@ -67,6 +65,10 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "BinaryCheck": ("terok_shield.prereqs", "BinaryCheck"),
     "ExecError": ("terok_shield.run", "ExecError"),
     "HooksInstaller": ("terok_shield.hooks.install", "HooksInstaller"),
+    "ensure_user_hooks_dir_configured": (
+        "terok_shield.hooks.install",
+        "ensure_user_hooks_dir_configured",
+    ),
     "NftNotFoundError": ("terok_shield.run", "NftNotFoundError"),
     "ShieldNeedsSetup": ("terok_shield.run", "ShieldNeedsSetup"),
     "check_firewall_binaries": ("terok_shield.prereqs", "check_firewall_binaries"),
@@ -132,24 +134,36 @@ class EnvironmentCheck:
 def _read_installed_hook_version(hooks_dirs: list[Path]) -> int | None:
     """Read ``BUNDLE_VERSION`` from the installed ballast module, or ``None``.
 
-    The hooks directory contains the shared ``_oci_state.py`` ballast
-    that both role scripts import from at runtime.  ``BUNDLE_VERSION``
-    lives there as the canonical definition; reading it from a role
-    script would only see a re-import.  Returns ``None`` if the
-    ballast file is absent or unparseable.
+    The ballast (``_oci_state.py``) lives *next to* the role script, not
+    in *hooks_dirs* — for system-scope installs those happen to be the
+    same directory, but a user-scope install splits them: descriptors
+    land in *hooks_dirs* (the podman scan path), scripts and ballast
+    land under ``namespace_state_dir("shield") / "hooks"``.  The
+    installed JSON descriptor's ``path`` is the load-bearing reference
+    to the role script, so the ballast lives in its parent directory.
     """
+    import json
     import re
+
+    from .podman_info.hooks_dir import HOOK_JSON_FILENAME
 
     pattern = re.compile(r"^BUNDLE_VERSION\s*=\s*(\d+)", re.MULTILINE)
     for d in hooks_dirs:
-        ballast = d / "_oci_state.py"
-        if ballast.is_file():
-            try:
+        descriptor = d / HOOK_JSON_FILENAME
+        if not descriptor.is_file():
+            continue
+        try:
+            data = json.loads(descriptor.read_text())
+            argv = data.get("hook", {}).get("path")
+            if not isinstance(argv, str):
+                continue
+            ballast = Path(argv).parent / "_oci_state.py"
+            if ballast.is_file():
                 m = pattern.search(ballast.read_text())
                 if m:
                     return int(m.group(1))
-            except (OSError, ValueError):
-                pass
+        except (OSError, ValueError, json.JSONDecodeError):
+            continue
     return None
 
 
@@ -187,8 +201,12 @@ class Shield:
             ruleset: Ruleset builder (default: from config loopback_ports).
             hub_events: Best-effort emitter for ``shield_up`` / ``shield_down``
                 events bound for the terok-clearance hub (default: a fresh
-                [`HubEventEmitter`][terok_shield.HubEventEmitter] pointed at the canonical socket).
-                Pass a no-op stub in tests that should not touch the socket.
+                [`HubEventEmitter`][terok_shield.HubEventEmitter]).  The
+                emitter routes each event to the supervisor's
+                per-container socket using the ``container_id`` supplied
+                on every [`up`][terok_shield.Shield.up] /
+                [`down`][terok_shield.Shield.down] call.  Pass a no-op
+                stub in tests that should not touch the socket.
         """
         from ._hub_events import HubEventEmitter
         from .audit import AuditLogger
@@ -263,8 +281,7 @@ class Shield:
 
         if not info.hooks_dir_persists:
             if global_hooks:
-                sys_dir = system_hooks_dir()
-                hooks = "global-system" if has_global_hooks([sys_dir]) else "global-user"
+                hooks = "global"
                 health = "ok"
                 # Check hook version matches current package
                 hook_ver = _read_installed_hook_version(hooks_dirs)
@@ -360,26 +377,42 @@ class Shield:
         """Return current nft rules for a container."""
         return self._mode.list_rules(container)
 
-    def down(self, container: str, *, allow_all: bool = False) -> None:
-        """Switch a running container to bypass mode."""
+    def down(self, container: str, container_id: str, *, allow_all: bool = False) -> None:
+        """Switch a running container to bypass mode.
+
+        *container* is the operator-facing podman name (audit log key);
+        *container_id* is the full podman UUID — the routing key for
+        the per-container hub socket the supervisor listens on.  The
+        caller knows both at every emit site, so neither carries a
+        default.
+        """
         self._mode.shield_down(container, allow_all=allow_all)
         self.audit.log_event(
             container,
             "shield_down",
             detail="allow_all=True" if allow_all else None,
         )
-        self.hub_events.shield_down(container, allow_all=allow_all, dossier=self._read_dossier())
+        self.hub_events.shield_down(
+            container,
+            container_id,
+            allow_all=allow_all,
+            dossier=self._read_dossier(),
+        )
 
     def quarantine(self, container: str) -> None:
         """Total network blackout — drop all traffic, log dropped traffic."""
         self._mode.shield_quarantine(container)
         self.audit.log_event(container, "shield_quarantine")
 
-    def up(self, container: str) -> None:
-        """Restore normal deny-all mode for a running container."""
+    def up(self, container: str, container_id: str) -> None:
+        """Restore normal deny-all mode for a running container.
+
+        *container* / *container_id* — see
+        [`down`][terok_shield.Shield.down].
+        """
         self._mode.shield_up(container)
         self.audit.log_event(container, "shield_up")
-        self.hub_events.shield_up(container, dossier=self._read_dossier())
+        self.hub_events.shield_up(container, container_id, dossier=self._read_dossier())
 
     def _read_dossier(self) -> dict[str, str]:
         """Resolve the wire dossier for this container by reading the orchestrator's task meta.
@@ -454,7 +487,7 @@ __all__ = [
     "ShieldNeedsSetup",
     "ShieldRuntime",
     "ShieldState",
-    "USER_HOOKS_DIR",
     "check_firewall_binaries",
     "check_krun_binaries",
+    "ensure_user_hooks_dir_configured",
 ]

--- a/src/terok_shield/_hub_events.py
+++ b/src/terok_shield/_hub_events.py
@@ -9,6 +9,12 @@ block notifications for a container whose shield just dropped.  Stays
 stdlib-only so the reader script resource (which bypasses the package)
 can mirror the same wire format without importing this module.
 
+Every emit targets the *per-container* hub socket under
+``$XDG_RUNTIME_DIR/terok/clearance/<container_id>.sock`` — the same
+addressing the NFLOG reader uses.  Callers therefore supply
+``container_id`` (the full podman container UUID) on every call;
+there is no host-wide fallback socket.
+
 Fails silent when the hub isn't listening: flipping shield state must
 never be held up by a desktop-side daemon being absent.
 """
@@ -26,34 +32,46 @@ from terok_shield._wire_sanitize import sanitize, sanitize_mapping
 
 _log = logging.getLogger(__name__)
 
-_SOCKET_BASENAME = "terok-shield-events.sock"
 #: Cap on the socket connect/send syscalls so a dead but unreaped hub
 #: (listener exists, accept thread wedged) can't block the shield CLI
 #: for longer than the operator will patiently hold the keyboard.
 _IO_TIMEOUT_S = 0.5
 
 
-def hub_socket_path() -> Path:
-    """Return the canonical hub ingester path under ``$XDG_RUNTIME_DIR``."""
+def _per_container_hub_socket(container_id: str) -> Path:
+    """Return the per-container hub-ingester path under ``$XDG_RUNTIME_DIR``.
+
+    Mirrors the NFLOG reader's path scheme (12-char short ID) so every
+    event for one container converges on the same supervisor-owned
+    socket — without the truncation match, ``shield_up``/``shield_down``
+    events and ``pending`` events for the same container land on
+    different sockets.
+    """
     xdg = os.environ.get("XDG_RUNTIME_DIR") or f"/run/user/{os.getuid()}"
-    return Path(xdg) / _SOCKET_BASENAME
+    return Path(xdg) / "terok" / "clearance" / f"{container_id[:12]}.sock"
 
 
 class HubEventEmitter:
     """One-shot writer of JSON-line events to the hub's unix ingester.
 
-    Each ``emit_*`` call opens a fresh connection, sends a single line,
-    and closes.  The hub stays up across many CLI invocations while each
-    CLI invocation is short-lived — pooling would save nothing and would
-    complicate the fail-silent semantics.
+    Each ``emit_*`` call opens a fresh connection to the per-container
+    socket, sends a single line, and closes.  The hub stays up across
+    many CLI invocations while each CLI invocation is short-lived —
+    pooling would save nothing and would complicate the fail-silent
+    semantics.
     """
 
-    def __init__(self, socket_path: Path | None = None) -> None:
-        """Remember the target socket; defaults to `hub_socket_path`."""
-        self._path = socket_path or hub_socket_path()
-
-    def shield_up(self, container: str, *, dossier: dict[str, str] | None = None) -> None:
+    def shield_up(
+        self,
+        container: str,
+        container_id: str,
+        *,
+        dossier: dict[str, str] | None = None,
+    ) -> None:
         """Emit a ``shield_up`` event for *container* (optional *dossier*).
+
+        *container_id* — full podman container UUID; routes the event
+        to the supervisor's per-container hub socket.
 
         *dossier* mirrors the orchestrator-supplied identity bundle the
         per-container reader already attaches to ``connection_blocked``
@@ -62,24 +80,38 @@ class HubEventEmitter:
         (``project/task · name`` rather than the bare container slug).
         Empty / omitted dossier omits the key entirely.
         """
-        self._send({"type": "shield_up", "container": container}, dossier)
+        self._send(container_id, {"type": "shield_up", "container": container}, dossier)
 
     def shield_down(
         self,
         container: str,
+        container_id: str,
         *,
         allow_all: bool = False,
         dossier: dict[str, str] | None = None,
     ) -> None:
         """Emit a ``shield_down`` (or ``shield_disengaged``) event for *container*.
 
-        *dossier* — see [`shield_up`][terok_shield._hub_events.HubEventEmitter.shield_up].
+        *container_id* — see
+        [`shield_up`][terok_shield._hub_events.HubEventEmitter.shield_up].
+
+        *dossier* — see
+        [`shield_up`][terok_shield._hub_events.HubEventEmitter.shield_up].
         """
         event_type = "shield_disengaged" if allow_all else "shield_down"
-        self._send({"type": event_type, "container": container}, dossier)
+        self._send(container_id, {"type": event_type, "container": container}, dossier)
 
-    def _send(self, payload: dict, dossier: dict[str, str] | None = None) -> None:
-        """Write one JSON line to the hub socket, swallowing all I/O errors.
+    def _send(
+        self,
+        container_id: str,
+        payload: dict,
+        dossier: dict[str, str] | None = None,
+    ) -> None:
+        """Write one JSON line to the per-container hub socket, swallowing all I/O errors.
+
+        *container_id* selects the destination socket
+        (``$XDG_RUNTIME_DIR/terok/clearance/<container_id>.sock``); the
+        caller — the shield CLI — knows the full UUID at every emit site.
 
         *dossier* is folded into the payload only when non-empty —
         keeps the wire flat for standalone containers (``podman run``
@@ -98,11 +130,12 @@ class HubEventEmitter:
         if dossier:
             sanitised["dossier"] = sanitize_mapping(dossier)
         line = (json.dumps(sanitised, separators=(",", ":")) + "\n").encode()
+        path = _per_container_hub_socket(container_id)
         try:
             sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
             sock.settimeout(_IO_TIMEOUT_S)
             with contextlib.closing(sock):
-                sock.connect(str(self._path))
+                sock.connect(str(path))
                 sock.sendall(line)
         except OSError as exc:
             # Hub absent, socket path stale, peer buffer full — none of

--- a/src/terok_shield/cli/main.py
+++ b/src/terok_shield/cli/main.py
@@ -80,7 +80,7 @@ def _dispatch(args: argparse.Namespace) -> None:
 
     # CLI-only: setup doesn't need Shield
     if cmd_name == "setup":
-        _cmd_setup(root=getattr(args, "root", False), user=getattr(args, "user", False))
+        _cmd_setup()
         return
 
     # CLI-only: logs with aggregated mode (no container -> scan all)
@@ -220,6 +220,11 @@ def _add_argdef(parser: argparse.ArgumentParser, arg: ArgDef) -> None:
         kwargs["dest"] = arg.dest
     if arg.nargs is not None:
         kwargs["nargs"] = arg.nargs
+    # argparse only accepts ``required`` on optional (``--``) arguments —
+    # positionals are required by definition.  Guard so the registry can
+    # mark optional flags like ``--container-id`` as mandatory.
+    if arg.required and arg.name.startswith("-"):
+        kwargs["required"] = True
     parser.add_argument(arg.name, **kwargs)
 
 
@@ -362,34 +367,12 @@ def _collect_all_audit_entries(state_root: Path, n: int) -> list[dict]:
     return entries[-n:]
 
 
-def _cmd_setup(*, root: bool, user: bool) -> None:
+def _cmd_setup() -> None:
     """Install global OCI hooks for podman < 5.6.0 restart persistence."""
     from ..hooks.install import HooksInstaller
-    from ..podman_info._conf import _user_containers_conf
 
-    if root and user:
-        raise ValueError("--root and --user are mutually exclusive")
-
-    if not root and not user:
-        # Interactive: present options.
-        system, user_installer = HooksInstaller.system(), HooksInstaller.user()
-        print("terok-shield setup: install global OCI hooks\n")
-        print(f"  [r] System-wide (sudo) -> {system.target_dir}")
-        print(f"  [u] User-local         -> {user_installer.target_dir}")
-        print(f"      (+ update {_user_containers_conf()})")
-        print()
-        choice = input("Choose [r/u]: ").strip().lower()
-        if choice == "r":
-            root = True
-        elif choice == "u":
-            user = True
-        else:
-            print("Cancelled.")
-            return
-
-    installer = HooksInstaller.system() if root else HooksInstaller.user()
-    scope = "sudo" if installer.use_sudo else "user"
-    print(f"Installing hooks to {installer.target_dir} ({scope})...")
+    installer = HooksInstaller()
+    print(f"Installing hooks to {installer.target_dir}...")
     installer.install()
     print("Done. Global hooks installed.")
 
@@ -425,7 +408,6 @@ def _build_config(
         state_dir=state_dir,
         mode=mode,
         default_profiles=tuple(file_cfg.default_profiles),
-        loopback_ports=tuple(file_cfg.loopback_ports),
         audit_enabled=file_cfg.audit.enabled,
         profiles_dir=profiles_dir,
     )

--- a/src/terok_shield/commands.py
+++ b/src/terok_shield/commands.py
@@ -106,16 +106,31 @@ def _handle_deny(shield: Shield, container: str, *, target: str) -> None:
         raise RuntimeError(f"No IPs denied for {container}")
 
 
-def _handle_down(shield: Shield, container: str, *, allow_all: bool = False) -> None:
-    """Switch container to bypass mode."""
-    shield.down(container, allow_all=allow_all)
+def _handle_down(
+    shield: Shield,
+    container: str,
+    *,
+    container_id: str,
+    allow_all: bool = False,
+) -> None:
+    """Switch container to bypass mode.
+
+    *container_id* — full podman UUID; supplied by the orchestrator at
+    the call site, used to route the hub event to the supervisor's
+    per-container socket.  Required, no default.
+    """
+    shield.down(container, container_id, allow_all=allow_all)
     label = " (all traffic)" if allow_all else ""
     print(f"Shield down for {container}{label}")
 
 
-def _handle_up(shield: Shield, container: str) -> None:
-    """Restore deny-all mode."""
-    shield.up(container)
+def _handle_up(shield: Shield, container: str, *, container_id: str) -> None:
+    """Restore deny-all mode.
+
+    *container_id* — see
+    [`_handle_down`][terok_shield.commands._handle_down].
+    """
+    shield.up(container, container_id)
     print(f"Shield up for {container}")
 
 
@@ -206,6 +221,17 @@ _STANDALONE: dict[str, Any] = {"standalone_only": True}
 _NEEDS_CTR_STANDALONE: dict[str, Any] = {"needs_container": True, "standalone_only": True}
 
 
+# ``--container-id`` is the per-container hub socket routing key
+# (full podman UUID).  Every emit-bearing verb (``up`` / ``down``)
+# accepts it as a required option — the caller (terok-sandbox) knows
+# the full UUID at every site that runs ``terok-shield <verb>``.
+_CONTAINER_ID_ARG = ArgDef(
+    name="--container-id",
+    required=True,
+    help="Full podman container UUID — routes hub events to the per-container supervisor socket",
+)
+
+
 # ── Command definitions ───────────────────────────────────
 
 COMMANDS: tuple[CommandDef, ...] = (
@@ -272,6 +298,7 @@ COMMANDS: tuple[CommandDef, ...] = (
         handler=_handle_down,
         extras=_NEEDS_CTR,
         args=(
+            _CONTAINER_ID_ARG,
             ArgDef(
                 name="--all",
                 action="store_true",
@@ -285,6 +312,7 @@ COMMANDS: tuple[CommandDef, ...] = (
         help="Restore deny-all mode for a container",
         handler=_handle_up,
         extras=_NEEDS_CTR,
+        args=(_CONTAINER_ID_ARG,),
     ),
     CommandDef(
         name="quarantine",
@@ -329,10 +357,6 @@ COMMANDS: tuple[CommandDef, ...] = (
         name="setup",
         help="Install global OCI hooks for restart persistence",
         extras=_STANDALONE,
-        args=(
-            ArgDef(name="--root", action="store_true", help="Install system-wide (uses sudo)"),
-            ArgDef(name="--user", action="store_true", help="Install to user directory"),
-        ),
     ),
     CommandDef(
         name="check-environment",

--- a/src/terok_shield/config.py
+++ b/src/terok_shield/config.py
@@ -20,7 +20,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 # ── OCI annotation keys ─────────────────────────────────
 
-# Delimiter for list-valued annotations (profiles, loopback_ports).
+# Delimiter for list-valued annotations (profiles).
 # Podman ≤4.9.x registers --annotation as StringSliceVar (pflag), which
 # splits values on commas.  Fixed in 5.0.0 (containers/podman#20945).
 # Colons are safe across all versions.
@@ -29,7 +29,6 @@ ANNOTATION_LIST_SEP = ":"
 ANNOTATION_KEY = "terok.shield.profiles"
 ANNOTATION_NAME_KEY = "terok.shield.name"
 ANNOTATION_STATE_DIR_KEY = "terok.shield.state_dir"
-ANNOTATION_LOOPBACK_PORTS_KEY = "terok.shield.loopback_ports"
 ANNOTATION_VERSION_KEY = "terok.shield.version"
 ANNOTATION_AUDIT_ENABLED_KEY = "terok.shield.audit_enabled"
 ANNOTATION_UPSTREAM_DNS_KEY = "terok.shield.upstream_dns"
@@ -184,10 +183,6 @@ class ShieldFileConfig(BaseModel):
         default_factory=lambda: ["dev-standard"],
         description="Profiles applied when no explicit list is given",
     )
-    loopback_ports: list[int] = Field(
-        default_factory=list,
-        description="TCP ports forwarded to host loopback (via pasta ``-T``)",
-    )
     audit: AuditFileConfig = Field(
         default_factory=AuditFileConfig, description="Audit logging settings"
     )
@@ -200,23 +195,6 @@ class ShieldFileConfig(BaseModel):
         if not v or not all(isinstance(p, str) and p for p in v):
             raise ValueError("each profile must be a non-empty string")
         return v
-
-    @field_validator("loopback_ports", mode="before")
-    @classmethod
-    def _ports_validated(cls, v: object) -> list[int]:
-        """Validate port entries: reject bools, enforce 1-65535 range."""
-        if isinstance(v, int) and not isinstance(v, bool):
-            v = [v]
-        if not isinstance(v, list):
-            raise ValueError(f"expected list of ints, got {type(v).__name__}")
-        ports: list[int] = []
-        for item in v:
-            if isinstance(item, bool) or not isinstance(item, int):
-                raise ValueError(f"expected integer port, got {type(item).__name__}: {item!r}")
-            if not (1 <= item <= 65535):
-                raise ValueError(f"port {item} out of range 1–65535")
-            ports.append(item)
-        return ports
 
 
 # ── ShieldModeBackend protocol ──────────────────────────

--- a/src/terok_shield/hooks/install.py
+++ b/src/terok_shield/hooks/install.py
@@ -8,10 +8,16 @@ Writes two role-specific entrypoint scripts (``nft-hook`` and
 target hooks directory, alongside the JSON descriptors that tell
 podman to invoke each one at ``createRuntime`` and ``poststop``.
 
+Single layout: scripts and descriptors both land in
+``namespace_state_dir("shield") / "hooks"`` under the operator's
+``paths.root``.  ``containers.conf`` is patched so podman scans that
+path.  Each sibling package owns its own subtree under ``paths.root``
+the same way (see ``terok_sandbox.supervisor.install``).
+
 Public entry points:
 
 - [`HooksInstaller`][terok_shield.hooks.install.HooksInstaller] — global
-  installation lifecycle (install + uninstall) at system or user scope.
+  installation lifecycle (install + uninstall).
 - [`install_hooks`][terok_shield.hooks.install.install_hooks] — per-container
   install used by ``HookMode.pre_start``.
 
@@ -22,18 +28,12 @@ Pure file I/O — no runtime container interaction.
 from __future__ import annotations
 
 import json
-import subprocess  # nosec B404 — sudo escalation for system-wide installs
-import tempfile
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 from ..config import ANNOTATION_KEY
 from ..podman_info._conf import _user_containers_conf
-from ..podman_info.hooks_dir import (
-    USER_HOOKS_DIR,
-    _parse_hooks_dir_from_conf,
-    system_hooks_dir,
-)
+from ..podman_info.hooks_dir import _parse_hooks_dir_from_conf
 from .reader_install import install_reader_resource
 
 #: File name for the shared OCI-state ballast module.  Both role
@@ -66,16 +66,25 @@ def _bridge_hook_json(stage: str) -> str:
     return f"terok-shield-bridge-{stage}.json"
 
 
-#: Every file ``HooksInstaller.install`` writes to ``target_dir``.
-#: Drives ``uninstall`` so the symmetric cleanup never drifts from
-#: the install layout.
-_INSTALLED_FILES: tuple[str, ...] = (
+#: Files ``HooksInstaller.install`` writes to ``target_dir`` — both
+#: the role scripts + ballast and the JSON descriptors podman scans.
+_SCRIPT_FILES: tuple[str, ...] = (
     _BALLAST_NAME,
     _NFT_ENTRYPOINT_NAME,
     _READER_ENTRYPOINT_NAME,
+)
+
+_DESCRIPTOR_FILES: tuple[str, ...] = (
     *(_nft_hook_json(stage) for stage in _HOOK_STAGES),
     *(_bridge_hook_json(stage) for stage in _HOOK_STAGES),
 )
+
+
+def _default_target_dir() -> Path:
+    """Canonical hooks dir under ``paths.root``: ``<state_root>/shield/hooks``."""
+    from ..paths import namespace_state_dir
+
+    return namespace_state_dir("shield") / "hooks"
 
 
 # ── Global installer ────────────────────────────────────
@@ -89,99 +98,58 @@ class HooksInstaller:
     restarts: podman ≥ 5.x drops per-container ``--hooks-dir`` on
     stop/start (containers/podman#17935), so global hooks are the
     only reliable activation path until that upstream regression is
-    fixed.  Two scopes, exposed as classmethod factories:
+    fixed.
 
-    - [`HooksInstaller.system`][terok_shield.hooks.install.HooksInstaller.system] —
-      `/etc/containers/oci/hooks.d` (or the existing equivalent);
-      escalates writes through ``sudo``, visible to root and every user.
-    - [`HooksInstaller.user`][terok_shield.hooks.install.HooksInstaller.user] —
-      `~/.local/share/containers/oci/hooks.d`; rootless, also patches
-      ``hooks_dir`` into the user's ``containers.conf`` so podman
-      discovers it.
+    Scripts, ballast, and JSON descriptors all land in *target_dir*
+    (default: ``namespace_state_dir("shield") / "hooks"``).
+    ``containers.conf`` is patched to register that path so podman
+    discovers the descriptors on the next container start.
 
-    The lifecycle is symmetric: [`install`][terok_shield.hooks.install.HooksInstaller.install]
+    Symmetric lifecycle: [`install`][terok_shield.hooks.install.HooksInstaller.install]
     writes, [`uninstall`][terok_shield.hooks.install.HooksInstaller.uninstall]
     removes.  Both are idempotent.
     """
 
-    target_dir: Path
-    """Directory the hook files (entrypoints, ballast, JSON descriptors) live in."""
+    target_dir: Path = field(default_factory=_default_target_dir)
+    """Directory the hook scripts, ballast, and JSON descriptors all live in."""
 
-    use_sudo: bool = False
-    """Escalate file writes and removals through ``sudo`` (system scope)."""
+    @property
+    def script_dir(self) -> Path:
+        """Alias kept for older callers that destructured the two-dir API."""
+        return self.target_dir
 
-    register_in_containers_conf: bool = False
-    """Patch ``hooks_dir`` into the user's ``containers.conf`` on install.
-
-    Only meaningful for the user scope — system hooks dirs are
-    discovered by podman without registration.
-    """
-
-    @classmethod
-    def system(cls) -> HooksInstaller:
-        """Installer for the canonical system hooks directory (sudo-escalated).
-
-        Targets the best-existing of ``/etc/containers/oci/hooks.d``
-        and ``/usr/share/containers/oci/hooks.d`` — see
-        [`system_hooks_dir`][terok_shield.podman_info.hooks_dir.system_hooks_dir]
-        for the resolution rule.
-        """
-        return cls(target_dir=system_hooks_dir(), use_sudo=True)
-
-    @classmethod
-    def user(cls) -> HooksInstaller:
-        """Installer for the rootless per-user hooks directory.
-
-        Writes to ``~/.local/share/containers/oci/hooks.d`` and
-        registers that directory in the user's ``containers.conf`` so
-        podman scans it on the next container start.
-        """
-        return cls(
-            target_dir=USER_HOOKS_DIR.expanduser(),
-            use_sudo=False,
-            register_in_containers_conf=True,
-        )
+    @property
+    def hooks_dir(self) -> Path:
+        """Alias kept for older callers that destructured the two-dir API."""
+        return self.target_dir
 
     def install(self) -> None:
-        """Write entrypoints, ballast, and JSON descriptors into ``target_dir``.
+        """Write entrypoints, ballast, and descriptors to ``target_dir``.
 
         Both hook pairs (nft + reader) and the shared ballast are
         written unconditionally — the reader hook soft-fails on
         missing clearance, so installing it on a shield-only host
         costs nothing and removes a configuration knob.  The
         standalone NFLOG reader resource is copied to its canonical
-        per-user path regardless of scope.
+        per-user path.
 
-        For [`HooksInstaller.user`][terok_shield.hooks.install.HooksInstaller.user]
-        installs (``register_in_containers_conf=True``), also patches
-        ``hooks_dir`` into the user's ``containers.conf``.
+        ``containers.conf`` is patched to list ``target_dir`` in
+        ``hooks_dir`` so podman discovers the descriptors.
         """
-        # Reader resource is per-user, never under target_dir; install it
-        # before the hook JSONs so the path the JSONs reference is already
-        # populated when the first container fires.
         install_reader_resource()
-        if self.use_sudo:
-            _install_via_sudo(self.target_dir)
-        else:
-            self.target_dir.mkdir(parents=True, exist_ok=True)
-            _write_role_files(self.target_dir, self.target_dir)
-        if self.register_in_containers_conf:
-            _register_hooks_dir_in_containers_conf(self.target_dir)
+        self.target_dir.mkdir(parents=True, exist_ok=True)
+        _write_role_files(self.target_dir, self.target_dir)
+        ensure_user_hooks_dir_configured(self.target_dir)
 
     def uninstall(self) -> None:
         """Remove every hook file [`install`][terok_shield.hooks.install.HooksInstaller.install] would write.
 
-        Idempotent — missing files are tolerated.  When ``use_sudo``
-        is set, deletion runs under ``sudo`` so the calling process
-        stays unprivileged.  Containers.conf is left untouched: the
-        user's other hook directories may still need the entry.
+        Idempotent — missing files are tolerated.  ``containers.conf``
+        is left untouched: other terok packages may still register
+        their own ``hooks_dir`` entries the operator wants to keep.
         """
-        paths = [self.target_dir / name for name in _INSTALLED_FILES]
-        if self.use_sudo:
-            _remove_via_sudo(paths)
-        else:
-            for path in paths:
-                path.unlink(missing_ok=True)
+        for name in (*_SCRIPT_FILES, *_DESCRIPTOR_FILES):
+            (self.target_dir / name).unlink(missing_ok=True)
 
     def is_installed(self) -> bool:
         """True when ``target_dir`` carries the canonical createRuntime hook JSON.
@@ -209,7 +177,7 @@ def install_hooks(*, hook_entrypoint: Path, hooks_dir: Path) -> None:
     their canonical names.
 
     WORKAROUND(hooks-dir-persist): currently only used for global
-    hooks (user or root) because podman does not persist per-container
+    hooks because podman does not persist per-container
     ``--hooks-dir`` across stop/start.  The per-container code path is
     kept for near-future use.
 
@@ -227,50 +195,10 @@ def install_hooks(*, hook_entrypoint: Path, hooks_dir: Path) -> None:
 # ── Installation mechanics ──────────────────────────────
 
 
-def _install_via_sudo(target_dir: Path) -> None:
-    """Write hooks to a temp dir, then sudo-copy to the target."""
-    with tempfile.TemporaryDirectory() as tmp:
-        tmp_path = Path(tmp)
-        # JSONs must reference the final script paths, not the temp
-        # copies — pass the install target as the JSON-side anchor.
-        _write_role_files(tmp_path, tmp_path, json_dir=target_dir)
-
-        subprocess.run(
-            ["sudo", "mkdir", "-p", str(target_dir)],
-            check=True,  # noqa: S603, S607
-        )
-        files = [str(tmp_path / name) for name in _INSTALLED_FILES]
-        subprocess.run(
-            ["sudo", "cp", *files, str(target_dir) + "/"],
-            check=True,  # noqa: S603, S607
-        )
-        subprocess.run(
-            [
-                "sudo",
-                "chmod",
-                "+x",
-                str(target_dir / _NFT_ENTRYPOINT_NAME),
-                str(target_dir / _READER_ENTRYPOINT_NAME),
-            ],  # noqa: S603, S607
-            check=True,
-        )
-
-
-def _remove_via_sudo(paths: list[Path]) -> None:
-    """Remove *paths* via ``sudo rm -f`` — idempotent, no error on missing files."""
-    if not paths:
-        return
-    subprocess.run(
-        ["sudo", "rm", "-f", *(str(p) for p in paths)],
-        check=True,  # noqa: S603, S607
-    )
-
-
 def _write_role_files(
     script_dir: Path,
     hooks_dir: Path,
     *,
-    json_dir: Path | None = None,
     nft_entrypoint_name: str = _NFT_ENTRYPOINT_NAME,
 ) -> None:
     """Write nft + reader entrypoints, the shared ballast, and the four hook JSONs.
@@ -278,35 +206,37 @@ def _write_role_files(
     The two role scripts and the ``_oci_state.py`` ballast all land in
     *script_dir*; each role script imports the ballast as a sibling at
     runtime (Python's default ``sys.path[0]`` is the script's
-    directory).
-
-    Hook JSONs go into *hooks_dir* and reference the script paths
-    under *json_dir* (defaulting to *script_dir* when the install is
-    in-place, or the final target when staged for ``sudo cp``).
+    directory).  Hook JSONs go into *hooks_dir* and reference the
+    script paths under *script_dir*.
 
     Args:
         script_dir: Where to write ``_oci_state.py``, the nft
             entrypoint, and the reader entrypoint.
         hooks_dir: Where to write the four ``terok-shield*.json`` files.
-        json_dir: Path to embed in hook JSONs.  Defaults to
-            *script_dir*; overridden for sudo installs where the temp
-            write location differs from the final install path.
         nft_entrypoint_name: On-disk filename for the nft entrypoint.
             Defaults to the canonical ``terok-shield-hook``; callers
             pinning a non-default path (``install_hooks``) thread
             their own filename through so the JSON descriptors point
             at the script the caller asked for.
     """
-    anchor = json_dir or script_dir
+    from ..paths import reader_script_path
 
     (script_dir / _BALLAST_NAME).write_text((_RESOURCES / _BALLAST_NAME).read_text())
     (script_dir / nft_entrypoint_name).write_text((_RESOURCES / "nft_hook.py").read_text())
-    (script_dir / _READER_ENTRYPOINT_NAME).write_text((_RESOURCES / "reader_hook.py").read_text())
+    # The reader hook carries an absolute path to the NFLOG reader
+    # script as a baked constant; rewrite the placeholder so the hook
+    # always finds the reader exactly where ``reader_script_path()``
+    # resolved at this ``terok-shield setup`` call.
+    reader_hook_source = (_RESOURCES / "reader_hook.py").read_text()
+    reader_hook_rendered = reader_hook_source.replace(
+        '"__READER_SCRIPT_PATH__"', json.dumps(str(reader_script_path()))
+    )
+    (script_dir / _READER_ENTRYPOINT_NAME).write_text(reader_hook_rendered)
     (script_dir / nft_entrypoint_name).chmod(0o755)
     (script_dir / _READER_ENTRYPOINT_NAME).chmod(0o755)
 
-    nft_path = str(anchor / nft_entrypoint_name)
-    reader_path = str(anchor / _READER_ENTRYPOINT_NAME)
+    nft_path = str(script_dir / nft_entrypoint_name)
+    reader_path = str(script_dir / _READER_ENTRYPOINT_NAME)
     for stage in _HOOK_STAGES:
         (hooks_dir / _nft_hook_json(stage)).write_text(
             _generate_hook_json(nft_path, stage, nft_entrypoint_name)
@@ -316,20 +246,32 @@ def _write_role_files(
         )
 
 
-# ── containers.conf registration (user scope only) ──────
+# ── containers.conf registration ────────────────────────
 
 
-def _register_hooks_dir_in_containers_conf(hooks_dir: Path) -> None:
+def ensure_user_hooks_dir_configured(hooks_dir: Path | None = None) -> None:
     """Ensure ``~/.config/containers/containers.conf`` lists *hooks_dir*.
 
-    Creates the file if absent.  Inserts ``hooks_dir`` into the
+    The canonical SSOT for the rootless OCI hooks directory across
+    every terok package: shield calls it at ``setup`` time; other
+    installers (e.g. terok-sandbox's per-container supervisor) call
+    it before dropping their own descriptors so they don't have to
+    re-implement the containers.conf patcher.  Idempotent.
+
+    *hooks_dir* defaults to ``namespace_state_dir("shield") / "hooks"``
+    — shield's canonical install location under ``paths.root``.
+
+    Creates the conf file if absent.  Inserts ``hooks_dir`` into the
     existing ``[engine]`` section or appends a new section if none
-    exists.  Warns (does not fail) when ``hooks_dir`` is already set
-    to a different value — the operator owns containers.conf and may
-    have intentionally pinned a different location.
+    exists.  Skips silently when *hooks_dir* is already listed.  When
+    a different ``hooks_dir`` is configured, appends ours to the list
+    rather than failing — the operator owns containers.conf and may
+    have intentionally pinned other locations.
 
     Pure line-based editing — comments and formatting are preserved.
     """
+    if hooks_dir is None:
+        hooks_dir = _default_target_dir()
     conf_path = _user_containers_conf()
     hooks_str = str(hooks_dir)
     hooks_line = f'hooks_dir = ["{hooks_str}"]'
@@ -346,10 +288,7 @@ def _register_hooks_dir_in_containers_conf(hooks_dir: Path) -> None:
 
     if hooks_str in existing or str(hooks_dir.expanduser()) in existing:
         return  # already configured
-    print(
-        f"Warning: {conf_path} already has hooks_dir = {existing}\n"
-        f"Add {hooks_str!r} to the list manually if needed."
-    )
+    _append_to_hooks_dir(conf_path, hooks_str)
 
 
 def _insert_hooks_line(conf_path: Path, hooks_line: str) -> None:
@@ -363,6 +302,34 @@ def _insert_hooks_line(conf_path: Path, hooks_line: str) -> None:
     # No [engine] section — append one.
     with conf_path.open("a") as f:
         f.write(f"\n[engine]\n{hooks_line}\n")
+
+
+def _append_to_hooks_dir(conf_path: Path, new_entry: str) -> None:
+    """Append *new_entry* to the existing ``hooks_dir = [...]`` list in place."""
+    import re
+
+    text = conf_path.read_text()
+    list_pattern = re.compile(r"^(\s*hooks_dir\s*=\s*\[)(.*?)(\])\s*$", re.MULTILINE | re.DOTALL)
+
+    def _list_repl(m: re.Match[str]) -> str:
+        body = m.group(2).rstrip()
+        sep = ", " if body and not body.endswith(",") else ""
+        return f'{m.group(1)}{body}{sep}"{new_entry}"{m.group(3)}'
+
+    new_text, count = list_pattern.subn(_list_repl, text, count=1)
+    if count:
+        conf_path.write_text(new_text)
+        return
+
+    # Scalar form: ``hooks_dir = "/path"`` — promote to a two-element list.
+    scalar_pattern = re.compile(r'^(\s*hooks_dir\s*=\s*)"([^"]+)"\s*$', re.MULTILINE)
+
+    def _scalar_repl(m: re.Match[str]) -> str:
+        return f'{m.group(1)}["{m.group(2)}", "{new_entry}"]'
+
+    new_text, count = scalar_pattern.subn(_scalar_repl, text, count=1)
+    if count:
+        conf_path.write_text(new_text)
 
 
 # ── Generators ──────────────────────────────────────────

--- a/src/terok_shield/hooks/mode.py
+++ b/src/terok_shield/hooks/mode.py
@@ -30,7 +30,6 @@ from ..config import (
     ANNOTATION_DNS_TIER_KEY,
     ANNOTATION_KEY,
     ANNOTATION_LIST_SEP,
-    ANNOTATION_LOOPBACK_PORTS_KEY,
     ANNOTATION_NAME_KEY,
     ANNOTATION_STATE_DIR_KEY,
     ANNOTATION_UPSTREAM_DNS_KEY,
@@ -143,11 +142,17 @@ class HookMode:
         upstream_dns = _upstream_dns_for_mode(mode)
         gw_v4, gw_v6 = self._gateways = _gateways_for_mode(mode)
 
-        # Resolve DNS, write allowlists, generate ruleset + dnsmasq config
+        # Resolve DNS, write allowlists, generate ruleset + dnsmasq config.
+        # ``loopback.ports`` is persisted before ``_write_ruleset`` runs so
+        # the builder reads ports from the bundle (SSOT): later up/down
+        # rebuilds use the same source.
         entries = self._profiles.compose_profiles(profiles)
         self._resolve_and_write_allowlists(sd, tier, entries)
         StateBundle(sd).upstream_dns.write_text(f"{upstream_dns}\n")
         StateBundle(sd).dns_tier.write_text(f"{tier.value}\n")
+        StateBundle(sd).loopback_ports.write_text(
+            "".join(f"{p}\n" for p in self._config.loopback_ports)
+        )
         self._write_ruleset(sd, tier, upstream_dns, gw_v4, gw_v6)
         self._write_dnsmasq_config_or_scrub(sd, tier, upstream_dns)
 
@@ -159,8 +164,9 @@ class HookMode:
         if tier == DnsTier.DNSMASQ:
             args += ["--volume", f"{StateBundle(sd).resolv_conf}:/etc/resolv.conf:ro,Z"]
 
-        # Annotations: profiles, name, state_dir, loopback_ports, version, dns
-        ports_str = ANNOTATION_LIST_SEP.join(str(p) for p in self._config.loopback_ports)
+        # Annotations: profiles, name, state_dir, version, dns.  loopback_ports
+        # lives in the state bundle (per-container, written above), not as an
+        # annotation — annotations are write-only on shield's side.
         args += [
             "--annotation",
             f"{ANNOTATION_KEY}={ANNOTATION_LIST_SEP.join(profiles)}",
@@ -168,8 +174,6 @@ class HookMode:
             f"{ANNOTATION_NAME_KEY}={container}",
             "--annotation",
             f"{ANNOTATION_STATE_DIR_KEY}={sd}",
-            "--annotation",
-            f"{ANNOTATION_LOOPBACK_PORTS_KEY}={ports_str}",
             "--annotation",
             f"{ANNOTATION_VERSION_KEY}={state.BUNDLE_VERSION}",
             "--annotation",
@@ -235,7 +239,7 @@ class HookMode:
         set_timeout = NFT_SET_TIMEOUT_DNSMASQ if tier == DnsTier.DNSMASQ else ""
         ruleset_builder = RulesetBuilder(
             dns=upstream_dns,
-            loopback_ports=self._config.loopback_ports,
+            loopback_ports=StateBundle(sd).read_loopback_ports(),
             gateway_v4=gw_v4,
             gateway_v6=gw_v6,
             set_timeout=set_timeout,
@@ -586,7 +590,7 @@ class HookMode:
         gw_v4, gw_v6 = self._gateways
         return RulesetBuilder(
             dns=dns,
-            loopback_ports=self._config.loopback_ports,
+            loopback_ports=StateBundle(sd).read_loopback_ports(),
             gateway_v4=gw_v4,
             gateway_v6=gw_v6,
             set_timeout=set_timeout,

--- a/src/terok_shield/paths.py
+++ b/src/terok_shield/paths.py
@@ -7,23 +7,26 @@ Per-container state paths live in [`terok_shield.state`][terok_shield.state].  T
 module is the single source of truth for artifacts shared across
 containers or installed into host-wide locations:
 
-- the NFLOG reader script's canonical install path (XDG data home);
+- the NFLOG reader script's canonical install path (under
+  ``paths.root`` via [`namespace_state_dir`][terok_util.paths.namespace_state_dir]);
 - the hook entrypoint filename used both under the user's
   ``containers/oci/hooks.d/`` and inside each per-container
   ``state_dir``.
 
-The reader-script path is computed in two places: ``reader_script_path()``
-in this module, and its stdlib-only mirror ``_reader_script_path()`` in
-``resources/reader_hook.py`` — that file cannot import from this package
-at runtime, so the computation is inlined there verbatim.  When either
-definition changes, the other must be updated by hand; the synced pair
-is the contract.
+The reader-script path is computed once in this module.  The
+``resources/reader_hook.py`` script cannot import from terok_shield
+at runtime (it runs under ``/usr/bin/python3`` outside any venv); the
+installer rewrites that script's ``_READER_SCRIPT_PATH`` placeholder
+with the resolved path at install time, so the on-disk hook always
+points at wherever ``reader_script_path()`` resolved when ``terok-shield
+setup`` ran.
 """
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
+
+from terok_util.paths import namespace_state_dir
 
 HOOK_ENTRYPOINT_NAME = "terok-shield-hook"
 """Canonical filename of the shield OCI hook entrypoint script.
@@ -38,9 +41,11 @@ the same constant means renaming the entrypoint is a single edit.
 def reader_script_path() -> Path:
     """Return the on-disk path where the NFLOG reader script is installed.
 
-    Respects ``XDG_DATA_HOME`` when set, otherwise falls back to the
-    POSIX default ``~/.local/share``.  Mirrors the stdlib-only
-    ``_reader_script_path()`` inlined in ``resources/reader_hook.py``.
+    Honours the operator's ``paths.root`` config via
+    [`namespace_state_dir`][terok_util.paths.namespace_state_dir] —
+    when ``config.yml`` sets ``paths.root: /virt/terok/state`` the
+    script lands at ``/virt/terok/state/shield/nflog-reader.py``;
+    without that override it falls back to the platform-default XDG
+    data dir.
     """
-    data_home = os.environ.get("XDG_DATA_HOME") or f"{os.environ.get('HOME', '')}/.local/share"
-    return Path(data_home) / "terok" / "shield" / "nflog-reader.py"
+    return namespace_state_dir("shield") / "nflog-reader.py"

--- a/src/terok_shield/podman_info/__init__.py
+++ b/src/terok_shield/podman_info/__init__.py
@@ -17,11 +17,9 @@ to import from the specific submodule when intent is clearer.
 
 from .hooks_dir import (
     HOOK_JSON_FILENAME,
-    USER_HOOKS_DIR,
     find_hooks_dirs,
     global_hooks_hint,
     has_global_hooks,
-    system_hooks_dir,
 )
 from .info import HOOKS_DIR_PERSIST_VERSION, PodmanInfo, parse_podman_info
 from .network import parse_resolv_conf, parse_slirp4netns_cidr, slirp4netns_gateway
@@ -30,7 +28,6 @@ __all__ = [
     "HOOKS_DIR_PERSIST_VERSION",
     "HOOK_JSON_FILENAME",
     "PodmanInfo",
-    "USER_HOOKS_DIR",
     "find_hooks_dirs",
     "global_hooks_hint",
     "has_global_hooks",
@@ -38,5 +35,4 @@ __all__ = [
     "parse_resolv_conf",
     "parse_slirp4netns_cidr",
     "slirp4netns_gateway",
-    "system_hooks_dir",
 ]

--- a/src/terok_shield/podman_info/hooks_dir.py
+++ b/src/terok_shield/podman_info/hooks_dir.py
@@ -13,40 +13,29 @@ from pathlib import Path
 
 from ._conf import _SYSTEM_CONF_PATHS, _user_containers_conf
 
-# Well-known system hooks directories (containers-common standard).
-# Used as fallback when containers.conf doesn't specify hooks_dir.
-_SYSTEM_HOOKS_DIRS = (
-    Path("/usr/share/containers/oci/hooks.d"),
-    Path("/etc/containers/oci/hooks.d"),
-)
-
 # Hook JSON filename used to detect terok-shield global hooks.
 HOOK_JSON_FILENAME = "terok-shield-createRuntime.json"
-
-USER_HOOKS_DIR: Path = Path("~/.local/share/containers/oci/hooks.d")
 
 
 def find_hooks_dirs() -> list[Path]:
     """Find hooks directories podman would check.
 
     Reads ``containers.conf`` (user config overrides system config).
-    Falls back to well-known system defaults if nothing is configured.
-
-    Returns directories in precedence order (last wins for podman).
+    Returns the configured directories in precedence order (last wins
+    for podman).  Empty when no ``hooks_dir`` entry is configured —
+    terok always patches ``containers.conf`` at setup time, so an
+    empty result implies setup has not run.
     """
-    # User config takes precedence over system config
     user_dirs = _parse_hooks_dir_from_conf(_user_containers_conf())
     if user_dirs:
         return [Path(d).expanduser() for d in user_dirs]
 
-    # System configs (checked in order, last found wins)
     for conf_path in reversed(_SYSTEM_CONF_PATHS):
         dirs = _parse_hooks_dir_from_conf(conf_path)
         if dirs:
             return [Path(d).expanduser() for d in dirs]
 
-    # No config → well-known system defaults (only existing ones)
-    return [d for d in _SYSTEM_HOOKS_DIRS if d.is_dir()]
+    return []
 
 
 def has_global_hooks(hooks_dirs: list[Path] | None = None) -> bool:
@@ -59,17 +48,6 @@ def has_global_hooks(hooks_dirs: list[Path] | None = None) -> bool:
     if hooks_dirs is None:
         hooks_dirs = find_hooks_dirs()
     return any((d / HOOK_JSON_FILENAME).is_file() for d in hooks_dirs)
-
-
-def system_hooks_dir() -> Path:
-    """Return the best system-level hooks directory.
-
-    Prefers existing directories; falls back to ``/etc/containers/oci/hooks.d``.
-    """
-    for d in _SYSTEM_HOOKS_DIRS:
-        if d.is_dir():
-            return d
-    return _SYSTEM_HOOKS_DIRS[-1]
 
 
 def global_hooks_hint() -> str:

--- a/src/terok_shield/resources/_oci_state.py
+++ b/src/terok_shield/resources/_oci_state.py
@@ -41,12 +41,18 @@ ANN_STATE_DIR = "terok.shield.state_dir"
 ANN_VERSION = "terok.shield.version"
 """OCI annotation carrying the bundle version this container was prepared with."""
 
-BUNDLE_VERSION = 13
+BUNDLE_VERSION = 14
 """Wire-protocol version for the hook ↔ pre_start state-bundle contract.
 
 Bumped whenever the on-disk file layout, the hook → reader argv
 shape, or the wire payload changes incompatibly.  The nft hook hard-
 fails on a version mismatch — operator must re-run ``terok setup``.
+
+v14: per-container host-loopback TCP ports are persisted at pre_start
+time as ``state_dir/loopback.ports`` (newline-separated list).
+Replaces the host-singleton ``loopback_ports`` ``config.yml`` field
+that couldn't represent the dynamically-allocated broker / signer
+ports the supervisor binds.
 
 v13: ``dnsmasq.conf`` ``listen-address`` is runtime-dependent
 (``127.0.0.1`` by default; ``169.254.1.3`` under krun); the nft

--- a/src/terok_shield/resources/nflog_reader.py
+++ b/src/terok_shield/resources/nflog_reader.py
@@ -170,20 +170,26 @@ def main() -> None:  # pragma: no cover — real argparse + subprocess re-exec
     On first entry (``_TEROK_SHIELD_NFLOG_NSENTER`` unset) this process re-execs
     itself under ``nsenter`` — with ``podman unshare`` prepended when we're not
     already in ``NS_ROOTLESS`` — so the NFLOG bind happens in the container's
-    netns.  The re-exec carries the same ``--emit`` and ``--annotations`` choice
-    forward, so the destination (unix socket or stdout JSON) and the orchestrator
-    dossier stay whatever the caller picked.
+    netns.  The re-exec carries the same ``--emit``, ``--annotations``,
+    ``--container-id`` and ``--hub-socket`` choice forward, so the destination
+    (unix socket or stdout JSON), the per-container hub path, and the
+    orchestrator dossier all stay whatever the caller picked.
     """
     args = _parse_args()
     logging.basicConfig(level=logging.INFO, format="nflog-reader: %(message)s")
 
     if os.environ.get(_NSENTER_ENV) != "1":
         _reexec_inside_container_netns(
-            args.state_dir, args.container, args.emit, args.annotations_raw
+            args.state_dir,
+            args.container,
+            args.emit,
+            args.annotations_raw,
+            args.container_id,
+            args.hub_socket,
         )
         return
 
-    emitter = _select_emitter(args.emit)
+    emitter = _select_emitter(args.emit, args.container_id, args.hub_socket)
     session = ReaderSession(
         state_dir=args.state_dir,
         container=args.container,
@@ -196,17 +202,53 @@ def main() -> None:  # pragma: no cover — real argparse + subprocess re-exec
         emitter.close()
 
 
-def _select_emitter(mode: str) -> EventEmitter:
-    """Pick the emitter matching ``--emit`` — socket by default, JSON for the CLI."""
+def _select_emitter(mode: str, container_id: str = "", hub_socket: str = "") -> EventEmitter:
+    """Pick the emitter matching ``--emit`` — socket by default, JSON for the CLI.
+
+    The socket emitter's target is resolved by [`_resolve_hub_socket_path`]
+    [terok_shield.resources.nflog_reader._resolve_hub_socket_path], which honours
+    an explicit ``--hub-socket`` override or a per-container path derived from
+    ``--container-id``.
+    """
     if mode == "json":
         return JsonEmitter()
-    return SocketEmitter(_events_socket_path())
+    return SocketEmitter(_resolve_hub_socket_path(container_id, hub_socket))
 
 
-def _events_socket_path() -> Path:
-    """Return the canonical hub-ingester socket path (mirrors ``terok_clearance``)."""
+def _resolve_hub_socket_path(container_id: str = "", hub_socket: str = "") -> Path:
+    """Return the hub-ingester socket path the reader should connect to.
+
+    Resolution order, matching the per-container-supervisor model:
+
+    1. ``--hub-socket`` (verbatim) — operator / supervisor explicitly pointed
+       us at a socket.  Wins outright.
+    2. ``--container-id`` — build the per-container path under
+       ``$XDG_RUNTIME_DIR/terok/clearance/<container_id>.sock``.  The
+       supervisor for *this* container listens there.
+
+    Raises ``SystemExit`` when neither is supplied — the OCI bridge hook
+    always passes ``--container-id``, so a missing value indicates a
+    misconfigured direct CLI invocation rather than a runtime fallback.
+
+    ``XDG_RUNTIME_DIR`` is honoured when set; the hook always exports it
+    (``_oci_state.bootstrap_env``) before spawning the reader, so the
+    ``os.getuid()`` fallback only ever fires on a direct CLI invocation
+    in the operator's own user namespace.
+    """
+    if hub_socket:
+        return Path(hub_socket)
+    if not container_id:
+        raise SystemExit(
+            "neither --hub-socket nor --container-id supplied; cannot resolve hub socket"
+        )
+    # AF_UNIX's ``sun_path`` is 108 bytes; the full 64-char container
+    # UUID under ``$XDG_RUNTIME_DIR/terok/clearance/<id>.sock`` lands
+    # right at the limit.  Use the 12-char podman short-ID convention,
+    # matching terok-sandbox supervisor's [`SupervisorPaths.for_container`][terok_sandbox.supervisor.main.SupervisorPaths.for_container]
+    # — both sides agree on the same per-container socket name.
+    short_id = container_id[:12]
     xdg = os.environ.get("XDG_RUNTIME_DIR") or f"/run/user/{os.getuid()}"
-    return Path(xdg) / "terok-shield-events.sock"
+    return Path(xdg) / "terok" / "clearance" / f"{short_id}.sock"
 
 
 # ── nsenter re-exec ───────────────────────────────────────────────────
@@ -217,7 +259,12 @@ def _events_socket_path() -> Path:
 
 
 def _reexec_inside_container_netns(
-    state_dir: Path, container: str, emit: str, annotations_raw: str
+    state_dir: Path,
+    container: str,
+    emit: str,
+    annotations_raw: str,
+    container_id: str,
+    hub_socket: str,
 ) -> None:  # pragma: no cover — real subprocess re-exec
     """Re-enter this script inside the container's netns so NFLOG is reachable.
 
@@ -231,6 +278,12 @@ def _reexec_inside_container_netns(
     arrived avoids one round of dict→JSON re-encoding (and the dict-key-order
     drift it would inflict on the cmdline that ``_is_our_reader`` later compares
     against).
+
+    ``container_id`` (per-container hub socket key) and ``hub_socket``
+    (explicit override) flow through unchanged so the second invocation
+    resolves the same socket path the first one did — empty strings are
+    forwarded as empty-valued flags rather than omitting the flag, which
+    keeps the cmdline shape stable for ``_is_our_reader``.
     """
     pid = _podman_container_pid(container)
     script = Path(__file__).resolve()
@@ -244,6 +297,8 @@ def _reexec_inside_container_netns(
         container,
         f"--emit={emit}",
         f"--annotations={annotations_raw}",
+        f"--container-id={container_id}",
+        f"--hub-socket={hub_socket}",
     ]
     cmd = (
         [nsenter, "-t", pid, "-n", *tail]
@@ -956,6 +1011,25 @@ def _parse_args() -> argparse.Namespace:  # pragma: no cover — thin argparse w
             "container_name, meta_path, …) extracted from the container's "
             "``dossier.*`` OCI annotations.  Forwarded verbatim through the "
             "nsenter re-exec; defaults to ``{}`` for orchestrator-less use."
+        ),
+    )
+    parser.add_argument(
+        "--container-id",
+        default="",
+        help=(
+            "Full podman container UUID used to construct the per-container "
+            "hub socket path (``$XDG_RUNTIME_DIR/terok/clearance/<id>.sock``).  "
+            "Set by the OCI bridge hook from the container's full id; required "
+            "unless ``--hub-socket`` is given."
+        ),
+    )
+    parser.add_argument(
+        "--hub-socket",
+        default="",
+        help=(
+            "Explicit hub-ingester socket path — overrides the per-container "
+            "default derived from ``--container-id``.  Lets a supervisor point "
+            "the reader at any socket directly without exposing UUID conventions."
         ),
     )
     args = parser.parse_args()

--- a/src/terok_shield/resources/reader_hook.py
+++ b/src/terok_shield/resources/reader_hook.py
@@ -78,7 +78,8 @@ def _bridge_main(oci: dict, sd: Path, stage: str, log_path: Path) -> None:
         _oci_state.log(f"terok-shield bridge hook: unknown stage {stage!r}", log_path)
         return
 
-    container_id = str(oci.get("id") or "")[:12]
+    full_id = str(oci.get("id") or "")
+    container_id = full_id[:12]
     if not container_id:
         _oci_state.log("terok-shield bridge hook: missing container id — skipping reader", log_path)
         return
@@ -90,7 +91,7 @@ def _bridge_main(oci: dict, sd: Path, stage: str, log_path: Path) -> None:
     # they need to resolve dossiers for their hub events.  Spawn is the
     # costly step; the file write is one syscall and soft-fails on its own.
     _oci_state.persist_meta_path(sd, dossier.get("meta_path", ""))
-    _spawn_reader(sd, container_id, dossier)
+    _spawn_reader(sd, container_id, dossier, full_id)
 
 
 def _extract_dossier(annotations: dict) -> dict[str, str]:
@@ -111,7 +112,12 @@ def _extract_dossier(annotations: dict) -> dict[str, str]:
     return out
 
 
-def _spawn_reader(sd: Path, container_id: str, dossier: dict[str, str] | None = None) -> None:
+def _spawn_reader(
+    sd: Path,
+    container_id: str,
+    dossier: dict[str, str] | None = None,
+    full_container_id: str = "",
+) -> None:
     """Start the NFLOG reader for *container_id* as a detached child.
 
     No-op when the reader script is missing (``--no-dbus-bridge``
@@ -125,6 +131,14 @@ def _spawn_reader(sd: Path, container_id: str, dossier: dict[str, str] | None = 
     forwarded to the reader as a JSON-encoded ``--annotations`` argv
     element so the reader (which composes the wire payload) doesn't
     re-parse the OCI state itself.
+
+    *full_container_id* — the full podman container UUID (not truncated).
+    Passed through as ``--container-id`` so the reader can resolve its
+    per-container hub socket at
+    ``$XDG_RUNTIME_DIR/terok/clearance/<id>.sock`` — the path the
+    per-container supervisor listens on.  The hook bails out earlier
+    when the OCI state has no ``id`` field, so ``--container-id`` is
+    always populated by the time we Popen the reader.
     """
     reader = _reader_script_path()
     if not reader.exists():
@@ -162,6 +176,7 @@ def _spawn_reader(sd: Path, container_id: str, dossier: dict[str, str] | None = 
                 container_id,
                 "--emit=socket",
                 f"--annotations={annotations_json}",
+                f"--container-id={full_container_id}",
             ],
             env=env,
             stdin=subprocess.DEVNULL,
@@ -281,10 +296,18 @@ def _is_our_reader(pid_int: int, sd: Path) -> bool:
     return args[0].endswith(b"python3") and args[1] == script_bytes and sd_bytes in args[2:]
 
 
+#: Absolute path to the NFLOG reader script, baked into the hook by
+#: ``terok-shield setup`` at install time.  The literal placeholder
+#: below is what the installer rewrites; running this script
+#: unmodified is intentionally an error so a half-installed setup
+#: surfaces fast.  See [`terok_shield.paths.reader_script_path`][terok_shield.paths.reader_script_path]
+#: for the resolver the installer uses.
+_READER_SCRIPT_PATH: str = "__READER_SCRIPT_PATH__"
+
+
 def _reader_script_path() -> Path:
-    """Return the on-disk path ``terok setup`` places the reader script at."""
-    data_home = os.environ.get("XDG_DATA_HOME") or f"{os.environ.get('HOME', '')}/.local/share"
-    return Path(data_home) / "terok" / "shield" / "nflog-reader.py"
+    """Return the path the installer baked into this hook copy."""
+    return Path(_READER_SCRIPT_PATH)
 
 
 def _session_bus_address() -> str | None:

--- a/src/terok_shield/state.py
+++ b/src/terok_shield/state.py
@@ -19,6 +19,7 @@ Bundle layout::
     ├── ruleset.nft                    # pre-generated nft ruleset (gateways baked in)
     ├── upstream.dns                   # upstream DNS address
     ├── dns.tier                       # active DNS tier (dig/getent/dnsmasq)
+    ├── loopback.ports                 # per-container host-loopback TCP ports (newline-separated)
     ├── profile.allowed                # IPs from DNS resolution
     ├── profile.domains                # domain names for dnsmasq config
     ├── live.allowed                   # IPs from allow/deny
@@ -41,7 +42,7 @@ from pathlib import Path
 
 from .paths import HOOK_ENTRYPOINT_NAME
 
-BUNDLE_VERSION = 13
+BUNDLE_VERSION = 14
 """Integer version of the state bundle layout.
 
 Bumped whenever the file layout changes in a backwards-incompatible way.
@@ -51,11 +52,11 @@ stale on-disk entrypoint — bump it whenever the entrypoint *protocol*
 changes even if the file layout itself is unchanged, so that
 ``terok setup`` rewrites the script instead of short-circuiting.
 
-Current shape (v13): ``dnsmasq.conf`` ``listen-address`` is runtime-
-dependent (``127.0.0.1`` by default, link-local under krun); the OCI
-hook runs ``ip addr add`` inside the netns for non-loopback binds
-before launching dnsmasq.  Earlier shapes are recoverable via
-``git log -L /^BUNDLE_VERSION/:src/terok_shield/state.py``.
+Current shape (v14): ``loopback.ports`` is now persisted per-container
+at pre_start time — replaces the host-singleton ``loopback_ports``
+config-file field that couldn't represent the per-container broker /
+signer ports the supervisor binds.  Earlier shapes are recoverable
+via ``git log -L /^BUNDLE_VERSION/:src/terok_shield/state.py``.
 """
 
 
@@ -120,6 +121,30 @@ class StateBundle:
     def dns_tier(self) -> Path:
         """Path to the persisted DNS tier value."""
         return self.state_dir / "dns.tier"
+
+    @property
+    def loopback_ports(self) -> Path:
+        """Path to the per-container host-loopback TCP ports list.
+
+        Written by ``HookMode.pre_start`` from the caller-supplied
+        ``ShieldConfig.loopback_ports`` (the per-container triple of
+        gate / token-broker / ssh-signer ports the supervisor binds).
+        Read back by ``shield_up`` / ``shield_down`` when they rebuild
+        the nft ruleset — so a fresh ``Shield`` constructed without
+        the override still emits the correct
+        ``tcp dport <p> ip daddr 10.0.2.2 accept`` rules.
+        """
+        return self.state_dir / "loopback.ports"
+
+    def read_loopback_ports(self) -> tuple[int, ...]:
+        """Read persisted loopback ports; empty tuple when the file is absent."""
+        if not self.loopback_ports.is_file():
+            return ()
+        return tuple(
+            int(line.strip())
+            for line in self.loopback_ports.read_text().splitlines()
+            if line.strip()
+        )
 
     # ── Allowlists and denylists ───────────────────────────
 

--- a/tests/integration/bypass/test_lifecycle.py
+++ b/tests/integration/bypass/test_lifecycle.py
@@ -57,26 +57,26 @@ class TestBypassBasicLifecycle:
         assert_blocked(shielded_container, BLOCKED_TARGET_HTTP)
 
         # Shield down: traffic allowed
-        shield.down(shielded_container)
+        shield.down(shielded_container, shielded_container)
         assert shield.state(shielded_container) == ShieldState.DOWN
         assert_connectable(shielded_container, BLOCKED_TARGET_IP, BLOCKED_TARGET_DNS_PORT)
 
         # Shield up: traffic blocked again
-        shield.up(shielded_container)
+        shield.up(shielded_container, shielded_container)
         assert shield.state(shielded_container) == ShieldState.UP
         assert_blocked(shielded_container, BLOCKED_TARGET_HTTP)
 
     def test_up_disengaged_up_cycle(self, shielded_container: str) -> None:
         """Full cycle with allow_all: UP -> DISENGAGED -> UP."""
         shield = _shield()
-        shield.down(shielded_container, allow_all=True)
+        shield.down(shielded_container, shielded_container, allow_all=True)
         assert shield.state(shielded_container) == ShieldState.DISENGAGED
 
         rules = shield.rules(shielded_container)
         assert "policy accept" in rules
         assert_connectable(shielded_container, BLOCKED_TARGET_IP, BLOCKED_TARGET_DNS_PORT)
 
-        shield.up(shielded_container)
+        shield.up(shielded_container, shielded_container)
         assert shield.state(shielded_container) == ShieldState.UP
         assert_blocked(shielded_container, BLOCKED_TARGET_HTTP)
 
@@ -93,10 +93,10 @@ class TestBypassIdempotency:
     def test_down_twice_stays_down(self, shielded_container: str) -> None:
         """Calling shield.down() twice does not break anything."""
         shield = _shield()
-        shield.down(shielded_container)
+        shield.down(shielded_container, shielded_container)
         assert shield.state(shielded_container) == ShieldState.DOWN
 
-        shield.down(shielded_container)
+        shield.down(shielded_container, shielded_container)
         assert shield.state(shielded_container) == ShieldState.DOWN
         assert_connectable(shielded_container, BLOCKED_TARGET_IP, BLOCKED_TARGET_DNS_PORT)
 
@@ -105,14 +105,14 @@ class TestBypassIdempotency:
         shield = _shield()
         assert shield.state(shielded_container) == ShieldState.UP
 
-        shield.up(shielded_container)
+        shield.up(shielded_container, shielded_container)
         assert shield.state(shielded_container) == ShieldState.UP
         assert_blocked(shielded_container, BLOCKED_TARGET_HTTP)
 
     def test_up_without_prior_down(self, shielded_container: str) -> None:
         """shield.up() on a freshly shielded container is a no-op."""
         shield = _shield()
-        shield.up(shielded_container)
+        shield.up(shielded_container, shielded_container)
         assert shield.state(shielded_container) == ShieldState.UP
         assert_blocked(shielded_container, BLOCKED_TARGET_HTTP)
 
@@ -129,10 +129,10 @@ class TestBypassModeSwitch:
     def test_down_to_disengaged(self, shielded_container: str) -> None:
         """Switch from protected bypass to full bypass."""
         shield = _shield()
-        shield.down(shielded_container)
+        shield.down(shielded_container, shielded_container)
         assert shield.state(shielded_container) == ShieldState.DOWN
 
-        shield.down(shielded_container, allow_all=True)
+        shield.down(shielded_container, shielded_container, allow_all=True)
         assert shield.state(shielded_container) == ShieldState.DISENGAGED
 
         # Private-range rules should be gone
@@ -142,10 +142,10 @@ class TestBypassModeSwitch:
     def test_disengaged_to_down(self, shielded_container: str) -> None:
         """Switch from full bypass back to protected bypass."""
         shield = _shield()
-        shield.down(shielded_container, allow_all=True)
+        shield.down(shielded_container, shielded_container, allow_all=True)
         assert shield.state(shielded_container) == ShieldState.DISENGAGED
 
-        shield.down(shielded_container)
+        shield.down(shielded_container, shielded_container)
         assert shield.state(shielded_container) == ShieldState.DOWN
 
         # Private-range rules should be restored
@@ -170,13 +170,13 @@ class TestBypassWithAllowDeny:
         transition even though the nft ruleset is atomically replaced.
         """
         shield = _shield()
-        shield.down(shielded_container)
+        shield.down(shielded_container, shielded_container)
 
         # Add IP to allow set during bypass — persists to live.allowed
         shield.allow(shielded_container, BLOCKED_TARGET_IP)
 
         # Restore shield — the IP is re-added from live.allowed
-        shield.up(shielded_container)
+        shield.up(shielded_container, shielded_container)
 
         # Verify the IP is still allowed
         assert_connectable(shielded_container, BLOCKED_TARGET_IP, BLOCKED_TARGET_DNS_PORT)
@@ -188,7 +188,7 @@ class TestBypassWithAllowDeny:
         operator-driven deny still drops matching traffic.  See PR #230.
         """
         shield = _shield()
-        shield.down(shielded_container)
+        shield.down(shielded_container, shielded_container)
 
         shield.deny(shielded_container, BLOCKED_TARGET_IP)
         assert_not_connectable(shielded_container, BLOCKED_TARGET_IP, BLOCKED_TARGET_DNS_PORT)
@@ -229,11 +229,11 @@ class TestBypassIPRestoration:
             StateBundle(sd).profile_allowed.write_text("\n".join(ALLOWED_TARGET_IPS) + "\n")
 
             # Go down (all traffic allowed regardless)
-            shield.down(name)
+            shield.down(name, name)
             assert_reachable(name, ALLOWED_TARGET_HTTP)
 
             # Come back up — cached IPs should be restored
-            shield.up(name)
+            shield.up(name, name)
             assert shield.state(name) == ShieldState.UP
             assert_reachable(name, ALLOWED_TARGET_HTTP)
 
@@ -254,8 +254,8 @@ class TestBypassAuditTrail:
         """shield.down and shield.up produce audit log entries."""
         sd = shield_env / "containers" / shielded_container
         shield = Shield(ShieldConfig(state_dir=sd))
-        shield.down(shielded_container)
-        shield.up(shielded_container)
+        shield.down(shielded_container, shielded_container)
+        shield.up(shielded_container, shielded_container)
 
         events = list(shield.tail_log())
         actions = [e["action"] for e in events]
@@ -271,7 +271,7 @@ class TestBypassAuditTrail:
         """shield.down(allow_all=True) logs the allow_all detail."""
         sd = shield_env / "containers" / shielded_container
         shield = Shield(ShieldConfig(state_dir=sd))
-        shield.down(shielded_container, allow_all=True)
+        shield.down(shielded_container, shielded_container, allow_all=True)
 
         events = list(shield.tail_log())
         down_events = [e for e in events if e["action"] == "shield_down"]
@@ -328,23 +328,23 @@ class TestBypassFullE2E:
             StateBundle(sd).profile_allowed.write_text("\n".join(ALLOWED_TARGET_IPS) + "\n")
 
             # Step 3: Down for discovery
-            shield.down(name)
+            shield.down(name, name)
             assert shield.state(name) == ShieldState.DOWN
             assert_reachable(name, ALLOWED_TARGET_HTTP)
             assert_connectable(name, BLOCKED_TARGET_IP, BLOCKED_TARGET_DNS_PORT)
 
             # Step 4: Switch to full bypass to also check RFC1918 destinations
-            shield.down(name, allow_all=True)
+            shield.down(name, name, allow_all=True)
             assert shield.state(name) == ShieldState.DISENGAGED
             assert_connectable(name, BLOCKED_TARGET_IP, BLOCKED_TARGET_DNS_PORT)
 
             # Step 5: Back to protected bypass
-            shield.down(name)
+            shield.down(name, name)
             assert shield.state(name) == ShieldState.DOWN
             assert_connectable(name, BLOCKED_TARGET_IP, BLOCKED_TARGET_DNS_PORT)
 
             # Step 6: Restore the shield
-            shield.up(name)
+            shield.up(name, name)
             assert shield.state(name) == ShieldState.UP
 
             # Cached IPs should be restored
@@ -377,12 +377,12 @@ class TestBypassFullE2E:
         """
         shield = _shield()
         # Rapid toggles
-        shield.down(shielded_container)
-        shield.up(shielded_container)
-        shield.down(shielded_container)
-        shield.down(shielded_container, allow_all=True)
-        shield.up(shielded_container)
-        shield.up(shielded_container)
+        shield.down(shielded_container, shielded_container)
+        shield.up(shielded_container, shielded_container)
+        shield.down(shielded_container, shielded_container)
+        shield.down(shielded_container, shielded_container, allow_all=True)
+        shield.up(shielded_container, shielded_container)
+        shield.up(shielded_container, shielded_container)
 
         # Final state must be UP and enforcing
         assert shield.state(shielded_container) == ShieldState.UP
@@ -407,8 +407,8 @@ class TestBypassFullE2E:
         assert_reachable(shielded_container, ALLOWED_TARGET_HTTP)
 
         # Bypass cycle
-        shield.down(shielded_container)
-        shield.up(shielded_container)
+        shield.down(shielded_container, shielded_container)
+        shield.up(shielded_container, shielded_container)
 
         # IPs survive because live.allowed is read back by shield_up()
         assert_reachable(shielded_container, ALLOWED_TARGET_HTTP)

--- a/tests/integration/bypass/test_state.py
+++ b/tests/integration/bypass/test_state.py
@@ -34,22 +34,22 @@ class TestShieldState:
     def test_state_down_after_shield_down(self, shielded_container: str) -> None:
         """State is DOWN after shield.down() (RFC1918 protection kept)."""
         shield = _shield()
-        shield.down(shielded_container)
+        shield.down(shielded_container, shielded_container)
         assert shield.state(shielded_container) == ShieldState.DOWN
 
     def test_state_disengaged_after_shield_disengaged(self, shielded_container: str) -> None:
         """State is DISENGAGED after shield.down(allow_all=True)."""
         shield = _shield()
-        shield.down(shielded_container, allow_all=True)
+        shield.down(shielded_container, shielded_container, allow_all=True)
         assert shield.state(shielded_container) == ShieldState.DISENGAGED
 
     def test_state_up_after_shield_up(self, shielded_container: str) -> None:
         """State returns to UP after shield.down() then shield.up()."""
         shield = _shield()
-        shield.down(shielded_container)
+        shield.down(shielded_container, shielded_container)
         assert shield.state(shielded_container) == ShieldState.DOWN
 
-        shield.up(shielded_container)
+        shield.up(shielded_container, shielded_container)
         assert shield.state(shielded_container) == ShieldState.UP
 
 

--- a/tests/integration/bypass/test_traffic.py
+++ b/tests/integration/bypass/test_traffic.py
@@ -49,10 +49,10 @@ class TestBypassTrafficDNS:
     def test_dns_blocked_again_after_up(self, shielded_container: str) -> None:
         """DNS connectivity is blocked again after restoring the shield."""
         shield = _shield()
-        shield.down(shielded_container)
+        shield.down(shielded_container, shielded_container)
         assert_connectable(shielded_container, BLOCKED_TARGET_IP, BLOCKED_TARGET_DNS_PORT)
 
-        shield.up(shielded_container)
+        shield.up(shielded_container, shielded_container)
         assert_not_connectable(shielded_container, BLOCKED_TARGET_IP, BLOCKED_TARGET_DNS_PORT)
 
 
@@ -73,10 +73,10 @@ class TestBypassTrafficHTTP:
     def test_http_blocked_again_after_up(self, shielded_container: str) -> None:
         """HTTP traffic to non-allowed target is blocked after restoring shield."""
         shield = _shield()
-        shield.down(shielded_container)
+        shield.down(shielded_container, shielded_container)
         assert_reachable(shielded_container, CONNCHECK_HTTP)
 
-        shield.up(shielded_container)
+        shield.up(shielded_container, shielded_container)
         assert_blocked(shielded_container, CONNCHECK_HTTP)
 
 
@@ -97,10 +97,10 @@ class TestBypassTrafficHTTPS:
     def test_https_blocked_again_after_up(self, shielded_container: str) -> None:
         """HTTPS traffic to non-allowed target is blocked after restoring shield."""
         shield = _shield()
-        shield.down(shielded_container)
+        shield.down(shielded_container, shielded_container)
         assert_reachable(shielded_container, CONNCHECK_HTTPS)
 
-        shield.up(shielded_container)
+        shield.up(shielded_container, shielded_container)
         assert_blocked(shielded_container, CONNCHECK_HTTPS)
 
 
@@ -131,14 +131,14 @@ class TestBypassRuleset:
     def test_bypass_ruleset_has_log_prefix(self, shielded_container: str) -> None:
         """The bypass ruleset contains the TEROK_SHIELD_BYPASS log prefix."""
         shield = _shield()
-        shield.down(shielded_container)
+        shield.down(shielded_container, shielded_container)
         rules = shield.rules(shielded_container)
         assert BYPASS_LOG_PREFIX in rules
 
     def test_bypass_ruleset_has_accept_policy(self, shielded_container: str) -> None:
         """The bypass ruleset output chain has policy accept."""
         shield = _shield()
-        shield.down(shielded_container)
+        shield.down(shielded_container, shielded_container)
         rules = shield.rules(shielded_container)
         assert "policy accept" in rules
 
@@ -155,7 +155,7 @@ class TestBypassRFC1918:
     def test_rfc1918_rules_present_in_default_bypass(self, shielded_container: str) -> None:
         """Default bypass (no --all) keeps RFC1918 reject rules."""
         shield = _shield()
-        shield.down(shielded_container)
+        shield.down(shielded_container, shielded_container)
         rules = shield.rules(shielded_container)
         for net in RFC1918:
             assert net in rules, f"RFC1918 reject rule for {net} missing in bypass"
@@ -163,7 +163,7 @@ class TestBypassRFC1918:
     def test_rfc1918_rules_absent_in_allow_all_bypass(self, shielded_container: str) -> None:
         """Bypass with allow_all=True removes RFC1918 reject rules."""
         shield = _shield()
-        shield.down(shielded_container, allow_all=True)
+        shield.down(shielded_container, shielded_container, allow_all=True)
         rules = shield.rules(shielded_container)
         for net in RFC1918:
             assert (
@@ -178,7 +178,7 @@ class TestBypassRFC1918:
         (which guarantees ICMP admin-prohibited responses).
         """
         shield = _shield()
-        shield.down(shielded_container)
+        shield.down(shielded_container, shielded_container)
         rules = shield.rules(shielded_container)
         assert "admin-prohibited" in rules
 
@@ -195,7 +195,7 @@ class TestBypassIPv6Private:
     def test_ipv6_private_rules_present_in_default_bypass(self, shielded_container: str) -> None:
         """Default bypass keeps IPv6 private reject rules."""
         shield = _shield()
-        shield.down(shielded_container)
+        shield.down(shielded_container, shielded_container)
         rules = shield.rules(shielded_container)
         for net in IPV6_PRIVATE:
             assert net in rules, f"IPv6 private reject rule for {net} missing in bypass"
@@ -203,7 +203,7 @@ class TestBypassIPv6Private:
     def test_ipv6_private_rules_absent_in_allow_all_bypass(self, shielded_container: str) -> None:
         """Bypass with allow_all=True removes IPv6 private reject rules."""
         shield = _shield()
-        shield.down(shielded_container, allow_all=True)
+        shield.down(shielded_container, shielded_container, allow_all=True)
         rules = shield.rules(shielded_container)
         for net in IPV6_PRIVATE:
             assert (

--- a/tests/integration/launch/test_hook_entrypoint.py
+++ b/tests/integration/launch/test_hook_entrypoint.py
@@ -71,7 +71,7 @@ class TestHookEntrypointStory:
         assert_blocked(name, BLOCKED_TARGET_HTTP)
 
         # 4. shield_up re-applies the ruleset cleanly
-        shield.up(name)
+        shield.up(name, name)
         assert "terok_shield" in shield.rules(name)
         assert_blocked(name, BLOCKED_TARGET_HTTP)
 

--- a/tests/integration/observability/test_rules.py
+++ b/tests/integration/observability/test_rules.py
@@ -81,7 +81,7 @@ class TestRulesBypassAPI:
     def test_rules_contain_bypass_prefix(self, shielded_container: str) -> None:
         """Bypass ruleset contains the TEROK_SHIELD_BYPASS log prefix."""
         shield = _shield()
-        shield.down(shielded_container)
+        shield.down(shielded_container, shielded_container)
         rules = shield.rules(shielded_container)
         assert BYPASS_LOG_PREFIX in rules
         assert "policy accept" in rules
@@ -89,10 +89,10 @@ class TestRulesBypassAPI:
     def test_rules_restored_after_up(self, shielded_container: str) -> None:
         """Rules revert to deny-all after shield.up()."""
         shield = _shield()
-        shield.down(shielded_container)
+        shield.down(shielded_container, shielded_container)
         assert "policy accept" in shield.rules(shielded_container)
 
-        shield.up(shielded_container)
+        shield.up(shielded_container, shielded_container)
         rules = shield.rules(shielded_container)
         assert "policy drop" in rules
         assert BYPASS_LOG_PREFIX not in rules

--- a/tests/integration/setup/test_environment.py
+++ b/tests/integration/setup/test_environment.py
@@ -79,29 +79,29 @@ class TestGlobalHooksSetup:
     """Test global hooks installation with real filesystem."""
 
     def test_setup_user_hooks(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        """``HooksInstaller`` (user scope) installs hooks and updates containers.conf."""
+        """``HooksInstaller`` installs hooks and updates containers.conf."""
         monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "share"))
-        hooks_dir = tmp_path / "hooks.d"
+        target = tmp_path / "hooks"
         conf_dir = tmp_path / "config" / "containers"
         monkeypatch.setattr(
             "terok_shield.hooks.install._user_containers_conf",
             lambda: conf_dir / "containers.conf",
         )
 
-        HooksInstaller(target_dir=hooks_dir, register_in_containers_conf=True).install()
-        assert (hooks_dir / "terok-shield-createRuntime.json").is_file()
-        assert (hooks_dir / "terok-shield-poststop.json").is_file()
-        assert (hooks_dir / "terok-shield-hook").is_file()
+        HooksInstaller(target_dir=target).install()
+        assert (target / "terok-shield-createRuntime.json").is_file()
+        assert (target / "terok-shield-poststop.json").is_file()
+        assert (target / "terok-shield-hook").is_file()
 
         # Verify entrypoint is executable
-        hook = hooks_dir / "terok-shield-hook"
+        hook = target / "terok-shield-hook"
         assert hook.stat().st_mode & 0o100
 
-        # containers.conf was patched as part of the user-scope install.
+        # containers.conf was patched as part of the install.
         conf = conf_dir / "containers.conf"
         assert conf.is_file()
         text = conf.read_text()
-        assert str(hooks_dir) in text
+        assert str(target) in text
         assert text.count("[engine]") == 1
 
     def test_has_global_hooks_after_setup(
@@ -109,17 +109,25 @@ class TestGlobalHooksSetup:
     ) -> None:
         """``has_global_hooks`` flips True once ``HooksInstaller.install()`` runs."""
         monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "share"))
-        hooks_dir = tmp_path / "hooks.d"
-        assert not has_global_hooks([hooks_dir])
-        HooksInstaller(target_dir=hooks_dir).install()
-        assert has_global_hooks([hooks_dir])
+        target = tmp_path / "hooks"
+        monkeypatch.setattr(
+            "terok_shield.hooks.install._user_containers_conf",
+            lambda: tmp_path / "containers.conf",
+        )
+        assert not has_global_hooks([target])
+        HooksInstaller(target_dir=target).install()
+        assert has_global_hooks([target])
 
     def test_setup_idempotent(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """Running install twice doesn't break anything — file contents stay stable."""
         monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "share"))
-        hooks_dir = tmp_path / "hooks.d"
-        installer = HooksInstaller(target_dir=hooks_dir)
+        target = tmp_path / "hooks"
+        monkeypatch.setattr(
+            "terok_shield.hooks.install._user_containers_conf",
+            lambda: tmp_path / "containers.conf",
+        )
+        installer = HooksInstaller(target_dir=target)
         installer.install()
-        first_content = (hooks_dir / "terok-shield-hook").read_text()
+        first_content = (target / "terok-shield-hook").read_text()
         installer.install()
-        assert (hooks_dir / "terok-shield-hook").read_text() == first_content
+        assert (target / "terok-shield-hook").read_text() == first_content

--- a/tests/unit/podman_info/test_hooks_dir.py
+++ b/tests/unit/podman_info/test_hooks_dir.py
@@ -13,10 +13,8 @@ from terok_shield.podman_info.hooks_dir import (
     find_hooks_dirs,
     global_hooks_hint,
     has_global_hooks,
-    system_hooks_dir,
 )
 from tests.testfs import (
-    NONEXISTENT_DIR,
     SINGLE_HOOKS_PATH_LITERAL,
     SYSTEM_HOOKS_DIR_LITERAL,
     USER_HOOKS_DIR_LITERAL,
@@ -42,26 +40,25 @@ class TestFindHooksDirs:
             "terok_shield.podman_info.hooks_dir._SYSTEM_CONF_PATHS",
             (tmp_path / "nonexistent",),
         )
-        monkeypatch.setattr("terok_shield.podman_info.hooks_dir._SYSTEM_HOOKS_DIRS", ())
 
         dirs = find_hooks_dirs()
         assert dirs == [Path(USER_HOOKS_DIR_LITERAL)]
 
-    def test_falls_back_to_system_dirs(
+    def test_returns_empty_when_no_config(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Falls back to existing system dirs when no config."""
+        """Returns empty when neither user nor system config has hooks_dir.
+
+        terok always patches containers.conf at setup time, so an empty
+        result implies setup has not run — the caller (e.g.
+        ``check_environment``) treats it as ``setup-needed``.
+        """
         monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "no-config"))
         monkeypatch.setattr(
             "terok_shield.podman_info.hooks_dir._SYSTEM_CONF_PATHS",
             (tmp_path / "nonexistent",),
         )
-        system_dir = tmp_path / "system-hooks"
-        system_dir.mkdir()
-        monkeypatch.setattr("terok_shield.podman_info.hooks_dir._SYSTEM_HOOKS_DIRS", (system_dir,))
-
-        dirs = find_hooks_dirs()
-        assert dirs == [system_dir]
+        assert find_hooks_dirs() == []
 
     def test_system_conf_used_when_no_user_conf(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -71,7 +68,6 @@ class TestFindHooksDirs:
         sys_conf = tmp_path / "system.conf"
         sys_conf.write_text(f'[engine]\nhooks_dir = ["{SYSTEM_HOOKS_DIR_LITERAL}"]\n')
         monkeypatch.setattr("terok_shield.podman_info.hooks_dir._SYSTEM_CONF_PATHS", (sys_conf,))
-        monkeypatch.setattr("terok_shield.podman_info.hooks_dir._SYSTEM_HOOKS_DIRS", ())
         dirs = find_hooks_dirs()
         assert dirs == [Path(SYSTEM_HOOKS_DIR_LITERAL)]
 
@@ -154,28 +150,6 @@ class TestParseHooksDirFromConf:
         conf = tmp_path / "containers.conf"
         conf.write_text("[engine]\nhooks_dir = 42\n")
         assert _parse_hooks_dir_from_conf(conf) == []
-
-
-# ── system_hooks_dir tests ───────────────────────────────
-
-
-class TestSystemHooksDir:
-    """Tests for system hooks directory detection."""
-
-    def test_returns_existing_dir(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Returns an existing system dir when available."""
-        d = tmp_path / "hooks.d"
-        d.mkdir()
-        monkeypatch.setattr("terok_shield.podman_info.hooks_dir._SYSTEM_HOOKS_DIRS", (d,))
-        assert system_hooks_dir() == d
-
-    def test_fallback_when_none_exist(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Falls back to last entry when no system dir exists."""
-        monkeypatch.setattr(
-            "terok_shield.podman_info.hooks_dir._SYSTEM_HOOKS_DIRS",
-            (NONEXISTENT_DIR / "a", NONEXISTENT_DIR / "b"),
-        )
-        assert system_hooks_dir() == NONEXISTENT_DIR / "b"
 
 
 # ── global_hooks_hint tests ──────────────────────────────

--- a/tests/unit/test_api_surface.py
+++ b/tests/unit/test_api_surface.py
@@ -38,9 +38,9 @@ EXPECTED_ALL = [
     "ShieldNeedsSetup",
     "ShieldRuntime",
     "ShieldState",
-    "USER_HOOKS_DIR",
     "check_firewall_binaries",
     "check_krun_binaries",
+    "ensure_user_hooks_dir_configured",
 ]
 
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -50,6 +50,7 @@ from ..testnet import TEST_DOMAIN, TEST_IP1
 from .helpers import write_jsonl
 
 _CONTAINER = "test"
+_CONTAINER_ID = "deadbeefcafe1234"
 _IMAGE = "alpine:latest"
 
 
@@ -131,8 +132,8 @@ def force_hook_mode(monkeypatch: pytest.MonkeyPatch) -> None:
         pytest.param(["status"], "status", id="status"),
         pytest.param(["rules", _CONTAINER], "rules", id="rules"),
         pytest.param(["logs"], "logs", id="logs"),
-        pytest.param(["down", _CONTAINER], "down", id="down"),
-        pytest.param(["up", _CONTAINER], "up", id="up"),
+        pytest.param(["down", _CONTAINER, "--container-id", _CONTAINER_ID], "down", id="down"),
+        pytest.param(["up", _CONTAINER, "--container-id", _CONTAINER_ID], "up", id="up"),
         pytest.param(["preview"], "preview", id="preview"),
         pytest.param(["profiles"], "profiles", id="profiles"),
     ],
@@ -227,8 +228,30 @@ def test_logs_parser_supports_optional_container_and_count(parser: argparse.Argu
 
 def test_down_parser_supports_allow_all(parser: argparse.ArgumentParser) -> None:
     """down defaults to allow_all=False and flips with --all."""
-    assert not parser.parse_args(["down", "ctr"]).allow_all
-    assert parser.parse_args(["down", "ctr", "--all"]).allow_all
+    base = ["down", "ctr", "--container-id", _CONTAINER_ID]
+    assert not parser.parse_args(base).allow_all
+    assert parser.parse_args([*base, "--all"]).allow_all
+
+
+@pytest.mark.parametrize(
+    "verb",
+    [pytest.param("up", id="up"), pytest.param("down", id="down")],
+)
+def test_emit_verbs_require_container_id(parser: argparse.ArgumentParser, verb: str) -> None:
+    """The hub-emitting verbs reject argv without ``--container-id``.
+
+    The shield CLI has no host-wide fallback hub socket; every emit
+    needs the routing key supplied by the caller.  Argparse enforces
+    this via ``required=True`` on the ``--container-id`` option.
+    """
+    with pytest.raises(SystemExit):
+        parser.parse_args([verb, "ctr"])
+
+
+def test_container_id_parses_as_attribute(parser: argparse.ArgumentParser) -> None:
+    """``--container-id <uuid>`` lands on ``args.container_id``."""
+    parsed = parser.parse_args(["up", "ctr", "--container-id", _CONTAINER_ID])
+    assert parsed.container_id == _CONTAINER_ID
 
 
 @pytest.mark.parametrize(
@@ -527,15 +550,23 @@ def test_allow_and_deny_dispatch_to_shield(
     ("argv", "method_name", "expected_call"),
     [
         pytest.param(
-            ["down", _CONTAINER], "down", mock.call(_CONTAINER, allow_all=False), id="down"
+            ["down", _CONTAINER, "--container-id", _CONTAINER_ID],
+            "down",
+            mock.call(_CONTAINER, _CONTAINER_ID, allow_all=False),
+            id="down",
         ),
         pytest.param(
-            ["down", _CONTAINER, "--all"],
+            ["down", _CONTAINER, "--container-id", _CONTAINER_ID, "--all"],
             "down",
-            mock.call(_CONTAINER, allow_all=True),
+            mock.call(_CONTAINER, _CONTAINER_ID, allow_all=True),
             id="down-all",
         ),
-        pytest.param(["up", _CONTAINER], "up", mock.call(_CONTAINER), id="up"),
+        pytest.param(
+            ["up", _CONTAINER, "--container-id", _CONTAINER_ID],
+            "up",
+            mock.call(_CONTAINER, _CONTAINER_ID),
+            id="up",
+        ),
         pytest.param(
             ["preview"],
             "preview",
@@ -884,19 +915,18 @@ def test_build_config_loads_yaml(
     isolated_roots: tuple[Path, Path],
     write_config: Callable[[str], Path],
 ) -> None:
-    """_build_config() loads mode, profiles, ports, and audit settings from YAML."""
+    """_build_config() loads mode, profiles, and audit settings from YAML.
+
+    ``loopback_ports`` is *not* a config-file knob in the per-container
+    model — it lives in the state bundle, written by ``pre_start`` from
+    the caller-supplied ``ShieldConfig``.
+    """
     state_root, _ = isolated_roots
-    write_config(
-        "mode: hook\n"
-        "default_profiles: [base, dev-python]\n"
-        "loopback_ports: [1234, 5678]\n"
-        "audit:\n"
-        "  enabled: false\n"
-    )
+    write_config("mode: hook\ndefault_profiles: [base, dev-python]\naudit:\n  enabled: false\n")
     config = _build_config("ctr", state_dir_override=state_root)
     assert config.mode == ShieldMode.HOOK
     assert config.default_profiles == ("base", "dev-python")
-    assert config.loopback_ports == (1234, 5678)
+    assert config.loopback_ports == ()
     assert not config.audit_enabled
 
 
@@ -1048,35 +1078,26 @@ class TestSetupCommand:
     """Tests for the setup CLI command."""
 
     @mock.patch("terok_shield.hooks.install.HooksInstaller.install")
-    def test_setup_user(
+    def test_setup_installs(
         self,
         install: mock.Mock,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
-        """``setup --user`` dispatches to the user-scope installer."""
-        main(["setup", "--user"])
+        """``setup`` installs hooks to the canonical user-owned dir."""
+        main(["setup"])
         install.assert_called_once()
         out = capsys.readouterr().out
         assert "Done" in out
-        assert "user" in out
 
-    @mock.patch("terok_shield.hooks.install.HooksInstaller.install")
-    def test_setup_root(
-        self,
-        install: mock.Mock,
-        capsys: pytest.CaptureFixture[str],
-    ) -> None:
-        """``setup --root`` dispatches to the system-scope installer with sudo."""
-        main(["setup", "--root"])
-        install.assert_called_once()
-        out = capsys.readouterr().out
-        assert "Done" in out
-        assert "sudo" in out
-
-    def test_setup_root_and_user_rejected(self) -> None:
-        """setup --root --user raises."""
+    def test_setup_rejects_root_flag(self) -> None:
+        """``--root`` is gone; passing it is a parser error."""
         with pytest.raises(SystemExit):
-            main(["setup", "--root", "--user"])
+            main(["setup", "--root"])
+
+    def test_setup_rejects_user_flag(self) -> None:
+        """``--user`` is gone; the single layout is implicit."""
+        with pytest.raises(SystemExit):
+            main(["setup", "--user"])
 
 
 # ── check-environment command test ───────────────────────
@@ -1136,49 +1157,6 @@ def test_version_flag_podman_missing(
     out = capsys.readouterr().out
     assert "podman not found" in out
     assert "nft not found" in out
-
-
-# ── interactive setup test ───────────────────────────────
-
-
-class TestSetupInteractive:
-    """Tests for interactive setup mode."""
-
-    @mock.patch("terok_shield.hooks.install.HooksInstaller.install")
-    @mock.patch("builtins.input", return_value="u")
-    def test_interactive_user_choice(
-        self,
-        _input: mock.Mock,
-        install: mock.Mock,
-        capsys: pytest.CaptureFixture[str],
-    ) -> None:
-        """Interactive setup with 'u' choice installs user hooks."""
-        main(["setup"])
-        install.assert_called_once()
-        assert "Done" in capsys.readouterr().out
-
-    @mock.patch("builtins.input", return_value="x")
-    def test_interactive_cancel(
-        self,
-        _input: mock.Mock,
-        capsys: pytest.CaptureFixture[str],
-    ) -> None:
-        """Interactive setup with invalid choice cancels."""
-        main(["setup"])
-        assert "Cancelled" in capsys.readouterr().out
-
-    @mock.patch("terok_shield.hooks.install.HooksInstaller.install")
-    @mock.patch("builtins.input", return_value="r")
-    def test_interactive_root_choice(
-        self,
-        _input: mock.Mock,
-        install: mock.Mock,
-        capsys: pytest.CaptureFixture[str],
-    ) -> None:
-        """Interactive setup with 'r' choice uses sudo."""
-        main(["setup"])
-        install.assert_called_once()
-        assert "sudo" in capsys.readouterr().out
 
 
 def test_simple_clearance_command_routes_to_handler(cli_dispatch: CliDispatchHarness) -> None:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -11,7 +11,6 @@ from pydantic import ValidationError
 
 from terok_shield.config import (
     ANNOTATION_KEY,
-    ANNOTATION_LOOPBACK_PORTS_KEY,
     ANNOTATION_NAME_KEY,
     ANNOTATION_STATE_DIR_KEY,
     ANNOTATION_VERSION_KEY,
@@ -102,7 +101,6 @@ class TestAnnotationConstants:
         assert ANNOTATION_KEY == "terok.shield.profiles"
         assert ANNOTATION_NAME_KEY == "terok.shield.name"
         assert ANNOTATION_STATE_DIR_KEY == "terok.shield.state_dir"
-        assert ANNOTATION_LOOPBACK_PORTS_KEY == "terok.shield.loopback_ports"
         assert ANNOTATION_VERSION_KEY == "terok.shield.version"
 
 
@@ -117,7 +115,6 @@ class TestShieldFileConfigDefaults:
         cfg = ShieldFileConfig()
         assert cfg.mode == "auto"
         assert cfg.default_profiles == ["dev-standard"]
-        assert cfg.loopback_ports == []
         assert cfg.audit.enabled is True
 
     def test_audit_defaults(self) -> None:
@@ -133,23 +130,11 @@ class TestShieldFileConfigValid:
         cfg = ShieldFileConfig(
             mode="hook",
             default_profiles=["base", "dev-python"],
-            loopback_ports=[8080, 9090],
             audit=AuditFileConfig(enabled=False),
         )
         assert cfg.mode == "hook"
         assert cfg.default_profiles == ["base", "dev-python"]
-        assert cfg.loopback_ports == [8080, 9090]
         assert cfg.audit.enabled is False
-
-    def test_single_port_int_coerced_to_list(self) -> None:
-        """A bare integer is accepted and wrapped in a list."""
-        cfg = ShieldFileConfig(loopback_ports=1234)
-        assert cfg.loopback_ports == [1234]
-
-    def test_boundary_ports(self) -> None:
-        """Port 1 and 65535 are both valid."""
-        cfg = ShieldFileConfig(loopback_ports=[1, 65535])
-        assert cfg.loopback_ports == [1, 65535]
 
 
 class TestShieldFileConfigUnknownKeys:
@@ -165,34 +150,10 @@ class TestShieldFileConfigUnknownKeys:
         with pytest.raises(ValidationError, match="enbled"):
             ShieldFileConfig(audit={"enbled": True})  # type: ignore[arg-type]
 
-
-class TestShieldFileConfigPortValidation:
-    """Port range and type enforcement."""
-
-    def test_port_zero_rejected(self) -> None:
-        """Port 0 is out of range."""
-        with pytest.raises(ValidationError, match="out of range"):
-            ShieldFileConfig(loopback_ports=[0])
-
-    def test_port_too_high_rejected(self) -> None:
-        """Port above 65535 is rejected."""
-        with pytest.raises(ValidationError, match="out of range"):
-            ShieldFileConfig(loopback_ports=[99999])
-
-    def test_bool_in_ports_rejected(self) -> None:
-        """Booleans in port list are rejected (not silently coerced to 0/1)."""
-        with pytest.raises(ValidationError, match="bool"):
-            ShieldFileConfig(loopback_ports=[True])
-
-    def test_bare_bool_rejected(self) -> None:
-        """A bare boolean instead of a list is rejected."""
-        with pytest.raises(ValidationError, match="bool"):
-            ShieldFileConfig(loopback_ports=True)
-
-    def test_string_rejected(self) -> None:
-        """A string instead of a port list is rejected."""
-        with pytest.raises(ValidationError, match="expected list"):
-            ShieldFileConfig(loopback_ports="not-a-list")
+    def test_loopback_ports_rejected(self) -> None:
+        """``loopback_ports`` is per-container state (state bundle), not config — reject if seen."""
+        with pytest.raises(ValidationError, match="loopback_ports"):
+            ShieldFileConfig(loopback_ports=[8080])  # type: ignore[call-arg]
 
 
 class TestShieldFileConfigProfileValidation:

--- a/tests/unit/test_hook_mode_class.py
+++ b/tests/unit/test_hook_mode_class.py
@@ -696,16 +696,18 @@ def test_pre_start_writes_ruleset_nft(
     assert "terok_shield" in content
 
 
-def test_hooks_installer_non_sudo_writes_role_files(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """A non-sudo install lays down nft + reader hooks, ballast, and reader resource."""
+def test_hooks_installer_writes_role_files(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``HooksInstaller.install()`` lays down nft + reader hooks, ballast, and reader resource."""
     from terok_shield.hooks.install import HooksInstaller
 
     # Reader resource lands at ``$XDG_DATA_HOME/terok/shield/nflog-reader.py``;
     # redirect it under tmp_path so the test stays hermetic.
     monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "share"))
-    target = tmp_path / "hooks.d"
+    monkeypatch.setattr(
+        "terok_shield.hooks.install._user_containers_conf",
+        lambda: tmp_path / "containers.conf",
+    )
+    target = tmp_path / "hooks"
     HooksInstaller(target_dir=target).install()
 
     # Shared ballast lands once — both role scripts import from it.
@@ -766,26 +768,6 @@ def test_install_hooks_honors_custom_entrypoint_name(tmp_path: Path) -> None:
     assert (target / "terok-shield-bridge-hook").is_file()
     bridge_json = json.loads((target / "terok-shield-bridge-createRuntime.json").read_text())
     assert bridge_json["hook"]["path"] == str(target / "terok-shield-bridge-hook")
-
-
-def test_hooks_installer_sudo_uses_subprocess(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """``HooksInstaller(use_sudo=True).install()`` escalates writes via sudo."""
-    from unittest import mock
-
-    from terok_shield.hooks.install import HooksInstaller
-
-    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "share"))
-    target = tmp_path / "system-hooks"
-    with mock.patch("terok_shield.hooks.install.subprocess.run") as mock_run:
-        HooksInstaller(target_dir=target, use_sudo=True).install()
-        # sudo mkdir + sudo cp + sudo chmod (reader install runs in-process).
-        assert mock_run.call_count == 3
-        cmds = [call.args[0] for call in mock_run.call_args_list]
-        assert all(cmd[0] == "sudo" for cmd in cmds)
-    # Reader resource still lands locally (no sudo for the per-user path).
-    assert (tmp_path / "share" / "terok" / "shield" / "nflog-reader.py").is_file()
 
 
 @mock.patch("terok_shield.hooks.mode.has_global_hooks", return_value=True)

--- a/tests/unit/test_hub_events.py
+++ b/tests/unit/test_hub_events.py
@@ -14,9 +14,14 @@ from pathlib import Path
 
 import pytest
 
-from terok_shield._hub_events import HubEventEmitter, hub_socket_path
+from terok_shield._hub_events import HubEventEmitter, _per_container_hub_socket
 
 _CONTAINER = "test-ctr"
+# Shorter than the canonical 64-char podman UUID — the unix-socket
+# 108-byte path limit (sun_path) makes long ids unusable under deep
+# pytest tmp_path trees.  The routing logic is character-agnostic;
+# the path-length test pins the real path shape independently.
+_CONTAINER_ID = "deadbeefcafe1234"
 
 
 class _SocketRecorder:
@@ -25,6 +30,7 @@ class _SocketRecorder:
     def __init__(self, path: Path) -> None:
         self.path = path
         self.received: list[bytes] = []
+        path.parent.mkdir(parents=True, exist_ok=True)
         self._sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         self._sock.bind(str(path))
         self._sock.listen(1)
@@ -59,9 +65,16 @@ class _SocketRecorder:
 
 
 @pytest.fixture
-def hub_socket(tmp_path: Path) -> Iterator[_SocketRecorder]:
-    """Spin up a throwaway AF_UNIX listener the emitter can hit."""
-    recorder = _SocketRecorder(tmp_path / "hub.sock")
+def hub_socket(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Iterator[_SocketRecorder]:
+    """Spin up a throwaway AF_UNIX listener bound to the per-container path.
+
+    Points ``XDG_RUNTIME_DIR`` at *tmp_path* so the emitter resolves to
+    ``tmp_path/terok/clearance/<container_id>.sock`` — the very path the
+    recorder is listening on.
+    """
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+    path = tmp_path / "terok" / "clearance" / f"{_CONTAINER_ID[:12]}.sock"
+    recorder = _SocketRecorder(path)
     recorder.start()
     try:
         yield recorder
@@ -69,32 +82,46 @@ def hub_socket(tmp_path: Path) -> Iterator[_SocketRecorder]:
         recorder.stop()
 
 
-class TestHubSocketPath:
-    """Canonical socket path resolution."""
+class TestPerContainerHubSocket:
+    """Per-container socket path resolution."""
 
     def test_uses_xdg_runtime_dir(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-        """The canonical path sits directly under XDG_RUNTIME_DIR."""
+        """The per-container path sits under ``$XDG_RUNTIME_DIR/terok/clearance``."""
         monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
-        assert hub_socket_path() == tmp_path / "terok-shield-events.sock"
+        assert _per_container_hub_socket(_CONTAINER_ID) == (
+            tmp_path / "terok" / "clearance" / f"{_CONTAINER_ID[:12]}.sock"
+        )
 
     def test_falls_back_to_run_user_uid(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Without XDG_RUNTIME_DIR we fall back to ``/run/user/<uid>``."""
         monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
-        assert hub_socket_path() == Path(f"/run/user/{os.getuid()}/terok-shield-events.sock")
+        assert _per_container_hub_socket(_CONTAINER_ID) == Path(
+            f"/run/user/{os.getuid()}/terok/clearance/{_CONTAINER_ID[:12]}.sock"
+        )
+
+    def test_distinct_container_ids_route_to_distinct_sockets(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Two containers under one operator land on two different sockets."""
+        monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+        a = _per_container_hub_socket("aaaa1111")
+        b = _per_container_hub_socket("bbbb2222")
+        assert a != b
+        assert a.parent == b.parent
 
 
 class TestHubEventEmitter:
-    """End-to-end emitter behaviour against a real unix socket."""
+    """End-to-end emitter behaviour against a real per-container unix socket."""
 
     def test_shield_up_writes_single_json_line(self, hub_socket: _SocketRecorder) -> None:
         """``shield_up`` produces one newline-terminated JSON payload."""
-        HubEventEmitter(hub_socket.path).shield_up(_CONTAINER)
+        HubEventEmitter().shield_up(_CONTAINER, _CONTAINER_ID)
         line = _received_one_line(hub_socket)
         assert json.loads(line) == {"type": "shield_up", "container": _CONTAINER}
 
     def test_shield_down_default_is_plain_down(self, hub_socket: _SocketRecorder) -> None:
         """``shield_down`` without ``allow_all`` maps to ``shield_down``."""
-        HubEventEmitter(hub_socket.path).shield_down(_CONTAINER)
+        HubEventEmitter().shield_down(_CONTAINER, _CONTAINER_ID)
         assert json.loads(_received_one_line(hub_socket)) == {
             "type": "shield_down",
             "container": _CONTAINER,
@@ -102,17 +129,20 @@ class TestHubEventEmitter:
 
     def test_shield_down_allow_all_maps_to_disengaged(self, hub_socket: _SocketRecorder) -> None:
         """``allow_all=True`` flips the event type to ``shield_disengaged``."""
-        HubEventEmitter(hub_socket.path).shield_down(_CONTAINER, allow_all=True)
+        HubEventEmitter().shield_down(_CONTAINER, _CONTAINER_ID, allow_all=True)
         assert json.loads(_received_one_line(hub_socket)) == {
             "type": "shield_disengaged",
             "container": _CONTAINER,
         }
 
-    def test_missing_socket_is_fail_silent(self, tmp_path: Path) -> None:
+    def test_missing_socket_is_fail_silent(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
         """Emission against a missing hub must not raise."""
-        emitter = HubEventEmitter(tmp_path / "does-not-exist.sock")
-        emitter.shield_up(_CONTAINER)  # must not raise
-        emitter.shield_down(_CONTAINER, allow_all=True)  # must not raise
+        monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+        emitter = HubEventEmitter()
+        emitter.shield_up(_CONTAINER, "nonexistent-container-id")  # must not raise
+        emitter.shield_down(_CONTAINER, "nonexistent-container-id", allow_all=True)
 
     def test_dossier_is_attached_when_present(self, hub_socket: _SocketRecorder) -> None:
         """A non-empty dossier rides under the ``dossier`` key on the wire.
@@ -121,8 +151,9 @@ class TestHubEventEmitter:
         ``connection_blocked`` events — keeps every event for one
         container rendering with the same identity bundle.
         """
-        HubEventEmitter(hub_socket.path).shield_up(
+        HubEventEmitter().shield_up(
             _CONTAINER,
+            _CONTAINER_ID,
             dossier={"project": "terok", "task": "abc", "name": "diligent-octopus"},
         )
         assert json.loads(_received_one_line(hub_socket)) == {
@@ -132,35 +163,59 @@ class TestHubEventEmitter:
         }
 
     def test_empty_dossier_omits_the_key(self, hub_socket: _SocketRecorder) -> None:
-        """Empty / missing dossier preserves the pre-v12 wire shape — no ``dossier`` key.
+        """Empty / missing dossier yields a flat wire payload — no ``dossier`` key.
 
-        Old hub ingesters that don't know about ``dossier`` will keep
-        round-tripping standalone-container events without seeing an
-        unknown key during the rollout window.
+        Hub ingesters that don't know about ``dossier`` keep round-tripping
+        standalone-container events without seeing an unknown key.
         """
-        HubEventEmitter(hub_socket.path).shield_down(_CONTAINER, dossier={})
+        HubEventEmitter().shield_down(_CONTAINER, _CONTAINER_ID, dossier={})
         assert json.loads(_received_one_line(hub_socket)) == {
             "type": "shield_down",
             "container": _CONTAINER,
         }
 
-    def test_attacker_bytes_in_container_id_are_sanitised(
+    def test_attacker_bytes_in_container_name_are_sanitised(
         self, hub_socket: _SocketRecorder
     ) -> None:
         """A crafted container name can't smuggle control chars onto the wire."""
-        HubEventEmitter(hub_socket.path).shield_up("evil\x00\x1bfoo")
+        HubEventEmitter().shield_up("evil\x00\x1bfoo", _CONTAINER_ID)
         parsed = json.loads(_received_one_line(hub_socket))
         assert parsed["container"] == "evil  foo"
 
     def test_dossier_values_are_sanitised(self, hub_socket: _SocketRecorder) -> None:
         """Producer-side belt-and-braces: dossier strings hit the wire as printable ASCII."""
-        HubEventEmitter(hub_socket.path).shield_up(
+        HubEventEmitter().shield_up(
             _CONTAINER,
+            _CONTAINER_ID,
             dossier={"name": "p1\nProtocol: spoof", "task": "café"},
         )
         parsed = json.loads(_received_one_line(hub_socket))
         assert parsed["dossier"]["name"] == "p1 Protocol: spoof"
         assert parsed["dossier"]["task"] == "caf "
+
+    def test_routes_to_per_container_socket(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """An emit for container A must not reach the listener for container B.
+
+        Two listeners, two container ids: only the matching one sees the
+        payload.  Guards the routing key — if the path scheme regresses to
+        a single global socket both listeners would receive everything.
+        """
+        monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+        cid_a = "a" * 16
+        cid_b = "b" * 16
+        rec_a = _SocketRecorder(tmp_path / "terok" / "clearance" / f"{cid_a[:12]}.sock")
+        rec_b = _SocketRecorder(tmp_path / "terok" / "clearance" / f"{cid_b[:12]}.sock")
+        rec_a.start()
+        rec_b.start()
+        try:
+            HubEventEmitter().shield_up(_CONTAINER, cid_a)
+            assert _received_one_line(rec_a)
+            assert not rec_b.received
+        finally:
+            rec_a.stop()
+            rec_b.stop()
 
 
 def _received_one_line(recorder: _SocketRecorder) -> str:

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -3,55 +3,26 @@
 
 """Unit tests for HooksInstaller and the containers.conf patcher.
 
-Covers the system/user factory pair, the symmetric install/uninstall
-lifecycle, and the line-based containers.conf editing that user-scope
-installs trigger.  The per-container [`install_hooks`][terok_shield.hooks.install.install_hooks]
-path and the role-file generators are exercised by ``test_hook_mode_class``.
+Covers the single-layout install/uninstall lifecycle and the line-based
+containers.conf editing that install triggers.  The per-container
+[`install_hooks`][terok_shield.hooks.install.install_hooks] path and the
+role-file generators are exercised by ``test_hook_mode_class``.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
-from unittest import mock
 
 import pytest
 
 from terok_shield.hooks.install import (
-    _INSTALLED_FILES,
+    _DESCRIPTOR_FILES,
+    _SCRIPT_FILES,
     HooksInstaller,
-    _register_hooks_dir_in_containers_conf,
+    ensure_user_hooks_dir_configured,
 )
 
 from ..testfs import PLACEHOLDER_ALT_HOOKS_DIR, PLACEHOLDER_HOOKS_DIR
-
-# ── Factory constructors ─────────────────────────────────
-
-
-class TestFactories:
-    """The ``system`` / ``user`` classmethods bind the right scope defaults."""
-
-    def test_system_uses_sudo(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """``system()`` escalates writes and skips containers.conf registration."""
-        monkeypatch.setattr(
-            "terok_shield.hooks.install.system_hooks_dir",
-            lambda: Path("/fake/system"),
-        )
-        installer = HooksInstaller.system()
-        assert installer.target_dir == Path("/fake/system")
-        assert installer.use_sudo is True
-        assert installer.register_in_containers_conf is False
-
-    def test_user_does_not_use_sudo(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """``user()`` writes directly and registers in containers.conf."""
-        monkeypatch.setattr(
-            "terok_shield.hooks.install.USER_HOOKS_DIR",
-            Path("/fake/user"),
-        )
-        installer = HooksInstaller.user()
-        assert installer.target_dir == Path("/fake/user")
-        assert installer.use_sudo is False
-        assert installer.register_in_containers_conf is True
-
 
 # ── Install / uninstall lifecycle ────────────────────────
 
@@ -62,11 +33,15 @@ class TestInstallLifecycle:
     def test_install_writes_every_hook_file(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """A fresh non-sudo install lays down every name in ``_INSTALLED_FILES``."""
+        """A fresh install lays down every name in ``_SCRIPT_FILES`` + ``_DESCRIPTOR_FILES``."""
         monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "share"))
-        installer = HooksInstaller(target_dir=tmp_path / "hooks.d")
+        monkeypatch.setattr(
+            "terok_shield.hooks.install._user_containers_conf",
+            lambda: tmp_path / "containers.conf",
+        )
+        installer = HooksInstaller(target_dir=tmp_path / "hooks")
         installer.install()
-        for name in _INSTALLED_FILES:
+        for name in (*_SCRIPT_FILES, *_DESCRIPTOR_FILES):
             assert (installer.target_dir / name).is_file(), f"missing {name}"
 
     def test_install_marks_entrypoints_executable(
@@ -74,7 +49,11 @@ class TestInstallLifecycle:
     ) -> None:
         """The two role scripts get the executable bit; the ballast does not."""
         monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "share"))
-        installer = HooksInstaller(target_dir=tmp_path / "hooks.d")
+        monkeypatch.setattr(
+            "terok_shield.hooks.install._user_containers_conf",
+            lambda: tmp_path / "containers.conf",
+        )
+        installer = HooksInstaller(target_dir=tmp_path / "hooks")
         installer.install()
         assert (installer.target_dir / "terok-shield-hook").stat().st_mode & 0o100
         assert (installer.target_dir / "terok-shield-bridge-hook").stat().st_mode & 0o100
@@ -82,7 +61,11 @@ class TestInstallLifecycle:
     def test_install_is_idempotent(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """A second install overwrites without raising; file contents stay stable."""
         monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "share"))
-        installer = HooksInstaller(target_dir=tmp_path / "hooks.d")
+        monkeypatch.setattr(
+            "terok_shield.hooks.install._user_containers_conf",
+            lambda: tmp_path / "containers.conf",
+        )
+        installer = HooksInstaller(target_dir=tmp_path / "hooks")
         installer.install()
         first = (installer.target_dir / "terok-shield-hook").read_text()
         installer.install()
@@ -93,10 +76,14 @@ class TestInstallLifecycle:
     ) -> None:
         """``uninstall`` clears what ``install`` wrote — symmetric cleanup."""
         monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "share"))
-        installer = HooksInstaller(target_dir=tmp_path / "hooks.d")
+        monkeypatch.setattr(
+            "terok_shield.hooks.install._user_containers_conf",
+            lambda: tmp_path / "containers.conf",
+        )
+        installer = HooksInstaller(target_dir=tmp_path / "hooks")
         installer.install()
         installer.uninstall()
-        for name in _INSTALLED_FILES:
+        for name in (*_SCRIPT_FILES, *_DESCRIPTOR_FILES):
             assert not (installer.target_dir / name).exists()
 
     def test_uninstall_tolerates_missing_files(self, tmp_path: Path) -> None:
@@ -108,52 +95,16 @@ class TestInstallLifecycle:
     ) -> None:
         """The presence probe flips True after install, False after uninstall."""
         monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "share"))
-        installer = HooksInstaller(target_dir=tmp_path / "hooks.d")
+        monkeypatch.setattr(
+            "terok_shield.hooks.install._user_containers_conf",
+            lambda: tmp_path / "containers.conf",
+        )
+        installer = HooksInstaller(target_dir=tmp_path / "hooks")
         assert not installer.is_installed()
         installer.install()
         assert installer.is_installed()
         installer.uninstall()
         assert not installer.is_installed()
-
-
-# ── Sudo escalation path ─────────────────────────────────
-
-
-class TestSudoEscalation:
-    """``use_sudo=True`` routes writes and removals through ``sudo``."""
-
-    def test_install_runs_sudo_subprocess_chain(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """sudo mkdir + sudo cp + sudo chmod fire in that order."""
-        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "share"))
-        target = tmp_path / "system-hooks"
-        installer = HooksInstaller(target_dir=target, use_sudo=True)
-        with mock.patch("terok_shield.hooks.install.subprocess.run") as run:
-            installer.install()
-        argv0s = [call.args[0][0] for call in run.call_args_list]
-        assert argv0s == ["sudo", "sudo", "sudo"]
-        verbs = [call.args[0][1] for call in run.call_args_list]
-        assert verbs == ["mkdir", "cp", "chmod"]
-
-    def test_uninstall_runs_sudo_rm(self, tmp_path: Path) -> None:
-        """Sudo uninstall fires a single ``sudo rm -f`` listing every hook file."""
-        target = tmp_path / "system-hooks"
-        installer = HooksInstaller(target_dir=target, use_sudo=True)
-        with mock.patch("terok_shield.hooks.install.subprocess.run") as run:
-            installer.uninstall()
-        [(call,)] = [(c,) for c in run.call_args_list]
-        argv = call.args[0]
-        assert argv[:3] == ["sudo", "rm", "-f"]
-        assert {Path(p).name for p in argv[3:]} == set(_INSTALLED_FILES)
-
-    def test_remove_via_sudo_empty_list_short_circuits(self) -> None:
-        """Empty paths list returns without shelling out — defensive guard."""
-        from terok_shield.hooks.install import _remove_via_sudo
-
-        with mock.patch("terok_shield.hooks.install.subprocess.run") as run:
-            _remove_via_sudo([])
-        run.assert_not_called()
 
 
 # ── containers.conf registration ─────────────────────────
@@ -169,7 +120,7 @@ class TestRegisterHooksDir:
             "terok_shield.hooks.install._user_containers_conf",
             lambda: conf_dir / "containers.conf",
         )
-        _register_hooks_dir_in_containers_conf(Path(PLACEHOLDER_HOOKS_DIR))
+        ensure_user_hooks_dir_configured(Path(PLACEHOLDER_HOOKS_DIR))
         text = (conf_dir / "containers.conf").read_text()
         assert f'hooks_dir = ["{PLACEHOLDER_HOOKS_DIR}"]' in text
         assert text.count("[engine]") == 1
@@ -184,111 +135,66 @@ class TestRegisterHooksDir:
             "terok_shield.hooks.install._user_containers_conf",
             lambda: conf,
         )
-        _register_hooks_dir_in_containers_conf(Path(PLACEHOLDER_HOOKS_DIR))
+        ensure_user_hooks_dir_configured(Path(PLACEHOLDER_HOOKS_DIR))
         text = conf.read_text()
         assert text.count("[engine]") == 1
         assert f'hooks_dir = ["{PLACEHOLDER_HOOKS_DIR}"]' in text
         assert 'image_copy_tmp_dir = "/data/tmp"' in text
 
     def test_preserves_comments(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Comments in the file are preserved across the insert."""
+        """Existing comments around [engine] are preserved verbatim."""
         conf = tmp_path / "containers.conf"
-        conf.write_text('# My config\n[engine]\n# temp dir\nimage_copy_tmp_dir = "/data"\n')
+        conf.write_text("# preamble\n[engine]\n# inner comment\n")
         monkeypatch.setattr(
             "terok_shield.hooks.install._user_containers_conf",
             lambda: conf,
         )
-        _register_hooks_dir_in_containers_conf(Path(PLACEHOLDER_HOOKS_DIR))
+        ensure_user_hooks_dir_configured(Path(PLACEHOLDER_HOOKS_DIR))
         text = conf.read_text()
-        assert "# My config" in text
-        assert "# temp dir" in text
+        assert "# preamble" in text
+        assert "# inner comment" in text
 
-    def test_ignores_engine_in_comment(
+    def test_idempotent_on_same_value(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """A literal ``[engine]`` inside a comment doesn't trigger the insert."""
+        """A second call with the same value is a no-op."""
         conf = tmp_path / "containers.conf"
-        conf.write_text('# see [engine] docs\n[engine]\nfoo = "bar"\n')
         monkeypatch.setattr(
             "terok_shield.hooks.install._user_containers_conf",
             lambda: conf,
         )
-        _register_hooks_dir_in_containers_conf(Path(PLACEHOLDER_HOOKS_DIR))
-        text = conf.read_text()
-        assert text.count("[engine]") == 2  # one in comment, one real
-        assert text.count("hooks_dir") == 1
+        ensure_user_hooks_dir_configured(Path(PLACEHOLDER_HOOKS_DIR))
+        first = conf.read_text()
+        ensure_user_hooks_dir_configured(Path(PLACEHOLDER_HOOKS_DIR))
+        assert conf.read_text() == first
 
-    def test_skips_if_already_configured(
+    def test_appends_to_existing_other_path(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """No-op when hooks_dir already points to the right path."""
-        conf = tmp_path / "containers.conf"
-        conf.write_text(f'[engine]\nhooks_dir = ["{PLACEHOLDER_HOOKS_DIR}"]\n')
-        monkeypatch.setattr(
-            "terok_shield.hooks.install._user_containers_conf",
-            lambda: conf,
-        )
-        _register_hooks_dir_in_containers_conf(Path(PLACEHOLDER_HOOKS_DIR))
-        assert conf.read_text().count("hooks_dir") == 1
-
-    def test_appends_engine_when_no_section(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """Appends [engine] when the file has other sections but no [engine]."""
-        conf = tmp_path / "containers.conf"
-        conf.write_text("[containers]\nlabel = false\n")
-        monkeypatch.setattr(
-            "terok_shield.hooks.install._user_containers_conf",
-            lambda: conf,
-        )
-        _register_hooks_dir_in_containers_conf(Path(PLACEHOLDER_HOOKS_DIR))
-        text = conf.read_text()
-        assert "[containers]" in text
-        assert "[engine]" in text
-        assert f'hooks_dir = ["{PLACEHOLDER_HOOKS_DIR}"]' in text
-
-    def test_warns_when_different_hooks_dir_configured(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
-    ) -> None:
-        """Warns (does not modify) when hooks_dir is already set differently."""
+        """When containers.conf lists a different hooks_dir, ours is appended to the list."""
         conf = tmp_path / "containers.conf"
         conf.write_text(f'[engine]\nhooks_dir = ["{PLACEHOLDER_ALT_HOOKS_DIR}"]\n')
         monkeypatch.setattr(
             "terok_shield.hooks.install._user_containers_conf",
             lambda: conf,
         )
-        _register_hooks_dir_in_containers_conf(Path(PLACEHOLDER_HOOKS_DIR))
-        assert "Warning" in capsys.readouterr().out
-        assert conf.read_text().count("hooks_dir") == 1  # unchanged
+        ensure_user_hooks_dir_configured(Path(PLACEHOLDER_HOOKS_DIR))
+        text = conf.read_text()
+        assert PLACEHOLDER_ALT_HOOKS_DIR in text
+        assert PLACEHOLDER_HOOKS_DIR in text
 
 
-# ── User-scope install registers in containers.conf ──────
+# ── Install also patches containers.conf ─────────────────
 
 
-def test_user_install_registers_in_containers_conf(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """``register_in_containers_conf=True`` patches containers.conf as part of install."""
+def test_install_patches_containers_conf(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``HooksInstaller.install()`` adds its target_dir to containers.conf."""
     monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "share"))
     conf = tmp_path / "containers.conf"
     monkeypatch.setattr(
         "terok_shield.hooks.install._user_containers_conf",
         lambda: conf,
     )
-    installer = HooksInstaller(target_dir=tmp_path / "hooks.d", register_in_containers_conf=True)
+    installer = HooksInstaller(target_dir=tmp_path / "hooks")
     installer.install()
     assert str(installer.target_dir) in conf.read_text()
-
-
-def test_non_user_install_skips_containers_conf(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """``register_in_containers_conf=False`` leaves containers.conf untouched."""
-    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "share"))
-    conf = tmp_path / "containers.conf"
-    monkeypatch.setattr(
-        "terok_shield.hooks.install._user_containers_conf",
-        lambda: conf,
-    )
-    HooksInstaller(target_dir=tmp_path / "hooks.d").install()
-    assert not conf.exists()

--- a/tests/unit/test_nflog_reader.py
+++ b/tests/unit/test_nflog_reader.py
@@ -142,8 +142,38 @@ class TestSelectEmitter:
     def test_json_mode_returns_json_emitter(self) -> None:
         assert isinstance(reader._select_emitter("json"), reader.JsonEmitter)
 
-    def test_default_mode_returns_socket_emitter(self) -> None:
-        assert isinstance(reader._select_emitter("socket"), reader.SocketEmitter)
+    def test_default_mode_returns_socket_emitter(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+        assert isinstance(
+            reader._select_emitter("socket", container_id="c" * 64),
+            reader.SocketEmitter,
+        )
+
+    def test_socket_emitter_uses_per_container_path(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """A non-empty ``container_id`` routes the socket emitter at the per-container path.
+
+        The basename uses the 12-char short ID so the path fits within
+        AF_UNIX's 108-byte ``sun_path`` limit.
+        """
+        monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+        cid = "cafef00d" * 8
+        emitter = reader._select_emitter("socket", container_id=cid)
+        assert isinstance(emitter, reader.SocketEmitter)
+        assert emitter._path == tmp_path / "terok" / "clearance" / f"{cid[:12]}.sock"
+
+    def test_socket_emitter_uses_explicit_hub_socket(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """An explicit ``hub_socket`` wins over the per-container default."""
+        monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+        override = tmp_path / "custom.sock"
+        emitter = reader._select_emitter("socket", container_id="abc", hub_socket=str(override))
+        assert isinstance(emitter, reader.SocketEmitter)
+        assert emitter._path == override
 
 
 class TestParseAnnotations:
@@ -337,18 +367,51 @@ class TestIsNoiseDest:
         assert reader._is_noise_dest("not-an-ip") is False
 
 
-class TestEventsSocketPath:
-    """``_events_socket_path`` honours XDG, falls back to /run/user/<uid>."""
+class TestResolveHubSocketPath:
+    """``_resolve_hub_socket_path`` picks the per-container path or the explicit override.
 
-    def test_xdg_runtime_dir_wins(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    Resolution order is the contract the OCI bridge hook and the
+    per-container supervisor rely on — explicit ``--hub-socket`` first,
+    then ``--container-id`` derived per-container path.  Neither
+    supplied is a programming error and must raise loudly rather than
+    silently picking a global default.
+    """
+
+    def test_explicit_hub_socket_wins(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """An explicit ``hub_socket`` is used verbatim even when a container id is also set."""
         monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
-        assert reader._events_socket_path() == tmp_path / "terok-shield-events.sock"
+        override = tmp_path / "explicit.sock"
+        assert (
+            reader._resolve_hub_socket_path(container_id="ignored", hub_socket=str(override))
+            == override
+        )
+
+    def test_container_id_builds_per_container_path(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """The 12-char short ID becomes the basename — AF_UNIX path limit avoidance."""
+        monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+        cid = "f" * 64  # full podman UUID shape
+        assert reader._resolve_hub_socket_path(container_id=cid) == (
+            tmp_path / "terok" / "clearance" / f"{cid[:12]}.sock"
+        )
+
+    def test_neither_raises(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """Missing both arguments must surface a clear, specific error."""
+        monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+        with pytest.raises(SystemExit) as excinfo:
+            reader._resolve_hub_socket_path()
+        assert "neither --hub-socket nor --container-id supplied" in str(excinfo.value)
 
     def test_xdg_missing_falls_back_to_run_user(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Direct CLI invocation without ``XDG_RUNTIME_DIR`` lands under ``/run/user/<uid>``."""
         monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
-        path = reader._events_socket_path()
+        # Per-container branch still composes the path beneath /run/user/<uid>.
+        path = reader._resolve_hub_socket_path(container_id="abc")
         assert str(path).startswith("/run/user/")
-        assert path.name == "terok-shield-events.sock"
+        assert path.name == "abc.sock"
 
 
 class TestResolveBinary:

--- a/tests/unit/test_reader_hook.py
+++ b/tests/unit/test_reader_hook.py
@@ -77,7 +77,7 @@ class TestBridgeDispatch:
         oci = _oci_json(str(tmp_path))
         with mock.patch.object(reader_hook, "_spawn_reader") as spawn:
             _run_bridge(oci, stage="createRuntime")
-        spawn.assert_called_once_with(tmp_path, _SHORT_ID, {})
+        spawn.assert_called_once_with(tmp_path, _SHORT_ID, {}, _CONTAINER_ID)
 
     def test_createruntime_extracts_dossier_annotations(self, tmp_path: Path) -> None:
         """``dossier.*`` annotations are stripped of their prefix and passed through."""
@@ -107,6 +107,7 @@ class TestBridgeDispatch:
                 "project": "terok",
                 "meta_path": "/var/lib/terok/tasks/abc.json",
             },
+            _CONTAINER_ID,
         )
 
     def test_poststop_invokes_reap_reader(self, tmp_path: Path) -> None:
@@ -301,7 +302,7 @@ class TestSpawnReader:
             ),
             mock.patch.object(_oci_state.subprocess, "Popen", return_value=fake_proc) as popen,
         ):
-            reader_hook._spawn_reader(tmp_path, _SHORT_ID)
+            reader_hook._spawn_reader(tmp_path, _SHORT_ID, full_container_id=_CONTAINER_ID)
         assert (tmp_path / "reader.pid").read_text().strip() == "12345"
         cmd = popen.call_args[0][0]
         assert cmd[:2] == ["/usr/bin/python3", str(reader)]
@@ -310,6 +311,8 @@ class TestSpawnReader:
         assert "--emit=socket" in cmd
         # Default-empty dossier is still serialised so the reader's argparse always sees the flag.
         assert "--annotations={}" in cmd
+        # Full UUID flows through so the reader resolves the per-container hub socket.
+        assert f"--container-id={_CONTAINER_ID}" in cmd
         env = popen.call_args[1]["env"]
         assert env["DBUS_SESSION_BUS_ADDRESS"] == "unix:path=/run/user/1000/bus"
         assert popen.call_args[1]["start_new_session"] is True
@@ -331,6 +334,23 @@ class TestSpawnReader:
         cmd = popen.call_args[0][0]
         ann_arg = next(a for a in cmd if a.startswith("--annotations="))
         assert json.loads(ann_arg.removeprefix("--annotations=")) == dossier
+
+    def test_full_container_id_is_forwarded_as_container_id_argv(self, tmp_path: Path) -> None:
+        """The full UUID lands as ``--container-id=<uuid>`` so the reader can key the per-container hub socket."""
+        reader = tmp_path / "reader.py"
+        reader.touch()
+        fake_proc = mock.MagicMock(pid=12345)
+        with (
+            mock.patch.object(reader_hook, "_reader_script_path", return_value=reader),
+            mock.patch.object(
+                reader_hook, "_session_bus_address", return_value="unix:path=/run/user/1000/bus"
+            ),
+            mock.patch.object(_oci_state.subprocess, "Popen", return_value=fake_proc) as popen,
+        ):
+            reader_hook._spawn_reader(tmp_path, _SHORT_ID, full_container_id=_CONTAINER_ID)
+        cmd = popen.call_args[0][0]
+        cid_arg = next(a for a in cmd if a.startswith("--container-id="))
+        assert cid_arg.removeprefix("--container-id=") == _CONTAINER_ID
 
     def test_idempotent_when_reader_already_alive(self, tmp_path: Path) -> None:
         reader = tmp_path / "reader.py"
@@ -473,6 +493,9 @@ class TestIsOurReader:
             + b"\x00"
             + str(tmp_path).encode()
             + b"\x00cccccccccccc\x00--emit=socket\x00--annotations={}\x00"
+            + b"--container-id="
+            + _CONTAINER_ID.encode()
+            + b"\x00"
         )
         with (
             mock.patch.object(reader_hook, "_reader_script_path", return_value=reader),
@@ -661,22 +684,17 @@ class TestPidExists:
 
 
 class TestReaderScriptPath:
-    """``_reader_script_path`` honours XDG, falls back under HOME."""
+    """``_reader_script_path`` returns the installer-baked path verbatim.
 
-    def test_xdg_data_home_wins(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
-        assert reader_hook._reader_script_path() == (
-            tmp_path / "terok" / "shield" / "nflog-reader.py"
-        )
+    The hook script no longer guesses an XDG location at runtime;
+    ``terok-shield setup`` writes a templated copy with the resolved
+    [`reader_script_path()`][terok_shield.paths.reader_script_path]
+    (which honours ``paths.root``) baked into ``_READER_SCRIPT_PATH``.
+    """
 
-    def test_falls_back_to_home_local_share(
-        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-    ) -> None:
-        monkeypatch.delenv("XDG_DATA_HOME", raising=False)
-        monkeypatch.setenv("HOME", str(tmp_path))
-        assert reader_hook._reader_script_path() == (
-            tmp_path / ".local" / "share" / "terok" / "shield" / "nflog-reader.py"
-        )
+    def test_returns_baked_constant(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(reader_hook, "_READER_SCRIPT_PATH", "/opt/terok/shield/nflog-reader.py")
+        assert reader_hook._reader_script_path() == Path("/opt/terok/shield/nflog-reader.py")
 
 
 class TestPersistMetaPath:

--- a/tests/unit/test_shield_facade.py
+++ b/tests/unit/test_shield_facade.py
@@ -250,23 +250,23 @@ def test_down_delegates_and_logs(
 ) -> None:
     """down() delegates to the backend, logs, and pings the hub."""
     harness = make_shield()
-    harness.shield.down("test-ctr", allow_all=allow_all)
+    harness.shield.down("test-ctr", "ctr-uuid-1", allow_all=allow_all)
     harness.mode.shield_down.assert_called_once_with("test-ctr", allow_all=allow_all)
     harness.audit.log_event.assert_called_once_with(
         "test-ctr", "shield_down", detail=expected_detail
     )
     harness.hub_events.shield_down.assert_called_once_with(
-        "test-ctr", allow_all=allow_all, dossier={}
+        "test-ctr", "ctr-uuid-1", allow_all=allow_all, dossier={}
     )
 
 
 def test_up_delegates_and_logs(make_shield: ShieldHarnessFactory) -> None:
     """up() delegates to the backend, logs, and pings the hub."""
     harness = make_shield()
-    harness.shield.up("test-ctr")
+    harness.shield.up("test-ctr", "ctr-uuid-1")
     harness.mode.shield_up.assert_called_once_with("test-ctr")
     harness.audit.log_event.assert_called_once_with("test-ctr", "shield_up")
-    harness.hub_events.shield_up.assert_called_once_with("test-ctr", dossier={})
+    harness.hub_events.shield_up.assert_called_once_with("test-ctr", "ctr-uuid-1", dossier={})
 
 
 def test_up_resolves_dossier_via_meta_path(
@@ -284,9 +284,10 @@ def test_up_resolves_dossier_via_meta_path(
     meta.write_text(json.dumps({"project": "terok", "task": "abc", "name": "diligent-octopus"}))
     StateBundle(state_dir).meta_path.write_text(str(meta))
     harness = make_shield()
-    harness.shield.up("test-ctr")
+    harness.shield.up("test-ctr", "ctr-uuid-1")
     harness.hub_events.shield_up.assert_called_once_with(
         "test-ctr",
+        "ctr-uuid-1",
         dossier={"project": "terok", "task": "abc", "name": "diligent-octopus"},
     )
 
@@ -299,9 +300,10 @@ def test_down_resolves_dossier_via_meta_path(
     meta.write_text(json.dumps({"project": "terok", "task": "xyz"}))
     StateBundle(state_dir).meta_path.write_text(str(meta))
     harness = make_shield()
-    harness.shield.down("test-ctr", allow_all=True)
+    harness.shield.down("test-ctr", "ctr-uuid-1", allow_all=True)
     harness.hub_events.shield_down.assert_called_once_with(
         "test-ctr",
+        "ctr-uuid-1",
         allow_all=True,
         dossier={"project": "terok", "task": "xyz"},
     )
@@ -454,12 +456,31 @@ def _run_side_effect(podman_version: str = "5.8.0"):
 class TestCheckEnvironment:
     """Tests for Shield.check_environment()."""
 
+    @staticmethod
+    def _write_hook_layout(hooks_dir: Path, ballast_body: str) -> None:
+        """Write a JSON descriptor + ballast in the layout the version probe expects.
+
+        The probe follows the descriptor's ``hook.path`` to find the
+        script, then reads ``_oci_state.py`` next to it.  Single-flavor
+        installs put descriptors and scripts in the same dir, so the
+        helper just lays both there.
+        """
+        import json
+
+        from terok_shield.podman_info.hooks_dir import HOOK_JSON_FILENAME
+
+        hooks_dir.mkdir(parents=True, exist_ok=True)
+        script_path = hooks_dir / "terok-shield-hook"
+        script_path.write_text("#!/usr/bin/env python3\n")
+        (hooks_dir / "_oci_state.py").write_text(ballast_body)
+        (hooks_dir / HOOK_JSON_FILENAME).write_text(
+            json.dumps({"hook": {"path": str(script_path), "args": []}})
+        )
+
     @mock.patch("terok_shield.find_hooks_dirs", return_value=[Path("/fake/hooks")])
     @mock.patch("terok_shield.has_global_hooks", return_value=True)
-    @mock.patch("terok_shield.system_hooks_dir", return_value=Path("/fake/hooks"))
     def test_dig_missing_reports_issue(
         self,
-        _sys_dir: mock.Mock,
         _has_hooks: mock.Mock,
         _find_dirs: mock.Mock,
         make_shield: ShieldHarnessFactory,
@@ -492,10 +513,8 @@ class TestCheckEnvironment:
 
     @mock.patch("terok_shield.find_hooks_dirs", return_value=[Path("/fake/hooks")])
     @mock.patch("terok_shield.has_global_hooks", return_value=True)
-    @mock.patch("terok_shield.system_hooks_dir", return_value=Path("/fake/hooks"))
     def test_stale_hooks_on_persistent_podman(
         self,
-        _sys_dir: mock.Mock,
         _has_hooks: mock.Mock,
         _find_dirs: mock.Mock,
         make_shield: ShieldHarnessFactory,
@@ -514,51 +533,25 @@ class TestCheckEnvironment:
     @mock.patch("terok_shield._read_installed_hook_version", return_value=state.BUNDLE_VERSION)
     @mock.patch("terok_shield.find_hooks_dirs", return_value=[Path("/fake/hooks")])
     @mock.patch("terok_shield.has_global_hooks", return_value=True)
-    @mock.patch("terok_shield.system_hooks_dir", return_value=Path("/fake/hooks"))
-    def test_global_system_hooks(
+    def test_global_hooks_installed(
         self,
-        _sys_dir: mock.Mock,
         _has_hooks: mock.Mock,
         _find_dirs: mock.Mock,
         _hook_ver: mock.Mock,
         make_shield: ShieldHarnessFactory,
     ) -> None:
-        """System global hooks → ok/global-system."""
+        """Global hooks present + version match → ok/global."""
         harness = make_shield()
         harness.runner.run.side_effect = _run_side_effect("5.8.0")
         env = harness.shield.check_environment()
         assert env.ok
         assert env.health == "ok"
-        assert env.hooks == "global-system"
-
-    @mock.patch("terok_shield._read_installed_hook_version", return_value=state.BUNDLE_VERSION)
-    @mock.patch("terok_shield.find_hooks_dirs", return_value=[Path("/user/hooks")])
-    @mock.patch("terok_shield.system_hooks_dir", return_value=Path("/nonexistent"))
-    def test_global_user_hooks(
-        self,
-        _sys_dir: mock.Mock,
-        _find_dirs: mock.Mock,
-        _hook_ver: mock.Mock,
-        make_shield: ShieldHarnessFactory,
-    ) -> None:
-        """User global hooks (not system) → ok/global-user."""
-        harness = make_shield()
-        harness.runner.run.side_effect = _run_side_effect("5.8.0")
-
-        # First call (hooks_dirs from find_hooks_dirs) -> True (hooks exist)
-        # Second call ([sys_dir]) -> False (not in system dir)
-        with mock.patch("terok_shield.has_global_hooks", side_effect=[True, False]):
-            env = harness.shield.check_environment()
-        assert env.ok
-        assert env.health == "ok"
-        assert env.hooks == "global-user"
+        assert env.hooks == "global"
 
     @mock.patch("terok_shield.find_hooks_dirs")
     @mock.patch("terok_shield.has_global_hooks", return_value=True)
-    @mock.patch("terok_shield.system_hooks_dir", return_value=Path("/fake/hooks"))
     def test_stale_hook_version_detected(
         self,
-        _sys_dir: mock.Mock,
         _has_hooks: mock.Mock,
         _find_dirs: mock.Mock,
         make_shield: ShieldHarnessFactory,
@@ -566,8 +559,7 @@ class TestCheckEnvironment:
     ) -> None:
         """Mismatched ballast version → stale-hooks health status."""
         hooks_dir = tmp_path / "hooks.d"
-        hooks_dir.mkdir()
-        (hooks_dir / "_oci_state.py").write_text("BUNDLE_VERSION = 1\n")
+        self._write_hook_layout(hooks_dir, "BUNDLE_VERSION = 1\n")
         _find_dirs.return_value = [hooks_dir]
 
         harness = make_shield()
@@ -578,10 +570,8 @@ class TestCheckEnvironment:
 
     @mock.patch("terok_shield.find_hooks_dirs")
     @mock.patch("terok_shield.has_global_hooks", return_value=True)
-    @mock.patch("terok_shield.system_hooks_dir", return_value=Path("/fake/hooks"))
     def test_unreadable_hook_version_treated_as_stale(
         self,
-        _sys_dir: mock.Mock,
         _has_hooks: mock.Mock,
         _find_dirs: mock.Mock,
         make_shield: ShieldHarnessFactory,
@@ -589,8 +579,7 @@ class TestCheckEnvironment:
     ) -> None:
         """Ballast file without ``BUNDLE_VERSION`` line → stale-hooks (not silently ok)."""
         hooks_dir = tmp_path / "hooks.d"
-        hooks_dir.mkdir()
-        (hooks_dir / "_oci_state.py").write_text("# no version here\n")
+        self._write_hook_layout(hooks_dir, "# no version here\n")
         _find_dirs.return_value = [hooks_dir]
 
         harness = make_shield()
@@ -604,21 +593,39 @@ class TestCheckEnvironment:
 
 
 class TestReadInstalledHookVersion:
-    """Tests for the _read_installed_hook_version helper."""
+    """Tests for the _read_installed_hook_version helper.
+
+    User-scope installs split scripts from descriptors: the JSON
+    descriptor in ``hooks_dir`` carries the absolute ``path`` of the
+    role script, and the ballast lives next to that script.  The fixture
+    helpers mirror that layout: ``_write_layout`` writes a descriptor in
+    ``hooks_dir`` and a ballast in a sibling ``script_dir``.
+    """
+
+    @staticmethod
+    def _write_layout(hooks_dir: Path, script_dir: Path, ballast_body: str) -> None:
+        import json
+
+        from terok_shield.podman_info.hooks_dir import HOOK_JSON_FILENAME
+
+        hooks_dir.mkdir(parents=True, exist_ok=True)
+        script_dir.mkdir(parents=True, exist_ok=True)
+        script_path = script_dir / "terok-shield-hook"
+        script_path.write_text("#!/usr/bin/env python3\n")
+        (script_dir / "_oci_state.py").write_text(ballast_body)
+        (hooks_dir / HOOK_JSON_FILENAME).write_text(
+            json.dumps({"hook": {"path": str(script_path), "args": []}})
+        )
 
     def test_reads_version_from_hook(self, tmp_path: Path) -> None:
-        """Extracts ``BUNDLE_VERSION`` from the installed ballast module."""
+        """Extracts ``BUNDLE_VERSION`` via the descriptor's script-path reference."""
         from terok_shield import _read_installed_hook_version
 
-        hooks_dir = tmp_path / "hooks.d"
-        hooks_dir.mkdir()
-        # The version lives in the shared ``_oci_state.py`` ballast that
-        # the role scripts import from at runtime.
-        (hooks_dir / "_oci_state.py").write_text("BUNDLE_VERSION = 42\n")
-        assert _read_installed_hook_version([hooks_dir]) == 42
+        self._write_layout(tmp_path / "hooks.d", tmp_path / "scripts", "BUNDLE_VERSION = 42\n")
+        assert _read_installed_hook_version([tmp_path / "hooks.d"]) == 42
 
-    def test_returns_none_when_no_hook(self, tmp_path: Path) -> None:
-        """Returns None when no hook entrypoint is found."""
+    def test_returns_none_when_no_descriptor(self, tmp_path: Path) -> None:
+        """Returns None when no shield JSON descriptor is found."""
         from terok_shield import _read_installed_hook_version
 
         assert _read_installed_hook_version([tmp_path]) is None
@@ -627,21 +634,16 @@ class TestReadInstalledHookVersion:
         """Returns None when the ballast file cannot be read."""
         from terok_shield import _read_installed_hook_version
 
-        hooks_dir = tmp_path / "hooks.d"
-        hooks_dir.mkdir()
-        ballast = hooks_dir / "_oci_state.py"
-        ballast.write_text("BUNDLE_VERSION = 5\n")
+        self._write_layout(tmp_path / "hooks.d", tmp_path / "scripts", "BUNDLE_VERSION = 5\n")
         with mock.patch.object(Path, "read_text", side_effect=OSError("boom")):
-            assert _read_installed_hook_version([hooks_dir]) is None
+            assert _read_installed_hook_version([tmp_path / "hooks.d"]) is None
 
     def test_returns_none_on_no_match(self, tmp_path: Path) -> None:
         """Returns None when the ballast file has no ``BUNDLE_VERSION`` line."""
         from terok_shield import _read_installed_hook_version
 
-        hooks_dir = tmp_path / "hooks.d"
-        hooks_dir.mkdir()
-        (hooks_dir / "_oci_state.py").write_text("# no version here\n")
-        assert _read_installed_hook_version([hooks_dir]) is None
+        self._write_layout(tmp_path / "hooks.d", tmp_path / "scripts", "# no version here\n")
+        assert _read_installed_hook_version([tmp_path / "hooks.d"]) is None
 
 
 from terok_shield.state import StateBundle


### PR DESCRIPTION
- Per-container state (`loopback_ports`, hub sockets) moved into the state bundle.
- Single user-owned install layout. `HooksInstaller.system()` / `--root` / sudo plumbing gone; one frozen dataclass under `namespace_state_dir("shield") / "hooks"`.
- `check_environment` version probe follows the descriptor's `hook.path` instead of scanning `hooks_dir` for the ballast (silently missed user-scope installs before).
- `BUNDLE_VERSION` 13 → 14.

Part of the per-container-supervisor work; depends-on / depended-by chain across `terok-sandbox`, `terok-executor`, `terok`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * `shield.down()` and `shield.up()` methods now require a `container_id` parameter.
  * CLI `down` and `up` commands now require `--container-id` flag.

* **Refactor**
  * Simplified setup command (removed `--root` and `--user` options).
  * Container hook routing now uses per-container endpoints instead of a single shared endpoint.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok-shield/pull/337?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->