### PR TITLE
feat: per-container shield state; single user-owned install layout

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -450,118 +450,118 @@ typer = ">=0.12.5"
 
 [[package]]
 name = "coverage"
-version = "7.14.0"
+version = "7.14.1"
 description = "Code coverage measurement for Python"
 optional = false
 python-versions = ">=3.10"
 groups = ["test"]
 files = [
-    {file = "coverage-7.14.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:84c32d90bf4537f0e7b4dec9aaa9a938fb8205136b9d2ecf4d7629d5262dc075"},
-    {file = "coverage-7.14.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:7c843572c605ab51cfdb5c6b5f2586e2a8467c0d28eca4bdef4ec70c5fecbd82"},
-    {file = "coverage-7.14.0-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:0c451757d3fa2603354fdc789b5e58a0e327a117c370a40e3476ba4eabab228c"},
-    {file = "coverage-7.14.0-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3fd43f0616e765ab78d069cf8358def7363957a45cee446d65c502dcfeea7893"},
-    {file = "coverage-7.14.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:731e535b1498b27d13594a0527a79b0510867b0ad891532be41cb883f2128e20"},
-    {file = "coverage-7.14.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c7492f2d493b976941c7ca050f273cbda2f43c381124f7586a3e3c16d1804fec"},
-    {file = "coverage-7.14.0-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:dc38367eaa2abb1b766ac333142bce7655335a73537f5c8b75aaa89c2b987757"},
-    {file = "coverage-7.14.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:0a951308cde22cf77f953955a754d04dccb57fe3bb8e345d685778ed9fc1632a"},
-    {file = "coverage-7.14.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:fab3877e4ebb06bd9d4d4d00ee53309ee5478e66873c66a382272e3ee33eb7ea"},
-    {file = "coverage-7.14.0-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:b812eb847b19876ebf33fb6c4f11819af05ab6050b0bfa1bc53412ae81779adb"},
-    {file = "coverage-7.14.0-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:d9c8ef6ed820c433de075657d72dda1f89a2984955e58b8a75feb3f184250218"},
-    {file = "coverage-7.14.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:d128b1bba9361fbaaf6a19e179e6cfd6a9103ce0c0555876f72780acc93efd85"},
-    {file = "coverage-7.14.0-cp310-cp310-win32.whl", hash = "sha256:65f267ca1370726ec2c1aa38bbe4df9a71a740f22878d2d4bf59d71a4cd8d323"},
-    {file = "coverage-7.14.0-cp310-cp310-win_amd64.whl", hash = "sha256:b34ece8065914f938ed7f2c5872bb865336977a52919149846eac3744327267a"},
-    {file = "coverage-7.14.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6a78e2a9d9c5e3b8d4ab9b9d28c985ea66fced0a7d7c2aec1f216e03a2011480"},
-    {file = "coverage-7.14.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a1816c505187592dcd1c5a5f226601a549f70365fbd00930ac88b0c225b76bb4"},
-    {file = "coverage-7.14.0-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:d8e1762f0e9cbc26ec315471e7b47855218e833cd5a032d706fbf43845d878c7"},
-    {file = "coverage-7.14.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9336e23e8bb3a3925398261385e2a1533957d3e760e91070dcb0e98bfa514eed"},
-    {file = "coverage-7.14.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9cd1169b2230f9cbe9c638ba38022ed7a2b1e641cc07f7cea0365e4be2a74980"},
-    {file = "coverage-7.14.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d1bb3543b58fea74d2cd1abc4054cc927e4724687cb4560cd2ed88d2c7d820c0"},
-    {file = "coverage-7.14.0-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a93bac2cb577ef60074999ed56d8a1535894398e2ed920d4185c3ec0c8864742"},
-    {file = "coverage-7.14.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:5904abf7e18cddc463219b17552229650c6b79e061d31a1059283051169cf7d5"},
-    {file = "coverage-7.14.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:741f57cddc9004a8c81b084660215f33a6b597dbe62c31386b983ee26310e327"},
-    {file = "coverage-7.14.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:664123feb0929d7affc135717dbd70d61d98688a08ab1e5ba464739620c6252d"},
-    {file = "coverage-7.14.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:c83d2399a51bbec8429266905d33616f04bc5726b1138c35844d5fcd896b2e20"},
-    {file = "coverage-7.14.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:bcb2e855b87321259a037429288ae85216d191c74de3e79bf57cd2bc0761992c"},
-    {file = "coverage-7.14.0-cp311-cp311-win32.whl", hash = "sha256:731dc15b385ac52289743d476245b61e1a2927e803bef655b52bc3b2a75a21f3"},
-    {file = "coverage-7.14.0-cp311-cp311-win_amd64.whl", hash = "sha256:bfb0ed8ec5d25e93face268115d7964db9df8b9aae8edcde9ec6b16c726a7cc1"},
-    {file = "coverage-7.14.0-cp311-cp311-win_arm64.whl", hash = "sha256:7ebb1c6df9f78046a1b1e0a89674cd4bf73b7c648914eebcf976a57fd99a5627"},
-    {file = "coverage-7.14.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7ffd19fc8aed057fd686a17a4935eef5f9859d69208f96310e893e64b9b6ccf5"},
-    {file = "coverage-7.14.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:829994cfe1aeb773ca27bf246d4badc1e764893e3bfb98fff820fcecd1ca4662"},
-    {file = "coverage-7.14.0-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:b4f07cf7edcb7ec39431a5074d7ea83b29a9f71fcfc494f0f40af4e65180420f"},
-    {file = "coverage-7.14.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:ca3d9cf2c32b521bd9518385608787fa86f38daf993695307531822c3430ed67"},
-    {file = "coverage-7.14.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:92af52828e7f29d827346b0294e5a0853fa206db77db0395b282918d41e28db9"},
-    {file = "coverage-7.14.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7b2bb6c9d7e769360d0f20a0f219603fd64f0c8f97de17ab25853261602be0fb"},
-    {file = "coverage-7.14.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1c9ed6ef99f88fb8c14aa8e2bf8eb0fe55fa2edfea68f8675d78741df1a5ac0e"},
-    {file = "coverage-7.14.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8231ade007f37959fbf58acc677f26b922c02eda6f0428ea307da0fd39681bf3"},
-    {file = "coverage-7.14.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:d8b013632cc1ce1d09dbe4f32667b4d320ec2f54fc326ebeffcd0b0bcc2bb6c4"},
-    {file = "coverage-7.14.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:1733198802d71ec4c524f322e2867ee05c62e9e75df86bdca545407a221827d1"},
-    {file = "coverage-7.14.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:72a305291fa8ee01332f1aaf38b348ca34097f6aa0b0ef627eef2837e57bbba5"},
-    {file = "coverage-7.14.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fcaba850dd317c65423a9d63d88f9573c53b00354d6dd95724576cc98a131595"},
-    {file = "coverage-7.14.0-cp312-cp312-win32.whl", hash = "sha256:5ac83957a80d0701310e96d8bec68cdcf4f90a7674b7d13f15a344315b41ab27"},
-    {file = "coverage-7.14.0-cp312-cp312-win_amd64.whl", hash = "sha256:70390b0da32cb90b501953716302906e8bcce087cb283e70d8c97729f22e92b2"},
-    {file = "coverage-7.14.0-cp312-cp312-win_arm64.whl", hash = "sha256:91b993743d959b8be85b4abf9d5478216a69329c321efe5be0433c1a841d691d"},
-    {file = "coverage-7.14.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f2bbb8254370eb4c628ff3d6fa8a7f74ddc40565394d4f7ab791d1fe568e37ef"},
-    {file = "coverage-7.14.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:23b81107f46d3f21d0cbce30664fcec0f5d9f585638a67081750f99738f6bf66"},
-    {file = "coverage-7.14.0-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:22a7e06a5f11a757cdfe79018e9095f9f69ae283c5cd8123774c788deec8717b"},
-    {file = "coverage-7.14.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9d1aa57a1dc8e05bdc42e81c5d671d849577aeedf279f4c449d6d286f9ed88ca"},
-    {file = "coverage-7.14.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:90c1a51bcfddf645b3bb7ec333d9e94393a8e94f55642380fa8a9a5a9e636cb7"},
-    {file = "coverage-7.14.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a841fae2fadcae4f438d43b6ccc4aac2ad609f47cdb6cfdce60cbb3fe5ca7bc2"},
-    {file = "coverage-7.14.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c79d2319cabef1fe8e86df73371126931550804738f78ad7d31e3aad85a67367"},
-    {file = "coverage-7.14.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1b23b0c6f0b1db6ad769b7050c8b641c0bf215ded26c1816955b17b7f26edfa9"},
-    {file = "coverage-7.14.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:55d3089079ce181a4566b1065ab28d2575eb76d8ac8f81f4fcda2bf037fee087"},
-    {file = "coverage-7.14.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:49c005cba1e2f9677fb2845dcdf9a2e72a52a17d63e8231aaaae35d9f50215ef"},
-    {file = "coverage-7.14.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:9117377b823daa28aa8635fbb08cda1cd6be3d7143257345459559aeef852d52"},
-    {file = "coverage-7.14.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7b79d646cf46d5cf9a9f40281d4441df5849e445726e369006d2b117710b33fe"},
-    {file = "coverage-7.14.0-cp313-cp313-win32.whl", hash = "sha256:fb609b3658479e33f9516d46f1a89dbb9b6c261366e3a11844a96ec487533dae"},
-    {file = "coverage-7.14.0-cp313-cp313-win_amd64.whl", hash = "sha256:0773d8329cf32b6fd222e4b52622c61fe8d503eb966cfc8d3c3c10c96266d50e"},
-    {file = "coverage-7.14.0-cp313-cp313-win_arm64.whl", hash = "sha256:b4e26a0f1b696faf283bffe5b8569e44e336c582439df5d53281ab89ee0cba96"},
-    {file = "coverage-7.14.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:953f521ca9445300397e65fda3dca58b2dbd68fee983777420b57ac3c77e9f90"},
-    {file = "coverage-7.14.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:98af83fd65ae24b1fdd03aaead967a9f523bcd2f1aab2d4f3ffda65bb568a6f1"},
-    {file = "coverage-7.14.0-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:668b92e6958c4db7cf92e81caac328dfbbdbb215db2850ad28f0cbe1eea0bfbd"},
-    {file = "coverage-7.14.0-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9fbd898551762dea00d3fef2b1c4f99afd2c6a3ff952ea07d60a9bd5ed4f34bc"},
-    {file = "coverage-7.14.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:68af363c07ecd8d4b7d4043d85cb376d7d227eceb54e5323ee45da73dbd3e426"},
-    {file = "coverage-7.14.0-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6e57054a583da8ac55edf24117ea4c9133032cfc4cf72aa2d48c1e5d4b52f899"},
-    {file = "coverage-7.14.0-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cc3499459bbcdd51a65b64c35ab7ed2764eaf3cba826e0df3f1d7fe2e102b70b"},
-    {file = "coverage-7.14.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:45899ec2138a4346ed34d601dedf5076fb74edf2d1dd9dc76a78e82397edee90"},
-    {file = "coverage-7.14.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:8767486808c436f05b23ab98eb963fb29185e32a9357a166971685cb3459900f"},
-    {file = "coverage-7.14.0-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:a3b5ddfd6aa7ddad53ee3edb231e88a2151507a43229b7d71b953916deca127d"},
-    {file = "coverage-7.14.0-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:63df0fe568e698e1045792399f8ab6da3a6c2dce3182813fb92afa2641087b47"},
-    {file = "coverage-7.14.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:827d6397dbd95144939b18f89edf31f63e1f99633e8d5f32f22ba8bdda567477"},
-    {file = "coverage-7.14.0-cp313-cp313t-win32.whl", hash = "sha256:7bf43e000d24012599b879791cff41589af90674722421ef11b11a5431920bab"},
-    {file = "coverage-7.14.0-cp313-cp313t-win_amd64.whl", hash = "sha256:3f5549365af25d770e06b1f8f5682d9a5637d06eb494db91c6fa75d3950cc917"},
-    {file = "coverage-7.14.0-cp313-cp313t-win_arm64.whl", hash = "sha256:6d160217ec6fe890f16ad3a9531761589443749e448f91986c972714fad361c8"},
-    {file = "coverage-7.14.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:9aed9fa983514ca032790f3fe0d1c0e42ca7e16b42432af1706b50a9a46bef5d"},
-    {file = "coverage-7.14.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ba3b8390db29296dbbf49e91b6fe08f990743a90c8f447ba4c2ffc29670dfa63"},
-    {file = "coverage-7.14.0-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:3a5d8e876dfa2f102e970b183863d6dedd023d3c0eeca1fe7a9787bc5f28b212"},
-    {file = "coverage-7.14.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5ebb8f4614a3787d567e610bbfdf96a4798dd69a1afb1bd8ad228d4111fe6ff3"},
-    {file = "coverage-7.14.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b9bf47223dd8db3d4c4b2e443b02bace480d428f0822c3f991600448a176c97"},
-    {file = "coverage-7.14.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3485a836550b303d006d57cc06e3d5afaabc642c77050b7c985a97b13e3776b8"},
-    {file = "coverage-7.14.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3e7e88110bae996d199d1693ca8ec3fd52441d426401ae963437598667b4c5eb"},
-    {file = "coverage-7.14.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:15228a6800ce7bdf1b74800595e56db7138cecb338fdbf044806e10dcf182dfe"},
-    {file = "coverage-7.14.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:9d26ac7f5398bafc5b57421ad994e8a4749e8a7a0e62d05ec7d53014d5963bfa"},
-    {file = "coverage-7.14.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2fb73254ff43c911c967a899e1359bc5049b4b115d6e8fbdde4937d0a2246cd5"},
-    {file = "coverage-7.14.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:454a380af72c6adada298ed270d38c7a391288198dbfb8467f786f588751a90c"},
-    {file = "coverage-7.14.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:65c86fb646d2bd2972e96bd1a8b45817ed907cee68655d6295fe7ec031d04cca"},
-    {file = "coverage-7.14.0-cp314-cp314-win32.whl", hash = "sha256:6a6516b02a6101398e19a3f44820f69bab2590697f7def4331f668b14adaf828"},
-    {file = "coverage-7.14.0-cp314-cp314-win_amd64.whl", hash = "sha256:45e0f79d8351fa76e256716df91eab12890d32678b9590df7ae1042e4bd4cf5d"},
-    {file = "coverage-7.14.0-cp314-cp314-win_arm64.whl", hash = "sha256:4b899594a8b2d81e5cc064a0d7f9cac2081fed91049456cae7676787e41549c9"},
-    {file = "coverage-7.14.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:f580f8c80acd94ac72e863efe2cab791d8c38d153e0b463b92dfa000d5c84cd1"},
-    {file = "coverage-7.14.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a2bd259c442cd43c49b30fbafc51776eb19ea396faf159d26a83e6a0a5f13b0c"},
-    {file = "coverage-7.14.0-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:a706b908dfa85538863504c624b237a3cc34232bf403c057414ebfdb3b4d9f84"},
-    {file = "coverage-7.14.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:7333cd944ee4393b9b3d3c1b598c936d4fc8d70573a4c7dacfec5590dd50e436"},
-    {file = "coverage-7.14.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0f162bc9a15b82d947b02651b0c7e1609d6f7a8735ca330cfadec8481dd97d5a"},
-    {file = "coverage-7.14.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:362cb78e01a5dc82009d88004cf60f2e6b6d6fcbfdec05b05af73b0abf40118f"},
-    {file = "coverage-7.14.0-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:acebd068fca5512c3a6fde9c045f901613478781a73f0e82b307b214daef23fb"},
-    {file = "coverage-7.14.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:29fe3da551dface75deb2ccbf87b6b66e2e7ef38f6d89050b428be94afff3490"},
-    {file = "coverage-7.14.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:b4cc4fce8672fffcb09b0eafc167b396b3ba53c4a7230f54b7aaffbf6c835fa9"},
-    {file = "coverage-7.14.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:5d4a51aad8ba8bdcd2b8bd8f03d4aca19693fa2327a3470e4718a25b03481020"},
-    {file = "coverage-7.14.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:9f323af3e1e4f68b60b7b247e37b8515563a61375518fa59de1af48ba28a3db6"},
-    {file = "coverage-7.14.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:1a0abc7342ea9711c469dd8b821c6c311e6bc6aac1442e5fbd6b27fae0a8f3db"},
-    {file = "coverage-7.14.0-cp314-cp314t-win32.whl", hash = "sha256:a9f864ef57b7172e2db87a096642dd51e179e085ab6b2c371c29e885f65c8fb2"},
-    {file = "coverage-7.14.0-cp314-cp314t-win_amd64.whl", hash = "sha256:29943e552fdc08e082eb51400fb2f58e118a83b5542bd06531214e084399b644"},
-    {file = "coverage-7.14.0-cp314-cp314t-win_arm64.whl", hash = "sha256:742a73ea621953b012f2c4c2219b512180dd84489acf5b1596b0aafc55b9100b"},
-    {file = "coverage-7.14.0-py3-none-any.whl", hash = "sha256:8de5b61163aee3d05c8a2beab6f47913df7981dad1baf82c414d99158c286ab1"},
-    {file = "coverage-7.14.0.tar.gz", hash = "sha256:057a6af2f160a85384cde4ab36f0d2777bae1057bae255f95413cdd382aa5c74"},
+    {file = "coverage-7.14.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:3e3680291c4a1d0dadfa84a2c459576a4af5133abb617905714339a0c73138cf"},
+    {file = "coverage-7.14.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a5274669f37f2343635a347b91a60777621341ab3378e9c6ac9335eee704bddf"},
+    {file = "coverage-7.14.1-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:cfe5a5fec635799ef33428f1e5e61bafa45a92a96190ba731561ba558ccc214d"},
+    {file = "coverage-7.14.1-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:62a9f70b52e0b5a95cfef4a5c5641b06983cadc5e538a3feeb5c00211f523ac2"},
+    {file = "coverage-7.14.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3c18ebc343e15be53049b3a2dce38fe82d58f37e20ab9094b3a39c0aa4f6bb47"},
+    {file = "coverage-7.14.1-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b84ffdf877644e7096aa936991efeed873f7f3df57b9cd001312b7668ab08550"},
+    {file = "coverage-7.14.1-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e854312c4103f2ad4c0dc023b69b77ebfd2c89db5f86c4c94dc2353f9a92167e"},
+    {file = "coverage-7.14.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:c643734307300234fafa36bf2a040a7235f8f177ea1fd6ec1423aea6fb7b929f"},
+    {file = "coverage-7.14.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:84ac9499e48700399a5dd0ea7085b5091961fec52c68d66b4ec0d3cf7f4441b1"},
+    {file = "coverage-7.14.1-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:7f02d09f70776579b926d889a4c9c235070a1f47c40458aeaca563fae5acfdb5"},
+    {file = "coverage-7.14.1-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:ce66d8e46da2bb5ee313a745cbd2e391d319176c1f7a9451bfcd3a2fb920859b"},
+    {file = "coverage-7.14.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:c912c259304cfb5ee584481cfb7ce1ff932b4d61e6c9140b8f19cb7b5ed82332"},
+    {file = "coverage-7.14.1-cp310-cp310-win32.whl", hash = "sha256:1238cb94638e610e972c60dac68e813f868dc7d6e982535270558443058d9d59"},
+    {file = "coverage-7.14.1-cp310-cp310-win_amd64.whl", hash = "sha256:fc459e5d73be2d6332fcfe8dbf3d8994671fe33c700f4565988ecfa511547253"},
+    {file = "coverage-7.14.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:478b5bcd63c2e1357c5c7e16c070690df7b07f676b1c114d7b93e533c664309f"},
+    {file = "coverage-7.14.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a24a81f9715ee42ef59a316cc11611c98fe23920f7c81861315c9f3ff4a230f4"},
+    {file = "coverage-7.14.1-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:196a13319ad88d6d8ef5ab489ec4f44ddde2143c0c7d5b27786f6c3ffd56a7e1"},
+    {file = "coverage-7.14.1-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3d452fd08b5c72c5167c93e6867b5c08500bd40f2a21e1e854a500550b6cc36f"},
+    {file = "coverage-7.14.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:23bf7fa51ac02e07fc7c96849b82946da47ae862dc8f86d183b2a4864fc38129"},
+    {file = "coverage-7.14.1-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:bcaa50684dcaadfa599ac48f81103c756d791cfd85c97203d2217c593d48b860"},
+    {file = "coverage-7.14.1-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4ea1c034f95c9b056e856b794630b17f9fa3d57e4800ff1e503d3be0f9c9078c"},
+    {file = "coverage-7.14.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c7e057326434e441306226fbeb5d1aaf14a2637efe97ba668306635835f32ad7"},
+    {file = "coverage-7.14.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:59baf88468dbc8d63b1887afd92bda52e40bb1561696e5819670601403810cec"},
+    {file = "coverage-7.14.1-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:d34d75f892b3ab73ba11cab5442cce7b3e168fd64162b16f0e1e0d09c508edef"},
+    {file = "coverage-7.14.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:3a56abc20a472baf0304c455721bc601477440d28ecfde8a03dde79ede07e0df"},
+    {file = "coverage-7.14.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:6a3cb83d1552c0cd1b4906655b6a33fd4a8473229633a901c6b73bf86914dee9"},
+    {file = "coverage-7.14.1-cp311-cp311-win32.whl", hash = "sha256:10274a1fbeb8ec5d72966e17bb198a3104257aca4ac09d98667c5f8aca8c8548"},
+    {file = "coverage-7.14.1-cp311-cp311-win_amd64.whl", hash = "sha256:87ebdf787d4888e3f3f2d523eadc6e18c6d18c6d0eb173801a189641627fb37e"},
+    {file = "coverage-7.14.1-cp311-cp311-win_arm64.whl", hash = "sha256:dd34767fa19848d35659ffc0a75314f58c7af3f1cd87ec521e8292a1238398a3"},
+    {file = "coverage-7.14.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a06c76364a9360e33d6d23769aefdf7f66f38e2ffb60ceb1baaa4989d83b695c"},
+    {file = "coverage-7.14.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fad54e871165f6ec2f536063ac74c3104508a12963e64072ba44bd822de52b0c"},
+    {file = "coverage-7.14.1-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:84b535f00655ecafe1d929d1fb00ed5d6fa3051ea643ab2c161a3887b86f294b"},
+    {file = "coverage-7.14.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6b6b0853b895fe0e98cbfc580d1ec3393d9302b4b1e96a77b3f5c91fdab899e6"},
+    {file = "coverage-7.14.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:442cc9c952b2df400cda54bb04ab87330cf2cd08a8692cbbea36773531eb6f37"},
+    {file = "coverage-7.14.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8270544c361ed405a27a060dbc9ed2c124b084d96dfdc2d9a2510482aef981ad"},
+    {file = "coverage-7.14.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:48b283b1dd6372e8de2a7a9a4c4d5dc06f4d4fd209b876f3c88a7a205a0c8f84"},
+    {file = "coverage-7.14.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5b0c99ba93a07d56f6df340bb79be53202a082b2fdb81bfe6190b741a3470d54"},
+    {file = "coverage-7.14.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:e471bc5769ff073b058cfadb0d736b56ce067c8560eabeb0da88462df98c23e7"},
+    {file = "coverage-7.14.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:f497a1ea81d4cd7c10ddcaa685135b9aabd291af3d55775a9ddf3cb7a364cdd9"},
+    {file = "coverage-7.14.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:2222be86d0b54f5dd5a38f45f17f315f737245e857bf0bdedc70734f84a13c02"},
+    {file = "coverage-7.14.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:85e85586565842f6932abebd4c18bcb1074223dc0b3576e7d173ca710622813a"},
+    {file = "coverage-7.14.1-cp312-cp312-win32.whl", hash = "sha256:4a28fd227808366b196a75476dced2eb35b351d6766ba9c858dc93319e87f4f1"},
+    {file = "coverage-7.14.1-cp312-cp312-win_amd64.whl", hash = "sha256:54acdb6674a4661768d7bf7db32dfb9f46ab1d764f8aba6df75ce1a6a088724e"},
+    {file = "coverage-7.14.1-cp312-cp312-win_arm64.whl", hash = "sha256:99cd41ff91afd94896fea3bc002706b6ae4ce95727d06e4a0f39c0a8d8bd8b1a"},
+    {file = "coverage-7.14.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:be9f2c802dcfce3f71298303aa5dad0dce440a76c52f2f60dacd8656dab78793"},
+    {file = "coverage-7.14.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6223a72fd0e4c7156353ec0f08a5f93623e1d3034d0e2683b9bb8ea674131b1d"},
+    {file = "coverage-7.14.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:7279d2110a28cebc738b6459ecda2771735a4c18465fbbd36b3288fe5ed92247"},
+    {file = "coverage-7.14.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9eeb3fcbc13ba40dfbdb22d01d196a28e9cef9ed4c29b60061a1e0e823a9929d"},
+    {file = "coverage-7.14.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f0cfc27c539f07cf5c0a4cfe211d0b6cae039f8f40526dbaa71944e64b50a7b"},
+    {file = "coverage-7.14.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:221c70f316241a78e77e607c227cefc8808d4e08f28d99c04f35694690e940be"},
+    {file = "coverage-7.14.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:da028256b04ec30e5e0114b6f76172938c313991f0a2d3d894271315cf5d5e43"},
+    {file = "coverage-7.14.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:76a085d7005236a767e3426148b2c407e53ad61695c562f8a81da2d373324901"},
+    {file = "coverage-7.14.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:b553d04b5e778a8e56d57eb134aff42a92718ecba45e79c4764ecfa40efd92ff"},
+    {file = "coverage-7.14.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:46f714d2fb8ae2f4f29f23ada7f1e79b759fff5a70f94a1dac23af204c3ec9e4"},
+    {file = "coverage-7.14.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:1896f5e19ff3f0431c7ce2172adc54890fd97f86b59ced8ca1649145d9ffe35d"},
+    {file = "coverage-7.14.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:62fd185ef9df3c33d1c8178c5af105f762afbad96038de9a4ae100aa6297ca33"},
+    {file = "coverage-7.14.1-cp313-cp313-win32.whl", hash = "sha256:ab4af6352741a604c431c6072fce5bee33bf0f20dc7a56618d6bf6bb89e9810c"},
+    {file = "coverage-7.14.1-cp313-cp313-win_amd64.whl", hash = "sha256:7af486dabe8954d03b087f0021540897afe084f04e16ff5579e08cc46f871416"},
+    {file = "coverage-7.14.1-cp313-cp313-win_arm64.whl", hash = "sha256:2224f89ffd0c5605ccce1ed7a584da162bc7c55f601ab1c946bc9de31a486b42"},
+    {file = "coverage-7.14.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:de286598cc65d2b489411174b1faec2f5a7775fb3201fd925db2a76b4030f37d"},
+    {file = "coverage-7.14.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:042c46ded7c288aeb07cf14a28b6c1e10b78fcba40171c3fa1e939377eeef0b5"},
+    {file = "coverage-7.14.1-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:f4ddbe407477f04c45115d1a4e5bc480f753553b534d338d4c3358b1cdd0ea52"},
+    {file = "coverage-7.14.1-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:d13e6725992e2d2fd7d81d4f5241952d13740121dfd501da09201be39b2c003a"},
+    {file = "coverage-7.14.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f747dc8edcfe740130f28f32f3995e955494285717e86ee25af51db2219df08a"},
+    {file = "coverage-7.14.1-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ced2f09ef276fd58611a1ef502164ad266d2b75174e5a40cabbdb4033f9f6cf2"},
+    {file = "coverage-7.14.1-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b84800013769a78ccb9ef4659402e26d06867e337b61ec365f77ad008adea80e"},
+    {file = "coverage-7.14.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:ea8cd6ca0ee9f616aaef3afc6882e32c2cbf18b00d96313ffd76af650574034d"},
+    {file = "coverage-7.14.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:aa5e304a873fabddc11e484e9b6b738bd38bd7bed17b09aa84eecf5332e8b8bb"},
+    {file = "coverage-7.14.1-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:5a1c5215be81035e629d5bc756650634d0bf31991038db7a0eccb90f025ce16d"},
+    {file = "coverage-7.14.1-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:79058c47dae6788504b5effb319961bcd72d7240551464b91d474bc0ed186d69"},
+    {file = "coverage-7.14.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:370c5afae3fa0658e11694a32b24c2778f6bc2d17718121f94ee185e69f26b54"},
+    {file = "coverage-7.14.1-cp313-cp313t-win32.whl", hash = "sha256:3758dd0a7f1fa57365ef2e781df0f0731d38b6e3772259d13dae4bd8a958d4b1"},
+    {file = "coverage-7.14.1-cp313-cp313t-win_amd64.whl", hash = "sha256:6ff665fb023a77386fe11685190cee1f60a7d635994a30d9b0a061533d470fce"},
+    {file = "coverage-7.14.1-cp313-cp313t-win_arm64.whl", hash = "sha256:17a5a241e5997621a956a7f402a7433ef4221e5152809b785bec79e2323799f1"},
+    {file = "coverage-7.14.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d5ed429d0b8edaac649e889b4ffcedb6c80b06629a3f93050e3dddfb99235bee"},
+    {file = "coverage-7.14.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8011224a62280e50dab346960c03cf47aca1a1e09e608c0fb33fd6e0cc8e9500"},
+    {file = "coverage-7.14.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:12c42ec1e14f553c4f817e989365982e646e27211f10a0f717855b94a79c8906"},
+    {file = "coverage-7.14.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:06144cd511cf2624873a035c5069cf297144f6e77a73ee3d7a55b605ec5efb42"},
+    {file = "coverage-7.14.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a311d8e1da24be5c1ccf85cbfb06315dbaa1703d5a1eab3f6432c72b837917c8"},
+    {file = "coverage-7.14.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c79cead5b5bc584d9c71451cb984d0e3a84e0c0937379c8efcbf27c8d661b851"},
+    {file = "coverage-7.14.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:dcbf65f1f66a26cdd88c35cf68fb4729c5d1cd2e88added72420541dfb212034"},
+    {file = "coverage-7.14.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fd86572566fb40189a8260446158235159bc7a82dfbc87a3b39cf4fb57fcec1c"},
+    {file = "coverage-7.14.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:7771b601718fdde84832c3a434ca9bbf4ae9adbc49d84198b4110700c3c77c36"},
+    {file = "coverage-7.14.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:39b21e212c55af06fa375e3dbf90a8a8e38792f3a910c580066d23563830ddd5"},
+    {file = "coverage-7.14.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:f2302660e32562a532b442480121aef8aa61a5bdb20b30bf0adab29f10a5a4b4"},
+    {file = "coverage-7.14.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:03a6f93c1ec3b7f2e77b5dbcc5573a2c21f12529a5c6bbe0f16f72303cc2fa4d"},
+    {file = "coverage-7.14.1-cp314-cp314-win32.whl", hash = "sha256:8a3ce026d73290f42f08dafecbd82c193a74df280461fbf97300fec51fd133ee"},
+    {file = "coverage-7.14.1-cp314-cp314-win_amd64.whl", hash = "sha256:114c95ef29302423b87d159075805f4ab973254a2638a5d7d046c94887cc87d7"},
+    {file = "coverage-7.14.1-cp314-cp314-win_arm64.whl", hash = "sha256:a07891c3f4805442b31b71e84ba3cf29ed1aa9a428284e06deeb4b23e5b46343"},
+    {file = "coverage-7.14.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:1101a5ebb083aecb625ebb6209d4105b58f647b093cb2dc8122d7b33f743cfe1"},
+    {file = "coverage-7.14.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:851b9e1e4e8a4608e77c79714b2e77c0970d2ed7202a05e92ae407817481887b"},
+    {file = "coverage-7.14.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:d5b89cdfb2ee051b71e8c3c70bd81a9eff81100f736a269136fe1a68efe00474"},
+    {file = "coverage-7.14.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0177614a0370f227888b4e436a7c55686d6a9f90eb1ade2b624ba685a1686e86"},
+    {file = "coverage-7.14.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2d69af5dea2de76fc485a83032a630523f985198b7e25be901ec60181587b01e"},
+    {file = "coverage-7.14.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:35ab22d91de736e8966b980dc355cbcdd2c6dbbcfe275f9a2991bc8a91b3df65"},
+    {file = "coverage-7.14.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:357d4e32935c36588aaba057d734fa32428c360c9fc2e4442afbf1b646beee6e"},
+    {file = "coverage-7.14.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:51bd64741cc6fa065abd300ede1afe5a5291ece9c31da8b24884deda48bcc3f8"},
+    {file = "coverage-7.14.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:9132cd363a68a4c3daa7c8704a654b1e39d3360f6f5b8ddd470608a945236c07"},
+    {file = "coverage-7.14.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:07c6290b1697b862c0478eab545eec949a0d0e4d6d03497f446d706da3b4f2de"},
+    {file = "coverage-7.14.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:5ea0c297e27133853b4d8a3eb799bff5a2dbd9f2f41537a240d337ac9b4df890"},
+    {file = "coverage-7.14.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:01b7733daad0237daa01ef80fe2dfceffc911e6a17fa7b55d14aa8214eaaaecd"},
+    {file = "coverage-7.14.1-cp314-cp314t-win32.whl", hash = "sha256:6adc5a36984624a70bf11d7184e20fa0a49aa7c47ffab43804106a1a695ea22e"},
+    {file = "coverage-7.14.1-cp314-cp314t-win_amd64.whl", hash = "sha256:ddf799247318f34dbcd2efa8c95a8d0642674e926bb1774cf9b63dfd2a389d1c"},
+    {file = "coverage-7.14.1-cp314-cp314t-win_arm64.whl", hash = "sha256:145986fe66647eb489f18d9a997567a3fd358584c4b5a808769113abc07466af"},
+    {file = "coverage-7.14.1-py3-none-any.whl", hash = "sha256:a252f21c27e38347e60111a3266b03827422a7d5525951aceee313aa68bab1d2"},
+    {file = "coverage-7.14.1.tar.gz", hash = "sha256:30c08f7d90415aa98b3c990385dea2939b0da55f38515e5b369b83655f8523be"},
 ]
 
 [package.extras]
@@ -1818,14 +1818,14 @@ test = ["pytest", "pytest-cov"]
 
 [[package]]
 name = "python-discovery"
-version = "1.3.1"
+version = "1.3.2"
 description = "Python interpreter discovery"
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
 files = [
-    {file = "python_discovery-1.3.1-py3-none-any.whl", hash = "sha256:ed188687ebb3b82c01a17cd5ac62fc94d9f6487a7f1a0f9dfe89753fec91039c"},
-    {file = "python_discovery-1.3.1.tar.gz", hash = "sha256:62f6db28064c9613e7ca76cb3f00c38c839a07c31c00dfe7ed0986493d2150a6"},
+    {file = "python_discovery-1.3.2-py3-none-any.whl", hash = "sha256:889d67b010d31fb19331fc723d7cb201c9f77c24c70cd21b0d9cc3255e86bb23"},
+    {file = "python_discovery-1.3.2.tar.gz", hash = "sha256:d5374db044e97325d49337e4d76f477ac2024ab78ac5ac915e89bd90c67c51d1"},
 ]
 
 [package.dependencies]
@@ -2162,17 +2162,18 @@ description = "Shared utility library for the terok-* sibling packages"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = [
-    {file = "terok_util-0.0.2a1-py3-none-any.whl", hash = "sha256:00506d9720bba29755fc01bf91a0a63999a92373750545acd4b459d6290502b7"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 platformdirs = ">=4.9.6"
 "ruamel.yaml" = ">=0.18"
 
 [package.source]
-type = "url"
-url = "https://github.com/terok-ai/terok-util/releases/download/v0.0.2a1/terok_util-0.0.2a1-py3-none-any.whl"
+type = "git"
+url = "https://github.com/sliwowitz/terok-util.git"
+reference = "feat/per-container-supervisor-v2"
+resolved_reference = "988281d4f8cba6eb508402bfecf10f75b1ddb7aa"
 
 [[package]]
 name = "tomli"
@@ -2279,19 +2280,19 @@ telegram = ["requests"]
 
 [[package]]
 name = "typer"
-version = "0.25.1"
+version = "0.26.2"
 description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "typer-0.25.1-py3-none-any.whl", hash = "sha256:75caa44ed46a03fb2dab8808753ffacdbfea88495e74c85a28c5eefcf5f39c89"},
-    {file = "typer-0.25.1.tar.gz", hash = "sha256:9616eb8853a09ffeabab1698952f33c6f29ffdbceb4eaeecf571880e8d7664cc"},
+    {file = "typer-0.26.2-py3-none-any.whl", hash = "sha256:39beff72ffbb31978a5b545f677d57edb97c6f980f433b38556deb0af25f094d"},
+    {file = "typer-0.26.2.tar.gz", hash = "sha256:9b4f19e08fcc9427a822d1ef467b1fe76737a2f65c7926bdeba2337d73569b68"},
 ]
 
 [package.dependencies]
 annotated-doc = ">=0.0.2"
-click = ">=8.2.1"
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
 rich = ">=13.8.0"
 shellingham = ">=1.3.0"
 
@@ -2428,4 +2429,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "5d1d66169d3716bd81ab2c0b47da9e37fda856ca7b0ad96d769c773d338ccb52"
+content-hash = "7200f70f0dae2c5fcae0282cb6f719df4d0218c5657e89584c9a60e66fd5eccc"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dynamic = ["version", "classifiers"]
 dependencies = [
     "PyYAML>=6.0",
     "pydantic>=2.0",
-    "terok-util @ https://github.com/terok-ai/terok-util/releases/download/v0.0.2a1/terok_util-0.0.2a1-py3-none-any.whl",
+    "terok-util @ git+https://github.com/sliwowitz/terok-util.git@feat/per-container-supervisor-v2",
 ]
 
 [project.urls]

--- a/src/terok_shield/__init__.py
+++ b/src/terok_shield/__init__.py
@@ -37,12 +37,10 @@ from .config import (
 )
 from .paths import HOOK_ENTRYPOINT_NAME
 from .podman_info import (
-    USER_HOOKS_DIR,
     find_hooks_dirs,
     global_hooks_hint,
     has_global_hooks,
     parse_podman_info,
-    system_hooks_dir,
 )
 from .state import StateBundle
 from .util import is_ip as _is_ip
@@ -67,6 +65,10 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "BinaryCheck": ("terok_shield.prereqs", "BinaryCheck"),
     "ExecError": ("terok_shield.run", "ExecError"),
     "HooksInstaller": ("terok_shield.hooks.install", "HooksInstaller"),
+    "ensure_user_hooks_dir_configured": (
+        "terok_shield.hooks.install",
+        "ensure_user_hooks_dir_configured",
+    ),
     "NftNotFoundError": ("terok_shield.run", "NftNotFoundError"),
     "ShieldNeedsSetup": ("terok_shield.run", "ShieldNeedsSetup"),
     "check_firewall_binaries": ("terok_shield.prereqs", "check_firewall_binaries"),
@@ -132,24 +134,35 @@ class EnvironmentCheck:
 def _read_installed_hook_version(hooks_dirs: list[Path]) -> int | None:
     """Read ``BUNDLE_VERSION`` from the installed ballast module, or ``None``.
 
-    The hooks directory contains the shared ``_oci_state.py`` ballast
-    that both role scripts import from at runtime.  ``BUNDLE_VERSION``
-    lives there as the canonical definition; reading it from a role
-    script would only see a re-import.  Returns ``None`` if the
-    ballast file is absent or unparseable.
+    The ballast (``_oci_state.py``) lives *next to* the role script, not
+    necessarily in *hooks_dirs* — shield's own installer keeps them in
+    one directory, but another package may register a *hooks_dirs* entry
+    that holds only descriptors.  So the ballast is located via the
+    descriptor's ``path`` (the load-bearing reference to the role
+    script) rather than scanned for directly in *hooks_dirs*.
     """
+    import json
     import re
+
+    from .podman_info.hooks_dir import HOOK_JSON_FILENAME
 
     pattern = re.compile(r"^BUNDLE_VERSION\s*=\s*(\d+)", re.MULTILINE)
     for d in hooks_dirs:
-        ballast = d / "_oci_state.py"
-        if ballast.is_file():
-            try:
+        descriptor = d / HOOK_JSON_FILENAME
+        if not descriptor.is_file():
+            continue
+        try:
+            data = json.loads(descriptor.read_text())
+            argv = data.get("hook", {}).get("path")
+            if not isinstance(argv, str):
+                continue
+            ballast = Path(argv).parent / "_oci_state.py"
+            if ballast.is_file():
                 m = pattern.search(ballast.read_text())
                 if m:
                     return int(m.group(1))
-            except (OSError, ValueError):
-                pass
+        except (OSError, ValueError):
+            continue
     return None
 
 
@@ -187,8 +200,12 @@ class Shield:
             ruleset: Ruleset builder (default: from config loopback_ports).
             hub_events: Best-effort emitter for ``shield_up`` / ``shield_down``
                 events bound for the terok-clearance hub (default: a fresh
-                [`HubEventEmitter`][terok_shield.HubEventEmitter] pointed at the canonical socket).
-                Pass a no-op stub in tests that should not touch the socket.
+                [`HubEventEmitter`][terok_shield._hub_events.HubEventEmitter]).  The
+                emitter routes each event to the supervisor's
+                per-container socket using the ``container_id`` supplied
+                on every [`up`][terok_shield.Shield.up] /
+                [`down`][terok_shield.Shield.down] call.  Pass a no-op
+                stub in tests that should not touch the socket.
         """
         from ._hub_events import HubEventEmitter
         from .audit import AuditLogger
@@ -263,8 +280,7 @@ class Shield:
 
         if not info.hooks_dir_persists:
             if global_hooks:
-                sys_dir = system_hooks_dir()
-                hooks = "global-system" if has_global_hooks([sys_dir]) else "global-user"
+                hooks = "global"
                 health = "ok"
                 # Check hook version matches current package
                 hook_ver = _read_installed_hook_version(hooks_dirs)
@@ -360,26 +376,42 @@ class Shield:
         """Return current nft rules for a container."""
         return self._mode.list_rules(container)
 
-    def down(self, container: str, *, allow_all: bool = False) -> None:
-        """Switch a running container to bypass mode."""
+    def down(self, container: str, container_id: str, *, allow_all: bool = False) -> None:
+        """Switch a running container to bypass mode.
+
+        *container* is the operator-facing podman name (audit log key);
+        *container_id* is the full podman UUID — the routing key for
+        the per-container hub socket the supervisor listens on.  The
+        caller knows both at every emit site, so neither carries a
+        default.
+        """
         self._mode.shield_down(container, allow_all=allow_all)
         self.audit.log_event(
             container,
             "shield_down",
             detail="allow_all=True" if allow_all else None,
         )
-        self.hub_events.shield_down(container, allow_all=allow_all, dossier=self._read_dossier())
+        self.hub_events.shield_down(
+            container,
+            container_id,
+            allow_all=allow_all,
+            dossier=self._read_dossier(),
+        )
 
     def quarantine(self, container: str) -> None:
         """Total network blackout — drop all traffic, log dropped traffic."""
         self._mode.shield_quarantine(container)
         self.audit.log_event(container, "shield_quarantine")
 
-    def up(self, container: str) -> None:
-        """Restore normal deny-all mode for a running container."""
+    def up(self, container: str, container_id: str) -> None:
+        """Restore normal deny-all mode for a running container.
+
+        *container* / *container_id* — see
+        [`down`][terok_shield.Shield.down].
+        """
         self._mode.shield_up(container)
         self.audit.log_event(container, "shield_up")
-        self.hub_events.shield_up(container, dossier=self._read_dossier())
+        self.hub_events.shield_up(container, container_id, dossier=self._read_dossier())
 
     def _read_dossier(self) -> dict[str, str]:
         """Resolve the wire dossier for this container by reading the orchestrator's task meta.
@@ -454,7 +486,7 @@ __all__ = [
     "ShieldNeedsSetup",
     "ShieldRuntime",
     "ShieldState",
-    "USER_HOOKS_DIR",
     "check_firewall_binaries",
     "check_krun_binaries",
+    "ensure_user_hooks_dir_configured",
 ]

--- a/src/terok_shield/_hub_events.py
+++ b/src/terok_shield/_hub_events.py
@@ -9,6 +9,14 @@ block notifications for a container whose shield just dropped.  Stays
 stdlib-only so the reader script resource (which bypasses the package)
 can mirror the same wire format without importing this module.
 
+Every emit targets the *per-container* ingester socket under
+``$XDG_RUNTIME_DIR/terok/events/<short_id>.sock``, where ``<short_id>``
+is the 12-char prefix of the container id — the same addressing the
+NFLOG reader uses, and deliberately distinct from the varlink
+subscriber socket at ``terok/clearance/<id>.sock`` that operator UIs
+glob.  Callers therefore supply ``container_id`` (the full podman
+container UUID) on every call; there is no host-wide fallback socket.
+
 Fails silent when the hub isn't listening: flipping shield state must
 never be held up by a desktop-side daemon being absent.
 """
@@ -26,34 +34,46 @@ from terok_shield._wire_sanitize import sanitize, sanitize_mapping
 
 _log = logging.getLogger(__name__)
 
-_SOCKET_BASENAME = "terok-shield-events.sock"
 #: Cap on the socket connect/send syscalls so a dead but unreaped hub
 #: (listener exists, accept thread wedged) can't block the shield CLI
 #: for longer than the operator will patiently hold the keyboard.
 _IO_TIMEOUT_S = 0.5
 
 
-def hub_socket_path() -> Path:
-    """Return the canonical hub ingester path under ``$XDG_RUNTIME_DIR``."""
+def _per_container_hub_socket(container_id: str) -> Path:
+    """Return the per-container ingester path under ``$XDG_RUNTIME_DIR``.
+
+    Mirrors the NFLOG reader's path scheme (12-char short ID under
+    ``terok/events/``) so every event for one container converges on the
+    same supervisor-owned ingester socket — without the truncation
+    match, ``shield_up``/``shield_down`` events and ``pending`` events
+    for the same container land on different sockets.
+    """
     xdg = os.environ.get("XDG_RUNTIME_DIR") or f"/run/user/{os.getuid()}"
-    return Path(xdg) / _SOCKET_BASENAME
+    return Path(xdg) / "terok" / "events" / f"{container_id[:12]}.sock"
 
 
 class HubEventEmitter:
     """One-shot writer of JSON-line events to the hub's unix ingester.
 
-    Each ``emit_*`` call opens a fresh connection, sends a single line,
-    and closes.  The hub stays up across many CLI invocations while each
-    CLI invocation is short-lived — pooling would save nothing and would
-    complicate the fail-silent semantics.
+    Each ``emit_*`` call opens a fresh connection to the per-container
+    socket, sends a single line, and closes.  The hub stays up across
+    many CLI invocations while each CLI invocation is short-lived —
+    pooling would save nothing and would complicate the fail-silent
+    semantics.
     """
 
-    def __init__(self, socket_path: Path | None = None) -> None:
-        """Remember the target socket; defaults to `hub_socket_path`."""
-        self._path = socket_path or hub_socket_path()
-
-    def shield_up(self, container: str, *, dossier: dict[str, str] | None = None) -> None:
+    def shield_up(
+        self,
+        container: str,
+        container_id: str,
+        *,
+        dossier: dict[str, str] | None = None,
+    ) -> None:
         """Emit a ``shield_up`` event for *container* (optional *dossier*).
+
+        *container_id* — full podman container UUID; routes the event
+        to the supervisor's per-container hub socket.
 
         *dossier* mirrors the orchestrator-supplied identity bundle the
         per-container reader already attaches to ``connection_blocked``
@@ -62,24 +82,38 @@ class HubEventEmitter:
         (``project/task · name`` rather than the bare container slug).
         Empty / omitted dossier omits the key entirely.
         """
-        self._send({"type": "shield_up", "container": container}, dossier)
+        self._send(container_id, {"type": "shield_up", "container": container}, dossier)
 
     def shield_down(
         self,
         container: str,
+        container_id: str,
         *,
         allow_all: bool = False,
         dossier: dict[str, str] | None = None,
     ) -> None:
         """Emit a ``shield_down`` (or ``shield_disengaged``) event for *container*.
 
-        *dossier* — see [`shield_up`][terok_shield._hub_events.HubEventEmitter.shield_up].
+        *container_id* — see
+        [`shield_up`][terok_shield._hub_events.HubEventEmitter.shield_up].
+
+        *dossier* — see
+        [`shield_up`][terok_shield._hub_events.HubEventEmitter.shield_up].
         """
         event_type = "shield_disengaged" if allow_all else "shield_down"
-        self._send({"type": event_type, "container": container}, dossier)
+        self._send(container_id, {"type": event_type, "container": container}, dossier)
 
-    def _send(self, payload: dict, dossier: dict[str, str] | None = None) -> None:
-        """Write one JSON line to the hub socket, swallowing all I/O errors.
+    def _send(
+        self,
+        container_id: str,
+        payload: dict,
+        dossier: dict[str, str] | None = None,
+    ) -> None:
+        """Write one JSON line to the per-container ingester socket, swallowing all I/O errors.
+
+        *container_id* selects the destination socket
+        (``$XDG_RUNTIME_DIR/terok/events/<container_id>.sock``); the
+        caller — the shield CLI — knows the full UUID at every emit site.
 
         *dossier* is folded into the payload only when non-empty —
         keeps the wire flat for standalone containers (``podman run``
@@ -98,11 +132,12 @@ class HubEventEmitter:
         if dossier:
             sanitised["dossier"] = sanitize_mapping(dossier)
         line = (json.dumps(sanitised, separators=(",", ":")) + "\n").encode()
+        path = _per_container_hub_socket(container_id)
         try:
             sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
             sock.settimeout(_IO_TIMEOUT_S)
             with contextlib.closing(sock):
-                sock.connect(str(self._path))
+                sock.connect(str(path))
                 sock.sendall(line)
         except OSError as exc:
             # Hub absent, socket path stale, peer buffer full — none of

--- a/src/terok_shield/cli/main.py
+++ b/src/terok_shield/cli/main.py
@@ -80,7 +80,7 @@ def _dispatch(args: argparse.Namespace) -> None:
 
     # CLI-only: setup doesn't need Shield
     if cmd_name == "setup":
-        _cmd_setup(root=getattr(args, "root", False), user=getattr(args, "user", False))
+        _cmd_setup()
         return
 
     # CLI-only: logs with aggregated mode (no container -> scan all)
@@ -220,6 +220,11 @@ def _add_argdef(parser: argparse.ArgumentParser, arg: ArgDef) -> None:
         kwargs["dest"] = arg.dest
     if arg.nargs is not None:
         kwargs["nargs"] = arg.nargs
+    # argparse only accepts ``required`` on optional (``--``) arguments —
+    # positionals are required by definition.  Guard so the registry can
+    # mark optional flags like ``--container-id`` as mandatory.
+    if arg.required and arg.name.startswith("-"):
+        kwargs["required"] = True
     parser.add_argument(arg.name, **kwargs)
 
 
@@ -362,34 +367,12 @@ def _collect_all_audit_entries(state_root: Path, n: int) -> list[dict]:
     return entries[-n:]
 
 
-def _cmd_setup(*, root: bool, user: bool) -> None:
+def _cmd_setup() -> None:
     """Install global OCI hooks for podman < 5.6.0 restart persistence."""
     from ..hooks.install import HooksInstaller
-    from ..podman_info._conf import _user_containers_conf
 
-    if root and user:
-        raise ValueError("--root and --user are mutually exclusive")
-
-    if not root and not user:
-        # Interactive: present options.
-        system, user_installer = HooksInstaller.system(), HooksInstaller.user()
-        print("terok-shield setup: install global OCI hooks\n")
-        print(f"  [r] System-wide (sudo) -> {system.target_dir}")
-        print(f"  [u] User-local         -> {user_installer.target_dir}")
-        print(f"      (+ update {_user_containers_conf()})")
-        print()
-        choice = input("Choose [r/u]: ").strip().lower()
-        if choice == "r":
-            root = True
-        elif choice == "u":
-            user = True
-        else:
-            print("Cancelled.")
-            return
-
-    installer = HooksInstaller.system() if root else HooksInstaller.user()
-    scope = "sudo" if installer.use_sudo else "user"
-    print(f"Installing hooks to {installer.target_dir} ({scope})...")
+    installer = HooksInstaller()
+    print(f"Installing hooks to {installer.target_dir}...")
     installer.install()
     print("Done. Global hooks installed.")
 
@@ -425,7 +408,6 @@ def _build_config(
         state_dir=state_dir,
         mode=mode,
         default_profiles=tuple(file_cfg.default_profiles),
-        loopback_ports=tuple(file_cfg.loopback_ports),
         audit_enabled=file_cfg.audit.enabled,
         profiles_dir=profiles_dir,
     )

--- a/src/terok_shield/commands.py
+++ b/src/terok_shield/commands.py
@@ -106,16 +106,30 @@ def _handle_deny(shield: Shield, container: str, *, target: str) -> None:
         raise RuntimeError(f"No IPs denied for {container}")
 
 
-def _handle_down(shield: Shield, container: str, *, allow_all: bool = False) -> None:
-    """Switch container to bypass mode."""
-    shield.down(container, allow_all=allow_all)
+def _handle_down(
+    shield: Shield,
+    container: str,
+    *,
+    container_id: str,
+    allow_all: bool = False,
+) -> None:
+    """Switch container to bypass mode.
+
+    *container_id* — full podman UUID; supplied by the orchestrator at
+    the call site, used to route the hub event to the supervisor's
+    per-container socket.  Required, no default.
+    """
+    shield.down(container, container_id, allow_all=allow_all)
     label = " (all traffic)" if allow_all else ""
     print(f"Shield down for {container}{label}")
 
 
-def _handle_up(shield: Shield, container: str) -> None:
-    """Restore deny-all mode."""
-    shield.up(container)
+def _handle_up(shield: Shield, container: str, *, container_id: str) -> None:
+    """Restore deny-all mode.
+
+    *container_id* — see ``_handle_down``.
+    """
+    shield.up(container, container_id)
     print(f"Shield up for {container}")
 
 
@@ -206,6 +220,17 @@ _STANDALONE: dict[str, Any] = {"standalone_only": True}
 _NEEDS_CTR_STANDALONE: dict[str, Any] = {"needs_container": True, "standalone_only": True}
 
 
+# ``--container-id`` is the per-container hub socket routing key
+# (full podman UUID).  Every emit-bearing verb (``up`` / ``down``)
+# accepts it as a required option — the caller (terok-sandbox) knows
+# the full UUID at every site that runs ``terok-shield <verb>``.
+_CONTAINER_ID_ARG = ArgDef(
+    name="--container-id",
+    required=True,
+    help="Full podman container UUID — routes hub events to the per-container supervisor socket",
+)
+
+
 # ── Command definitions ───────────────────────────────────
 
 COMMANDS: tuple[CommandDef, ...] = (
@@ -272,6 +297,7 @@ COMMANDS: tuple[CommandDef, ...] = (
         handler=_handle_down,
         extras=_NEEDS_CTR,
         args=(
+            _CONTAINER_ID_ARG,
             ArgDef(
                 name="--all",
                 action="store_true",
@@ -285,6 +311,7 @@ COMMANDS: tuple[CommandDef, ...] = (
         help="Restore deny-all mode for a container",
         handler=_handle_up,
         extras=_NEEDS_CTR,
+        args=(_CONTAINER_ID_ARG,),
     ),
     CommandDef(
         name="quarantine",
@@ -329,10 +356,6 @@ COMMANDS: tuple[CommandDef, ...] = (
         name="setup",
         help="Install global OCI hooks for restart persistence",
         extras=_STANDALONE,
-        args=(
-            ArgDef(name="--root", action="store_true", help="Install system-wide (uses sudo)"),
-            ArgDef(name="--user", action="store_true", help="Install to user directory"),
-        ),
     ),
     CommandDef(
         name="check-environment",

--- a/src/terok_shield/config.py
+++ b/src/terok_shield/config.py
@@ -20,7 +20,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 # ── OCI annotation keys ─────────────────────────────────
 
-# Delimiter for list-valued annotations (profiles, loopback_ports).
+# Delimiter for list-valued annotations (profiles).
 # Podman ≤4.9.x registers --annotation as StringSliceVar (pflag), which
 # splits values on commas.  Fixed in 5.0.0 (containers/podman#20945).
 # Colons are safe across all versions.
@@ -29,7 +29,6 @@ ANNOTATION_LIST_SEP = ":"
 ANNOTATION_KEY = "terok.shield.profiles"
 ANNOTATION_NAME_KEY = "terok.shield.name"
 ANNOTATION_STATE_DIR_KEY = "terok.shield.state_dir"
-ANNOTATION_LOOPBACK_PORTS_KEY = "terok.shield.loopback_ports"
 ANNOTATION_VERSION_KEY = "terok.shield.version"
 ANNOTATION_AUDIT_ENABLED_KEY = "terok.shield.audit_enabled"
 ANNOTATION_UPSTREAM_DNS_KEY = "terok.shield.upstream_dns"
@@ -184,10 +183,6 @@ class ShieldFileConfig(BaseModel):
         default_factory=lambda: ["dev-standard"],
         description="Profiles applied when no explicit list is given",
     )
-    loopback_ports: list[int] = Field(
-        default_factory=list,
-        description="TCP ports forwarded to host loopback (via pasta ``-T``)",
-    )
     audit: AuditFileConfig = Field(
         default_factory=AuditFileConfig, description="Audit logging settings"
     )
@@ -200,23 +195,6 @@ class ShieldFileConfig(BaseModel):
         if not v or not all(isinstance(p, str) and p for p in v):
             raise ValueError("each profile must be a non-empty string")
         return v
-
-    @field_validator("loopback_ports", mode="before")
-    @classmethod
-    def _ports_validated(cls, v: object) -> list[int]:
-        """Validate port entries: reject bools, enforce 1-65535 range."""
-        if isinstance(v, int) and not isinstance(v, bool):
-            v = [v]
-        if not isinstance(v, list):
-            raise ValueError(f"expected list of ints, got {type(v).__name__}")
-        ports: list[int] = []
-        for item in v:
-            if isinstance(item, bool) or not isinstance(item, int):
-                raise ValueError(f"expected integer port, got {type(item).__name__}: {item!r}")
-            if not (1 <= item <= 65535):
-                raise ValueError(f"port {item} out of range 1–65535")
-            ports.append(item)
-        return ports
 
 
 # ── ShieldModeBackend protocol ──────────────────────────

--- a/src/terok_shield/hooks/install.py
+++ b/src/terok_shield/hooks/install.py
@@ -8,10 +8,16 @@ Writes two role-specific entrypoint scripts (``nft-hook`` and
 target hooks directory, alongside the JSON descriptors that tell
 podman to invoke each one at ``createRuntime`` and ``poststop``.
 
+Single layout: scripts and descriptors both land in
+``namespace_state_dir("shield") / "hooks"`` under the operator's
+``paths.root``.  ``containers.conf`` is patched so podman scans that
+path.  Each sibling package owns its own subtree under ``paths.root``
+the same way (see ``terok_sandbox.supervisor.install``).
+
 Public entry points:
 
 - [`HooksInstaller`][terok_shield.hooks.install.HooksInstaller] — global
-  installation lifecycle (install + uninstall) at system or user scope.
+  installation lifecycle (install + uninstall).
 - [`install_hooks`][terok_shield.hooks.install.install_hooks] — per-container
   install used by ``HookMode.pre_start``.
 
@@ -22,18 +28,12 @@ Pure file I/O — no runtime container interaction.
 from __future__ import annotations
 
 import json
-import subprocess  # nosec B404 — sudo escalation for system-wide installs
-import tempfile
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 from ..config import ANNOTATION_KEY
 from ..podman_info._conf import _user_containers_conf
-from ..podman_info.hooks_dir import (
-    USER_HOOKS_DIR,
-    _parse_hooks_dir_from_conf,
-    system_hooks_dir,
-)
+from ..podman_info.hooks_dir import _parse_hooks_dir_from_conf
 from .reader_install import install_reader_resource
 
 #: File name for the shared OCI-state ballast module.  Both role
@@ -66,16 +66,25 @@ def _bridge_hook_json(stage: str) -> str:
     return f"terok-shield-bridge-{stage}.json"
 
 
-#: Every file ``HooksInstaller.install`` writes to ``target_dir``.
-#: Drives ``uninstall`` so the symmetric cleanup never drifts from
-#: the install layout.
-_INSTALLED_FILES: tuple[str, ...] = (
+#: Files ``HooksInstaller.install`` writes to ``target_dir`` — both
+#: the role scripts + ballast and the JSON descriptors podman scans.
+_SCRIPT_FILES: tuple[str, ...] = (
     _BALLAST_NAME,
     _NFT_ENTRYPOINT_NAME,
     _READER_ENTRYPOINT_NAME,
+)
+
+_DESCRIPTOR_FILES: tuple[str, ...] = (
     *(_nft_hook_json(stage) for stage in _HOOK_STAGES),
     *(_bridge_hook_json(stage) for stage in _HOOK_STAGES),
 )
+
+
+def _default_target_dir() -> Path:
+    """Canonical hooks dir under ``paths.root``: ``<state_root>/shield/hooks``."""
+    from ..paths import namespace_state_dir
+
+    return namespace_state_dir("shield") / "hooks"
 
 
 # ── Global installer ────────────────────────────────────
@@ -89,99 +98,48 @@ class HooksInstaller:
     restarts: podman ≥ 5.x drops per-container ``--hooks-dir`` on
     stop/start (containers/podman#17935), so global hooks are the
     only reliable activation path until that upstream regression is
-    fixed.  Two scopes, exposed as classmethod factories:
+    fixed.
 
-    - [`HooksInstaller.system`][terok_shield.hooks.install.HooksInstaller.system] —
-      `/etc/containers/oci/hooks.d` (or the existing equivalent);
-      escalates writes through ``sudo``, visible to root and every user.
-    - [`HooksInstaller.user`][terok_shield.hooks.install.HooksInstaller.user] —
-      `~/.local/share/containers/oci/hooks.d`; rootless, also patches
-      ``hooks_dir`` into the user's ``containers.conf`` so podman
-      discovers it.
+    Scripts, ballast, and JSON descriptors all land in *target_dir*
+    (default: ``namespace_state_dir("shield") / "hooks"``).
+    ``containers.conf`` is patched to register that path so podman
+    discovers the descriptors on the next container start.
 
-    The lifecycle is symmetric: [`install`][terok_shield.hooks.install.HooksInstaller.install]
+    Symmetric lifecycle: [`install`][terok_shield.hooks.install.HooksInstaller.install]
     writes, [`uninstall`][terok_shield.hooks.install.HooksInstaller.uninstall]
     removes.  Both are idempotent.
     """
 
-    target_dir: Path
-    """Directory the hook files (entrypoints, ballast, JSON descriptors) live in."""
-
-    use_sudo: bool = False
-    """Escalate file writes and removals through ``sudo`` (system scope)."""
-
-    register_in_containers_conf: bool = False
-    """Patch ``hooks_dir`` into the user's ``containers.conf`` on install.
-
-    Only meaningful for the user scope — system hooks dirs are
-    discovered by podman without registration.
-    """
-
-    @classmethod
-    def system(cls) -> HooksInstaller:
-        """Installer for the canonical system hooks directory (sudo-escalated).
-
-        Targets the best-existing of ``/etc/containers/oci/hooks.d``
-        and ``/usr/share/containers/oci/hooks.d`` — see
-        [`system_hooks_dir`][terok_shield.podman_info.hooks_dir.system_hooks_dir]
-        for the resolution rule.
-        """
-        return cls(target_dir=system_hooks_dir(), use_sudo=True)
-
-    @classmethod
-    def user(cls) -> HooksInstaller:
-        """Installer for the rootless per-user hooks directory.
-
-        Writes to ``~/.local/share/containers/oci/hooks.d`` and
-        registers that directory in the user's ``containers.conf`` so
-        podman scans it on the next container start.
-        """
-        return cls(
-            target_dir=USER_HOOKS_DIR.expanduser(),
-            use_sudo=False,
-            register_in_containers_conf=True,
-        )
+    target_dir: Path = field(default_factory=_default_target_dir)
+    """Directory the hook scripts, ballast, and JSON descriptors all live in."""
 
     def install(self) -> None:
-        """Write entrypoints, ballast, and JSON descriptors into ``target_dir``.
+        """Write entrypoints, ballast, and descriptors to ``target_dir``.
 
         Both hook pairs (nft + reader) and the shared ballast are
         written unconditionally — the reader hook soft-fails on
         missing clearance, so installing it on a shield-only host
         costs nothing and removes a configuration knob.  The
         standalone NFLOG reader resource is copied to its canonical
-        per-user path regardless of scope.
+        per-user path.
 
-        For [`HooksInstaller.user`][terok_shield.hooks.install.HooksInstaller.user]
-        installs (``register_in_containers_conf=True``), also patches
-        ``hooks_dir`` into the user's ``containers.conf``.
+        ``containers.conf`` is patched to list ``target_dir`` in
+        ``hooks_dir`` so podman discovers the descriptors.
         """
-        # Reader resource is per-user, never under target_dir; install it
-        # before the hook JSONs so the path the JSONs reference is already
-        # populated when the first container fires.
         install_reader_resource()
-        if self.use_sudo:
-            _install_via_sudo(self.target_dir)
-        else:
-            self.target_dir.mkdir(parents=True, exist_ok=True)
-            _write_role_files(self.target_dir, self.target_dir)
-        if self.register_in_containers_conf:
-            _register_hooks_dir_in_containers_conf(self.target_dir)
+        self.target_dir.mkdir(parents=True, exist_ok=True)
+        _write_role_files(self.target_dir, self.target_dir)
+        ensure_user_hooks_dir_configured(self.target_dir)
 
     def uninstall(self) -> None:
         """Remove every hook file [`install`][terok_shield.hooks.install.HooksInstaller.install] would write.
 
-        Idempotent — missing files are tolerated.  When ``use_sudo``
-        is set, deletion runs under ``sudo`` so the calling process
-        stays unprivileged.  Containers.conf is left untouched: the
-        user's other hook directories may still need the entry.
+        Idempotent — missing files are tolerated.  ``containers.conf``
+        is left untouched: other terok packages may still register
+        their own ``hooks_dir`` entries the operator wants to keep.
         """
-        paths = [self.target_dir / name for name in _INSTALLED_FILES]
-        if self.use_sudo:
-            _remove_via_sudo(paths)
-        else:
-            for path in paths:
-                path.unlink(missing_ok=True)
+        for name in (*_SCRIPT_FILES, *_DESCRIPTOR_FILES):
+            (self.target_dir / name).unlink(missing_ok=True)
 
     def is_installed(self) -> bool:
         """True when ``target_dir`` carries the canonical createRuntime hook JSON.
@@ -209,7 +167,7 @@ def install_hooks(*, hook_entrypoint: Path, hooks_dir: Path) -> None:
     their canonical names.
 
     WORKAROUND(hooks-dir-persist): currently only used for global
-    hooks (user or root) because podman does not persist per-container
+    hooks because podman does not persist per-container
     ``--hooks-dir`` across stop/start.  The per-container code path is
     kept for near-future use.
 
@@ -227,50 +185,10 @@ def install_hooks(*, hook_entrypoint: Path, hooks_dir: Path) -> None:
 # ── Installation mechanics ──────────────────────────────
 
 
-def _install_via_sudo(target_dir: Path) -> None:
-    """Write hooks to a temp dir, then sudo-copy to the target."""
-    with tempfile.TemporaryDirectory() as tmp:
-        tmp_path = Path(tmp)
-        # JSONs must reference the final script paths, not the temp
-        # copies — pass the install target as the JSON-side anchor.
-        _write_role_files(tmp_path, tmp_path, json_dir=target_dir)
-
-        subprocess.run(
-            ["sudo", "mkdir", "-p", str(target_dir)],
-            check=True,  # noqa: S603, S607
-        )
-        files = [str(tmp_path / name) for name in _INSTALLED_FILES]
-        subprocess.run(
-            ["sudo", "cp", *files, str(target_dir) + "/"],
-            check=True,  # noqa: S603, S607
-        )
-        subprocess.run(
-            [
-                "sudo",
-                "chmod",
-                "+x",
-                str(target_dir / _NFT_ENTRYPOINT_NAME),
-                str(target_dir / _READER_ENTRYPOINT_NAME),
-            ],  # noqa: S603, S607
-            check=True,
-        )
-
-
-def _remove_via_sudo(paths: list[Path]) -> None:
-    """Remove *paths* via ``sudo rm -f`` — idempotent, no error on missing files."""
-    if not paths:
-        return
-    subprocess.run(
-        ["sudo", "rm", "-f", *(str(p) for p in paths)],
-        check=True,  # noqa: S603, S607
-    )
-
-
 def _write_role_files(
     script_dir: Path,
     hooks_dir: Path,
     *,
-    json_dir: Path | None = None,
     nft_entrypoint_name: str = _NFT_ENTRYPOINT_NAME,
 ) -> None:
     """Write nft + reader entrypoints, the shared ballast, and the four hook JSONs.
@@ -278,35 +196,37 @@ def _write_role_files(
     The two role scripts and the ``_oci_state.py`` ballast all land in
     *script_dir*; each role script imports the ballast as a sibling at
     runtime (Python's default ``sys.path[0]`` is the script's
-    directory).
-
-    Hook JSONs go into *hooks_dir* and reference the script paths
-    under *json_dir* (defaulting to *script_dir* when the install is
-    in-place, or the final target when staged for ``sudo cp``).
+    directory).  Hook JSONs go into *hooks_dir* and reference the
+    script paths under *script_dir*.
 
     Args:
         script_dir: Where to write ``_oci_state.py``, the nft
             entrypoint, and the reader entrypoint.
         hooks_dir: Where to write the four ``terok-shield*.json`` files.
-        json_dir: Path to embed in hook JSONs.  Defaults to
-            *script_dir*; overridden for sudo installs where the temp
-            write location differs from the final install path.
         nft_entrypoint_name: On-disk filename for the nft entrypoint.
             Defaults to the canonical ``terok-shield-hook``; callers
             pinning a non-default path (``install_hooks``) thread
             their own filename through so the JSON descriptors point
             at the script the caller asked for.
     """
-    anchor = json_dir or script_dir
+    from ..paths import reader_script_path
 
     (script_dir / _BALLAST_NAME).write_text((_RESOURCES / _BALLAST_NAME).read_text())
     (script_dir / nft_entrypoint_name).write_text((_RESOURCES / "nft_hook.py").read_text())
-    (script_dir / _READER_ENTRYPOINT_NAME).write_text((_RESOURCES / "reader_hook.py").read_text())
+    # The reader hook carries an absolute path to the NFLOG reader
+    # script as a baked constant; rewrite the placeholder so the hook
+    # always finds the reader exactly where ``reader_script_path()``
+    # resolved at this ``terok-shield setup`` call.
+    reader_hook_source = (_RESOURCES / "reader_hook.py").read_text()
+    reader_hook_rendered = reader_hook_source.replace(
+        '"__READER_SCRIPT_PATH__"', json.dumps(str(reader_script_path()))
+    )
+    (script_dir / _READER_ENTRYPOINT_NAME).write_text(reader_hook_rendered)
     (script_dir / nft_entrypoint_name).chmod(0o755)
     (script_dir / _READER_ENTRYPOINT_NAME).chmod(0o755)
 
-    nft_path = str(anchor / nft_entrypoint_name)
-    reader_path = str(anchor / _READER_ENTRYPOINT_NAME)
+    nft_path = str(script_dir / nft_entrypoint_name)
+    reader_path = str(script_dir / _READER_ENTRYPOINT_NAME)
     for stage in _HOOK_STAGES:
         (hooks_dir / _nft_hook_json(stage)).write_text(
             _generate_hook_json(nft_path, stage, nft_entrypoint_name)
@@ -316,20 +236,32 @@ def _write_role_files(
         )
 
 
-# ── containers.conf registration (user scope only) ──────
+# ── containers.conf registration ────────────────────────
 
 
-def _register_hooks_dir_in_containers_conf(hooks_dir: Path) -> None:
+def ensure_user_hooks_dir_configured(hooks_dir: Path | None = None) -> None:
     """Ensure ``~/.config/containers/containers.conf`` lists *hooks_dir*.
 
-    Creates the file if absent.  Inserts ``hooks_dir`` into the
+    The canonical SSOT for the rootless OCI hooks directory across
+    every terok package: shield calls it at ``setup`` time; other
+    installers (e.g. terok-sandbox's per-container supervisor) call
+    it before dropping their own descriptors so they don't have to
+    re-implement the containers.conf patcher.  Idempotent.
+
+    *hooks_dir* defaults to ``namespace_state_dir("shield") / "hooks"``
+    — shield's canonical install location under ``paths.root``.
+
+    Creates the conf file if absent.  Inserts ``hooks_dir`` into the
     existing ``[engine]`` section or appends a new section if none
-    exists.  Warns (does not fail) when ``hooks_dir`` is already set
-    to a different value — the operator owns containers.conf and may
-    have intentionally pinned a different location.
+    exists.  Skips silently when *hooks_dir* is already listed.  When
+    a different ``hooks_dir`` is configured, appends ours to the list
+    rather than failing — the operator owns containers.conf and may
+    have intentionally pinned other locations.
 
     Pure line-based editing — comments and formatting are preserved.
     """
+    if hooks_dir is None:
+        hooks_dir = _default_target_dir()
     conf_path = _user_containers_conf()
     hooks_str = str(hooks_dir)
     hooks_line = f'hooks_dir = ["{hooks_str}"]'
@@ -346,10 +278,7 @@ def _register_hooks_dir_in_containers_conf(hooks_dir: Path) -> None:
 
     if hooks_str in existing or str(hooks_dir.expanduser()) in existing:
         return  # already configured
-    print(
-        f"Warning: {conf_path} already has hooks_dir = {existing}\n"
-        f"Add {hooks_str!r} to the list manually if needed."
-    )
+    _append_to_hooks_dir(conf_path, hooks_str)
 
 
 def _insert_hooks_line(conf_path: Path, hooks_line: str) -> None:
@@ -363,6 +292,42 @@ def _insert_hooks_line(conf_path: Path, hooks_line: str) -> None:
     # No [engine] section — append one.
     with conf_path.open("a") as f:
         f.write(f"\n[engine]\n{hooks_line}\n")
+
+
+def _append_to_hooks_dir(conf_path: Path, new_entry: str) -> None:
+    """Append *new_entry* to the existing ``hooks_dir = [...]`` list in place."""
+    import re
+
+    text = conf_path.read_text()
+    # The trailing group absorbs optional whitespace plus an inline ``# …``
+    # comment so a commented line (``hooks_dir = ["/x"]  # note``) still
+    # matches and the comment is preserved verbatim after the rewrite.
+    list_pattern = re.compile(
+        r"^(\s*hooks_dir\s*=\s*\[)(.*?)(\])([^\S\n]*(?:#[^\n]*)?)$",
+        re.MULTILINE | re.DOTALL,
+    )
+
+    def _list_repl(m: re.Match[str]) -> str:
+        body = m.group(2).rstrip()
+        sep = ", " if body and not body.endswith(",") else ""
+        return f'{m.group(1)}{body}{sep}"{new_entry}"{m.group(3)}{m.group(4)}'
+
+    new_text, count = list_pattern.subn(_list_repl, text, count=1)
+    if count:
+        conf_path.write_text(new_text)
+        return
+
+    # Scalar form: ``hooks_dir = "/path"`` — promote to a two-element list.
+    scalar_pattern = re.compile(
+        r'^(\s*hooks_dir\s*=\s*)"([^"]+)"([^\S\n]*(?:#[^\n]*)?)$', re.MULTILINE
+    )
+
+    def _scalar_repl(m: re.Match[str]) -> str:
+        return f'{m.group(1)}["{m.group(2)}", "{new_entry}"]{m.group(3)}'
+
+    new_text, count = scalar_pattern.subn(_scalar_repl, text, count=1)
+    if count:
+        conf_path.write_text(new_text)
 
 
 # ── Generators ──────────────────────────────────────────

--- a/src/terok_shield/hooks/mode.py
+++ b/src/terok_shield/hooks/mode.py
@@ -30,7 +30,6 @@ from ..config import (
     ANNOTATION_DNS_TIER_KEY,
     ANNOTATION_KEY,
     ANNOTATION_LIST_SEP,
-    ANNOTATION_LOOPBACK_PORTS_KEY,
     ANNOTATION_NAME_KEY,
     ANNOTATION_STATE_DIR_KEY,
     ANNOTATION_UPSTREAM_DNS_KEY,
@@ -143,11 +142,17 @@ class HookMode:
         upstream_dns = _upstream_dns_for_mode(mode)
         gw_v4, gw_v6 = self._gateways = _gateways_for_mode(mode)
 
-        # Resolve DNS, write allowlists, generate ruleset + dnsmasq config
+        # Resolve DNS, write allowlists, generate ruleset + dnsmasq config.
+        # ``loopback.ports`` is persisted before ``_write_ruleset`` runs so
+        # the builder reads ports from the bundle (SSOT): later up/down
+        # rebuilds use the same source.
         entries = self._profiles.compose_profiles(profiles)
         self._resolve_and_write_allowlists(sd, tier, entries)
         StateBundle(sd).upstream_dns.write_text(f"{upstream_dns}\n")
         StateBundle(sd).dns_tier.write_text(f"{tier.value}\n")
+        StateBundle(sd).loopback_ports.write_text(
+            "".join(f"{p}\n" for p in self._config.loopback_ports)
+        )
         self._write_ruleset(sd, tier, upstream_dns, gw_v4, gw_v6)
         self._write_dnsmasq_config_or_scrub(sd, tier, upstream_dns)
 
@@ -159,8 +164,9 @@ class HookMode:
         if tier == DnsTier.DNSMASQ:
             args += ["--volume", f"{StateBundle(sd).resolv_conf}:/etc/resolv.conf:ro,Z"]
 
-        # Annotations: profiles, name, state_dir, loopback_ports, version, dns
-        ports_str = ANNOTATION_LIST_SEP.join(str(p) for p in self._config.loopback_ports)
+        # Annotations: profiles, name, state_dir, version, dns.  loopback_ports
+        # lives in the state bundle (per-container, written above), not as an
+        # annotation — annotations are write-only on shield's side.
         args += [
             "--annotation",
             f"{ANNOTATION_KEY}={ANNOTATION_LIST_SEP.join(profiles)}",
@@ -168,8 +174,6 @@ class HookMode:
             f"{ANNOTATION_NAME_KEY}={container}",
             "--annotation",
             f"{ANNOTATION_STATE_DIR_KEY}={sd}",
-            "--annotation",
-            f"{ANNOTATION_LOOPBACK_PORTS_KEY}={ports_str}",
             "--annotation",
             f"{ANNOTATION_VERSION_KEY}={state.BUNDLE_VERSION}",
             "--annotation",
@@ -235,7 +239,7 @@ class HookMode:
         set_timeout = NFT_SET_TIMEOUT_DNSMASQ if tier == DnsTier.DNSMASQ else ""
         ruleset_builder = RulesetBuilder(
             dns=upstream_dns,
-            loopback_ports=self._config.loopback_ports,
+            loopback_ports=StateBundle(sd).read_loopback_ports(),
             gateway_v4=gw_v4,
             gateway_v6=gw_v6,
             set_timeout=set_timeout,
@@ -586,7 +590,7 @@ class HookMode:
         gw_v4, gw_v6 = self._gateways
         return RulesetBuilder(
             dns=dns,
-            loopback_ports=self._config.loopback_ports,
+            loopback_ports=StateBundle(sd).read_loopback_ports(),
             gateway_v4=gw_v4,
             gateway_v6=gw_v6,
             set_timeout=set_timeout,

--- a/src/terok_shield/paths.py
+++ b/src/terok_shield/paths.py
@@ -7,23 +7,26 @@ Per-container state paths live in [`terok_shield.state`][terok_shield.state].  T
 module is the single source of truth for artifacts shared across
 containers or installed into host-wide locations:
 
-- the NFLOG reader script's canonical install path (XDG data home);
+- the NFLOG reader script's canonical install path (under
+  ``paths.root`` via [`namespace_state_dir`][terok_util.paths.namespace_state_dir]);
 - the hook entrypoint filename used both under the user's
   ``containers/oci/hooks.d/`` and inside each per-container
   ``state_dir``.
 
-The reader-script path is computed in two places: ``reader_script_path()``
-in this module, and its stdlib-only mirror ``_reader_script_path()`` in
-``resources/reader_hook.py`` — that file cannot import from this package
-at runtime, so the computation is inlined there verbatim.  When either
-definition changes, the other must be updated by hand; the synced pair
-is the contract.
+The reader-script path is computed once in this module.  The
+``resources/reader_hook.py`` script cannot import from terok_shield
+at runtime (it runs under ``/usr/bin/python3`` outside any venv); the
+installer rewrites that script's ``_READER_SCRIPT_PATH`` placeholder
+with the resolved path at install time, so the on-disk hook always
+points at wherever ``reader_script_path()`` resolved when ``terok-shield
+setup`` ran.
 """
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
+
+from terok_util.paths import namespace_state_dir
 
 HOOK_ENTRYPOINT_NAME = "terok-shield-hook"
 """Canonical filename of the shield OCI hook entrypoint script.
@@ -38,9 +41,11 @@ the same constant means renaming the entrypoint is a single edit.
 def reader_script_path() -> Path:
     """Return the on-disk path where the NFLOG reader script is installed.
 
-    Respects ``XDG_DATA_HOME`` when set, otherwise falls back to the
-    POSIX default ``~/.local/share``.  Mirrors the stdlib-only
-    ``_reader_script_path()`` inlined in ``resources/reader_hook.py``.
+    Honours the operator's ``paths.root`` config via
+    [`namespace_state_dir`][terok_util.paths.namespace_state_dir] —
+    when ``config.yml`` sets ``paths.root: /virt/terok/state`` the
+    script lands at ``/virt/terok/state/shield/nflog-reader.py``;
+    without that override it falls back to the platform-default XDG
+    data dir.
     """
-    data_home = os.environ.get("XDG_DATA_HOME") or f"{os.environ.get('HOME', '')}/.local/share"
-    return Path(data_home) / "terok" / "shield" / "nflog-reader.py"
+    return namespace_state_dir("shield") / "nflog-reader.py"

--- a/src/terok_shield/podman_info/__init__.py
+++ b/src/terok_shield/podman_info/__init__.py
@@ -17,11 +17,9 @@ to import from the specific submodule when intent is clearer.
 
 from .hooks_dir import (
     HOOK_JSON_FILENAME,
-    USER_HOOKS_DIR,
     find_hooks_dirs,
     global_hooks_hint,
     has_global_hooks,
-    system_hooks_dir,
 )
 from .info import HOOKS_DIR_PERSIST_VERSION, PodmanInfo, parse_podman_info
 from .network import parse_resolv_conf, parse_slirp4netns_cidr, slirp4netns_gateway
@@ -30,7 +28,6 @@ __all__ = [
     "HOOKS_DIR_PERSIST_VERSION",
     "HOOK_JSON_FILENAME",
     "PodmanInfo",
-    "USER_HOOKS_DIR",
     "find_hooks_dirs",
     "global_hooks_hint",
     "has_global_hooks",
@@ -38,5 +35,4 @@ __all__ = [
     "parse_resolv_conf",
     "parse_slirp4netns_cidr",
     "slirp4netns_gateway",
-    "system_hooks_dir",
 ]

--- a/src/terok_shield/podman_info/hooks_dir.py
+++ b/src/terok_shield/podman_info/hooks_dir.py
@@ -13,40 +13,29 @@ from pathlib import Path
 
 from ._conf import _SYSTEM_CONF_PATHS, _user_containers_conf
 
-# Well-known system hooks directories (containers-common standard).
-# Used as fallback when containers.conf doesn't specify hooks_dir.
-_SYSTEM_HOOKS_DIRS = (
-    Path("/usr/share/containers/oci/hooks.d"),
-    Path("/etc/containers/oci/hooks.d"),
-)
-
 # Hook JSON filename used to detect terok-shield global hooks.
 HOOK_JSON_FILENAME = "terok-shield-createRuntime.json"
-
-USER_HOOKS_DIR: Path = Path("~/.local/share/containers/oci/hooks.d")
 
 
 def find_hooks_dirs() -> list[Path]:
     """Find hooks directories podman would check.
 
     Reads ``containers.conf`` (user config overrides system config).
-    Falls back to well-known system defaults if nothing is configured.
-
-    Returns directories in precedence order (last wins for podman).
+    Returns the configured directories in precedence order (last wins
+    for podman).  Empty when no ``hooks_dir`` entry is configured —
+    terok always patches ``containers.conf`` at setup time, so an
+    empty result implies setup has not run.
     """
-    # User config takes precedence over system config
     user_dirs = _parse_hooks_dir_from_conf(_user_containers_conf())
     if user_dirs:
         return [Path(d).expanduser() for d in user_dirs]
 
-    # System configs (checked in order, last found wins)
     for conf_path in reversed(_SYSTEM_CONF_PATHS):
         dirs = _parse_hooks_dir_from_conf(conf_path)
         if dirs:
             return [Path(d).expanduser() for d in dirs]
 
-    # No config → well-known system defaults (only existing ones)
-    return [d for d in _SYSTEM_HOOKS_DIRS if d.is_dir()]
+    return []
 
 
 def has_global_hooks(hooks_dirs: list[Path] | None = None) -> bool:
@@ -59,17 +48,6 @@ def has_global_hooks(hooks_dirs: list[Path] | None = None) -> bool:
     if hooks_dirs is None:
         hooks_dirs = find_hooks_dirs()
     return any((d / HOOK_JSON_FILENAME).is_file() for d in hooks_dirs)
-
-
-def system_hooks_dir() -> Path:
-    """Return the best system-level hooks directory.
-
-    Prefers existing directories; falls back to ``/etc/containers/oci/hooks.d``.
-    """
-    for d in _SYSTEM_HOOKS_DIRS:
-        if d.is_dir():
-            return d
-    return _SYSTEM_HOOKS_DIRS[-1]
 
 
 def global_hooks_hint() -> str:

--- a/src/terok_shield/resources/_oci_state.py
+++ b/src/terok_shield/resources/_oci_state.py
@@ -41,12 +41,18 @@ ANN_STATE_DIR = "terok.shield.state_dir"
 ANN_VERSION = "terok.shield.version"
 """OCI annotation carrying the bundle version this container was prepared with."""
 
-BUNDLE_VERSION = 13
+BUNDLE_VERSION = 14
 """Wire-protocol version for the hook ↔ pre_start state-bundle contract.
 
 Bumped whenever the on-disk file layout, the hook → reader argv
 shape, or the wire payload changes incompatibly.  The nft hook hard-
 fails on a version mismatch — operator must re-run ``terok setup``.
+
+v14: per-container host-loopback TCP ports are persisted at pre_start
+time as ``state_dir/loopback.ports`` (newline-separated list).
+Replaces the host-singleton ``loopback_ports`` ``config.yml`` field
+that couldn't represent the dynamically-allocated broker / signer
+ports the supervisor binds.
 
 v13: ``dnsmasq.conf`` ``listen-address`` is runtime-dependent
 (``127.0.0.1`` by default; ``169.254.1.3`` under krun); the nft

--- a/src/terok_shield/resources/nflog_reader.py
+++ b/src/terok_shield/resources/nflog_reader.py
@@ -170,20 +170,26 @@ def main() -> None:  # pragma: no cover — real argparse + subprocess re-exec
     On first entry (``_TEROK_SHIELD_NFLOG_NSENTER`` unset) this process re-execs
     itself under ``nsenter`` — with ``podman unshare`` prepended when we're not
     already in ``NS_ROOTLESS`` — so the NFLOG bind happens in the container's
-    netns.  The re-exec carries the same ``--emit`` and ``--annotations`` choice
-    forward, so the destination (unix socket or stdout JSON) and the orchestrator
-    dossier stay whatever the caller picked.
+    netns.  The re-exec carries the same ``--emit``, ``--annotations``,
+    ``--container-id`` and ``--hub-socket`` choice forward, so the destination
+    (unix socket or stdout JSON), the per-container hub path, and the
+    orchestrator dossier all stay whatever the caller picked.
     """
     args = _parse_args()
     logging.basicConfig(level=logging.INFO, format="nflog-reader: %(message)s")
 
     if os.environ.get(_NSENTER_ENV) != "1":
         _reexec_inside_container_netns(
-            args.state_dir, args.container, args.emit, args.annotations_raw
+            args.state_dir,
+            args.container,
+            args.emit,
+            args.annotations_raw,
+            args.container_id,
+            args.hub_socket,
         )
         return
 
-    emitter = _select_emitter(args.emit)
+    emitter = _select_emitter(args.emit, args.container_id, args.hub_socket)
     session = ReaderSession(
         state_dir=args.state_dir,
         container=args.container,
@@ -196,17 +202,56 @@ def main() -> None:  # pragma: no cover — real argparse + subprocess re-exec
         emitter.close()
 
 
-def _select_emitter(mode: str) -> EventEmitter:
-    """Pick the emitter matching ``--emit`` — socket by default, JSON for the CLI."""
+def _select_emitter(mode: str, container_id: str = "", hub_socket: str = "") -> EventEmitter:
+    """Pick the emitter matching ``--emit`` — socket by default, JSON for the CLI.
+
+    The socket emitter's target is resolved by ``_resolve_hub_socket_path``,
+    which honours an explicit ``--hub-socket`` override or a per-container
+    path derived from ``--container-id``.
+    """
     if mode == "json":
         return JsonEmitter()
-    return SocketEmitter(_events_socket_path())
+    return SocketEmitter(_resolve_hub_socket_path(container_id, hub_socket))
 
 
-def _events_socket_path() -> Path:
-    """Return the canonical hub-ingester socket path (mirrors ``terok_clearance``)."""
+def _resolve_hub_socket_path(container_id: str = "", hub_socket: str = "") -> Path:
+    """Return the hub-ingester socket path the reader should connect to.
+
+    Resolution order, matching the per-container-supervisor model:
+
+    1. ``--hub-socket`` (verbatim) — operator / supervisor explicitly pointed
+       us at a socket.  Wins outright.
+    2. ``--container-id`` — build the per-container path under
+       ``$XDG_RUNTIME_DIR/terok/events/<container_id>.sock``.  The
+       supervisor for *this* container ingests there.  This is the
+       reader-facing *ingester* socket and is deliberately distinct from
+       the varlink subscriber socket at ``terok/clearance/<id>.sock``
+       (which operator UIs glob and connect to) — the reader speaks raw
+       line-JSON, not varlink, so the two roles need separate sockets.
+
+    Raises ``SystemExit`` when neither is supplied — the OCI bridge hook
+    always passes ``--container-id``, so a missing value indicates a
+    misconfigured direct CLI invocation rather than a runtime fallback.
+
+    ``XDG_RUNTIME_DIR`` is honoured when set; the hook always exports it
+    (``_oci_state.bootstrap_env``) before spawning the reader, so the
+    ``os.getuid()`` fallback only ever fires on a direct CLI invocation
+    in the operator's own user namespace.
+    """
+    if hub_socket:
+        return Path(hub_socket)
+    if not container_id:
+        raise SystemExit(
+            "neither --hub-socket nor --container-id supplied; cannot resolve hub socket"
+        )
+    # AF_UNIX's ``sun_path`` is 108 bytes; the full 64-char container
+    # UUID under ``$XDG_RUNTIME_DIR/terok/events/<id>.sock`` lands
+    # right at the limit.  Use the 12-char podman short-ID convention,
+    # matching terok-sandbox supervisor's [`SupervisorPaths.for_container`][terok_sandbox.supervisor.main.SupervisorPaths.for_container]
+    # — both sides agree on the same per-container ingester socket name.
+    short_id = container_id[:12]
     xdg = os.environ.get("XDG_RUNTIME_DIR") or f"/run/user/{os.getuid()}"
-    return Path(xdg) / "terok-shield-events.sock"
+    return Path(xdg) / "terok" / "events" / f"{short_id}.sock"
 
 
 # ── nsenter re-exec ───────────────────────────────────────────────────
@@ -217,7 +262,12 @@ def _events_socket_path() -> Path:
 
 
 def _reexec_inside_container_netns(
-    state_dir: Path, container: str, emit: str, annotations_raw: str
+    state_dir: Path,
+    container: str,
+    emit: str,
+    annotations_raw: str,
+    container_id: str,
+    hub_socket: str,
 ) -> None:  # pragma: no cover — real subprocess re-exec
     """Re-enter this script inside the container's netns so NFLOG is reachable.
 
@@ -231,6 +281,12 @@ def _reexec_inside_container_netns(
     arrived avoids one round of dict→JSON re-encoding (and the dict-key-order
     drift it would inflict on the cmdline that ``_is_our_reader`` later compares
     against).
+
+    ``container_id`` (per-container hub socket key) and ``hub_socket``
+    (explicit override) flow through unchanged so the second invocation
+    resolves the same socket path the first one did — empty strings are
+    forwarded as empty-valued flags rather than omitting the flag, which
+    keeps the cmdline shape stable for ``_is_our_reader``.
     """
     pid = _podman_container_pid(container)
     script = Path(__file__).resolve()
@@ -244,6 +300,8 @@ def _reexec_inside_container_netns(
         container,
         f"--emit={emit}",
         f"--annotations={annotations_raw}",
+        f"--container-id={container_id}",
+        f"--hub-socket={hub_socket}",
     ]
     cmd = (
         [nsenter, "-t", pid, "-n", *tail]
@@ -956,6 +1014,25 @@ def _parse_args() -> argparse.Namespace:  # pragma: no cover — thin argparse w
             "container_name, meta_path, …) extracted from the container's "
             "``dossier.*`` OCI annotations.  Forwarded verbatim through the "
             "nsenter re-exec; defaults to ``{}`` for orchestrator-less use."
+        ),
+    )
+    parser.add_argument(
+        "--container-id",
+        default="",
+        help=(
+            "Full podman container UUID used to construct the per-container "
+            "ingester socket path (``$XDG_RUNTIME_DIR/terok/events/<id>.sock``).  "
+            "Set by the OCI bridge hook from the container's full id; required "
+            "unless ``--hub-socket`` is given."
+        ),
+    )
+    parser.add_argument(
+        "--hub-socket",
+        default="",
+        help=(
+            "Explicit hub-ingester socket path — overrides the per-container "
+            "default derived from ``--container-id``.  Lets a supervisor point "
+            "the reader at any socket directly without exposing UUID conventions."
         ),
     )
     args = parser.parse_args()

--- a/src/terok_shield/resources/reader_hook.py
+++ b/src/terok_shield/resources/reader_hook.py
@@ -78,7 +78,8 @@ def _bridge_main(oci: dict, sd: Path, stage: str, log_path: Path) -> None:
         _oci_state.log(f"terok-shield bridge hook: unknown stage {stage!r}", log_path)
         return
 
-    container_id = str(oci.get("id") or "")[:12]
+    full_container_id = str(oci.get("id") or "")
+    container_id = full_container_id[:12]
     if not container_id:
         _oci_state.log("terok-shield bridge hook: missing container id — skipping reader", log_path)
         return
@@ -90,7 +91,7 @@ def _bridge_main(oci: dict, sd: Path, stage: str, log_path: Path) -> None:
     # they need to resolve dossiers for their hub events.  Spawn is the
     # costly step; the file write is one syscall and soft-fails on its own.
     _oci_state.persist_meta_path(sd, dossier.get("meta_path", ""))
-    _spawn_reader(sd, container_id, dossier)
+    _spawn_reader(sd, container_id, dossier, full_container_id)
 
 
 def _extract_dossier(annotations: dict) -> dict[str, str]:
@@ -111,7 +112,12 @@ def _extract_dossier(annotations: dict) -> dict[str, str]:
     return out
 
 
-def _spawn_reader(sd: Path, container_id: str, dossier: dict[str, str] | None = None) -> None:
+def _spawn_reader(
+    sd: Path,
+    container_id: str,
+    dossier: dict[str, str] | None = None,
+    full_container_id: str = "",
+) -> None:
     """Start the NFLOG reader for *container_id* as a detached child.
 
     No-op when the reader script is missing (``--no-dbus-bridge``
@@ -125,6 +131,14 @@ def _spawn_reader(sd: Path, container_id: str, dossier: dict[str, str] | None = 
     forwarded to the reader as a JSON-encoded ``--annotations`` argv
     element so the reader (which composes the wire payload) doesn't
     re-parse the OCI state itself.
+
+    *full_container_id* — the full podman container UUID (not truncated).
+    Passed through as ``--container-id`` so the reader can resolve its
+    per-container ingester socket at
+    ``$XDG_RUNTIME_DIR/terok/events/<id>.sock`` — the path the
+    per-container supervisor ingests on.  The hook bails out earlier
+    when the OCI state has no ``id`` field, so ``--container-id`` is
+    always populated by the time we Popen the reader.
     """
     reader = _reader_script_path()
     if not reader.exists():
@@ -162,6 +176,7 @@ def _spawn_reader(sd: Path, container_id: str, dossier: dict[str, str] | None = 
                 container_id,
                 "--emit=socket",
                 f"--annotations={annotations_json}",
+                f"--container-id={full_container_id}",
             ],
             env=env,
             stdin=subprocess.DEVNULL,
@@ -281,10 +296,18 @@ def _is_our_reader(pid_int: int, sd: Path) -> bool:
     return args[0].endswith(b"python3") and args[1] == script_bytes and sd_bytes in args[2:]
 
 
+#: Absolute path to the NFLOG reader script, baked into the hook by
+#: ``terok-shield setup`` at install time.  The literal placeholder
+#: below is what the installer rewrites; running this script
+#: unmodified is intentionally an error so a half-installed setup
+#: surfaces fast.  See [`terok_shield.paths.reader_script_path`][terok_shield.paths.reader_script_path]
+#: for the resolver the installer uses.
+_READER_SCRIPT_PATH: str = "__READER_SCRIPT_PATH__"
+
+
 def _reader_script_path() -> Path:
-    """Return the on-disk path ``terok setup`` places the reader script at."""
-    data_home = os.environ.get("XDG_DATA_HOME") or f"{os.environ.get('HOME', '')}/.local/share"
-    return Path(data_home) / "terok" / "shield" / "nflog-reader.py"
+    """Return the path the installer baked into this hook copy."""
+    return Path(_READER_SCRIPT_PATH)
 
 
 def _session_bus_address() -> str | None:

--- a/src/terok_shield/state.py
+++ b/src/terok_shield/state.py
@@ -19,6 +19,7 @@ Bundle layout::
     ├── ruleset.nft                    # pre-generated nft ruleset (gateways baked in)
     ├── upstream.dns                   # upstream DNS address
     ├── dns.tier                       # active DNS tier (dig/getent/dnsmasq)
+    ├── loopback.ports                 # per-container host-loopback TCP ports (newline-separated)
     ├── profile.allowed                # IPs from DNS resolution
     ├── profile.domains                # domain names for dnsmasq config
     ├── live.allowed                   # IPs from allow/deny
@@ -41,7 +42,7 @@ from pathlib import Path
 
 from .paths import HOOK_ENTRYPOINT_NAME
 
-BUNDLE_VERSION = 13
+BUNDLE_VERSION = 14
 """Integer version of the state bundle layout.
 
 Bumped whenever the file layout changes in a backwards-incompatible way.
@@ -51,11 +52,11 @@ stale on-disk entrypoint — bump it whenever the entrypoint *protocol*
 changes even if the file layout itself is unchanged, so that
 ``terok setup`` rewrites the script instead of short-circuiting.
 
-Current shape (v13): ``dnsmasq.conf`` ``listen-address`` is runtime-
-dependent (``127.0.0.1`` by default, link-local under krun); the OCI
-hook runs ``ip addr add`` inside the netns for non-loopback binds
-before launching dnsmasq.  Earlier shapes are recoverable via
-``git log -L /^BUNDLE_VERSION/:src/terok_shield/state.py``.
+Current shape (v14): ``loopback.ports`` is now persisted per-container
+at pre_start time — replaces the host-singleton ``loopback_ports``
+config-file field that couldn't represent the per-container broker /
+signer ports the supervisor binds.  Earlier shapes are recoverable
+via ``git log -L /^BUNDLE_VERSION/:src/terok_shield/state.py``.
 """
 
 
@@ -120,6 +121,30 @@ class StateBundle:
     def dns_tier(self) -> Path:
         """Path to the persisted DNS tier value."""
         return self.state_dir / "dns.tier"
+
+    @property
+    def loopback_ports(self) -> Path:
+        """Path to the per-container host-loopback TCP ports list.
+
+        Written by ``HookMode.pre_start`` from the caller-supplied
+        ``ShieldConfig.loopback_ports`` (the per-container triple of
+        gate / token-broker / ssh-signer ports the supervisor binds).
+        Read back by ``shield_up`` / ``shield_down`` when they rebuild
+        the nft ruleset — so a fresh ``Shield`` constructed without
+        the override still emits the correct
+        ``tcp dport <p> ip daddr 10.0.2.2 accept`` rules.
+        """
+        return self.state_dir / "loopback.ports"
+
+    def read_loopback_ports(self) -> tuple[int, ...]:
+        """Read persisted loopback ports; empty tuple when the file is absent."""
+        if not self.loopback_ports.is_file():
+            return ()
+        return tuple(
+            int(line.strip())
+            for line in self.loopback_ports.read_text().splitlines()
+            if line.strip()
+        )
 
     # ── Allowlists and denylists ───────────────────────────
 

--- a/tests/integration/bypass/test_lifecycle.py
+++ b/tests/integration/bypass/test_lifecycle.py
@@ -57,26 +57,26 @@ class TestBypassBasicLifecycle:
         assert_blocked(shielded_container, BLOCKED_TARGET_HTTP)
 
         # Shield down: traffic allowed
-        shield.down(shielded_container)
+        shield.down(shielded_container, shielded_container)
         assert shield.state(shielded_container) == ShieldState.DOWN
         assert_connectable(shielded_container, BLOCKED_TARGET_IP, BLOCKED_TARGET_DNS_PORT)
 
         # Shield up: traffic blocked again
-        shield.up(shielded_container)
+        shield.up(shielded_container, shielded_container)
         assert shield.state(shielded_container) == ShieldState.UP
         assert_blocked(shielded_container, BLOCKED_TARGET_HTTP)
 
     def test_up_disengaged_up_cycle(self, shielded_container: str) -> None:
         """Full cycle with allow_all: UP -> DISENGAGED -> UP."""
         shield = _shield()
-        shield.down(shielded_container, allow_all=True)
+        shield.down(shielded_container, shielded_container, allow_all=True)
         assert shield.state(shielded_container) == ShieldState.DISENGAGED
 
         rules = shield.rules(shielded_container)
         assert "policy accept" in rules
         assert_connectable(shielded_container, BLOCKED_TARGET_IP, BLOCKED_TARGET_DNS_PORT)
 
-        shield.up(shielded_container)
+        shield.up(shielded_container, shielded_container)
         assert shield.state(shielded_container) == ShieldState.UP
         assert_blocked(shielded_container, BLOCKED_TARGET_HTTP)
 
@@ -93,10 +93,10 @@ class TestBypassIdempotency:
     def test_down_twice_stays_down(self, shielded_container: str) -> None:
         """Calling shield.down() twice does not break anything."""
         shield = _shield()
-        shield.down(shielded_container)
+        shield.down(shielded_container, shielded_container)
         assert shield.state(shielded_container) == ShieldState.DOWN
 
-        shield.down(shielded_container)
+        shield.down(shielded_container, shielded_container)
         assert shield.state(shielded_container) == ShieldState.DOWN
         assert_connectable(shielded_container, BLOCKED_TARGET_IP, BLOCKED_TARGET_DNS_PORT)
 
@@ -105,14 +105,14 @@ class TestBypassIdempotency:
         shield = _shield()
         assert shield.state(shielded_container) == ShieldState.UP
 
-        shield.up(shielded_container)
+        shield.up(shielded_container, shielded_container)
         assert shield.state(shielded_container) == ShieldState.UP
         assert_blocked(shielded_container, BLOCKED_TARGET_HTTP)
 
     def test_up_without_prior_down(self, shielded_container: str) -> None:
         """shield.up() on a freshly shielded container is a no-op."""
         shield = _shield()
-        shield.up(shielded_container)
+        shield.up(shielded_container, shielded_container)
         assert shield.state(shielded_container) == ShieldState.UP
         assert_blocked(shielded_container, BLOCKED_TARGET_HTTP)
 
@@ -129,10 +129,10 @@ class TestBypassModeSwitch:
     def test_down_to_disengaged(self, shielded_container: str) -> None:
         """Switch from protected bypass to full bypass."""
         shield = _shield()
-        shield.down(shielded_container)
+        shield.down(shielded_container, shielded_container)
         assert shield.state(shielded_container) == ShieldState.DOWN
 
-        shield.down(shielded_container, allow_all=True)
+        shield.down(shielded_container, shielded_container, allow_all=True)
         assert shield.state(shielded_container) == ShieldState.DISENGAGED
 
         # Private-range rules should be gone
@@ -142,10 +142,10 @@ class TestBypassModeSwitch:
     def test_disengaged_to_down(self, shielded_container: str) -> None:
         """Switch from full bypass back to protected bypass."""
         shield = _shield()
-        shield.down(shielded_container, allow_all=True)
+        shield.down(shielded_container, shielded_container, allow_all=True)
         assert shield.state(shielded_container) == ShieldState.DISENGAGED
 
-        shield.down(shielded_container)
+        shield.down(shielded_container, shielded_container)
         assert shield.state(shielded_container) == ShieldState.DOWN
 
         # Private-range rules should be restored
@@ -170,13 +170,13 @@ class TestBypassWithAllowDeny:
         transition even though the nft ruleset is atomically replaced.
         """
         shield = _shield()
-        shield.down(shielded_container)
+        shield.down(shielded_container, shielded_container)
 
         # Add IP to allow set during bypass — persists to live.allowed
         shield.allow(shielded_container, BLOCKED_TARGET_IP)
 
         # Restore shield — the IP is re-added from live.allowed
-        shield.up(shielded_container)
+        shield.up(shielded_container, shielded_container)
 
         # Verify the IP is still allowed
         assert_connectable(shielded_container, BLOCKED_TARGET_IP, BLOCKED_TARGET_DNS_PORT)
@@ -188,7 +188,7 @@ class TestBypassWithAllowDeny:
         operator-driven deny still drops matching traffic.  See PR #230.
         """
         shield = _shield()
-        shield.down(shielded_container)
+        shield.down(shielded_container, shielded_container)
 
         shield.deny(shielded_container, BLOCKED_TARGET_IP)
         assert_not_connectable(shielded_container, BLOCKED_TARGET_IP, BLOCKED_TARGET_DNS_PORT)
@@ -229,11 +229,11 @@ class TestBypassIPRestoration:
             StateBundle(sd).profile_allowed.write_text("\n".join(ALLOWED_TARGET_IPS) + "\n")
 
             # Go down (all traffic allowed regardless)
-            shield.down(name)
+            shield.down(name, name)
             assert_reachable(name, ALLOWED_TARGET_HTTP)
 
             # Come back up — cached IPs should be restored
-            shield.up(name)
+            shield.up(name, name)
             assert shield.state(name) == ShieldState.UP
             assert_reachable(name, ALLOWED_TARGET_HTTP)
 
@@ -254,8 +254,8 @@ class TestBypassAuditTrail:
         """shield.down and shield.up produce audit log entries."""
         sd = shield_env / "containers" / shielded_container
         shield = Shield(ShieldConfig(state_dir=sd))
-        shield.down(shielded_container)
-        shield.up(shielded_container)
+        shield.down(shielded_container, shielded_container)
+        shield.up(shielded_container, shielded_container)
 
         events = list(shield.tail_log())
         actions = [e["action"] for e in events]
@@ -271,7 +271,7 @@ class TestBypassAuditTrail:
         """shield.down(allow_all=True) logs the allow_all detail."""
         sd = shield_env / "containers" / shielded_container
         shield = Shield(ShieldConfig(state_dir=sd))
-        shield.down(shielded_container, allow_all=True)
+        shield.down(shielded_container, shielded_container, allow_all=True)
 
         events = list(shield.tail_log())
         down_events = [e for e in events if e["action"] == "shield_down"]
@@ -328,23 +328,23 @@ class TestBypassFullE2E:
             StateBundle(sd).profile_allowed.write_text("\n".join(ALLOWED_TARGET_IPS) + "\n")
 
             # Step 3: Down for discovery
-            shield.down(name)
+            shield.down(name, name)
             assert shield.state(name) == ShieldState.DOWN
             assert_reachable(name, ALLOWED_TARGET_HTTP)
             assert_connectable(name, BLOCKED_TARGET_IP, BLOCKED_TARGET_DNS_PORT)
 
             # Step 4: Switch to full bypass to also check RFC1918 destinations
-            shield.down(name, allow_all=True)
+            shield.down(name, name, allow_all=True)
             assert shield.state(name) == ShieldState.DISENGAGED
             assert_connectable(name, BLOCKED_TARGET_IP, BLOCKED_TARGET_DNS_PORT)
 
             # Step 5: Back to protected bypass
-            shield.down(name)
+            shield.down(name, name)
             assert shield.state(name) == ShieldState.DOWN
             assert_connectable(name, BLOCKED_TARGET_IP, BLOCKED_TARGET_DNS_PORT)
 
             # Step 6: Restore the shield
-            shield.up(name)
+            shield.up(name, name)
             assert shield.state(name) == ShieldState.UP
 
             # Cached IPs should be restored
@@ -377,12 +377,12 @@ class TestBypassFullE2E:
         """
         shield = _shield()
         # Rapid toggles
-        shield.down(shielded_container)
-        shield.up(shielded_container)
-        shield.down(shielded_container)
-        shield.down(shielded_container, allow_all=True)
-        shield.up(shielded_container)
-        shield.up(shielded_container)
+        shield.down(shielded_container, shielded_container)
+        shield.up(shielded_container, shielded_container)
+        shield.down(shielded_container, shielded_container)
+        shield.down(shielded_container, shielded_container, allow_all=True)
+        shield.up(shielded_container, shielded_container)
+        shield.up(shielded_container, shielded_container)
 
         # Final state must be UP and enforcing
         assert shield.state(shielded_container) == ShieldState.UP
@@ -407,8 +407,8 @@ class TestBypassFullE2E:
         assert_reachable(shielded_container, ALLOWED_TARGET_HTTP)
 
         # Bypass cycle
-        shield.down(shielded_container)
-        shield.up(shielded_container)
+        shield.down(shielded_container, shielded_container)
+        shield.up(shielded_container, shielded_container)
 
         # IPs survive because live.allowed is read back by shield_up()
         assert_reachable(shielded_container, ALLOWED_TARGET_HTTP)

--- a/tests/integration/bypass/test_state.py
+++ b/tests/integration/bypass/test_state.py
@@ -34,22 +34,22 @@ class TestShieldState:
     def test_state_down_after_shield_down(self, shielded_container: str) -> None:
         """State is DOWN after shield.down() (RFC1918 protection kept)."""
         shield = _shield()
-        shield.down(shielded_container)
+        shield.down(shielded_container, shielded_container)
         assert shield.state(shielded_container) == ShieldState.DOWN
 
     def test_state_disengaged_after_shield_disengaged(self, shielded_container: str) -> None:
         """State is DISENGAGED after shield.down(allow_all=True)."""
         shield = _shield()
-        shield.down(shielded_container, allow_all=True)
+        shield.down(shielded_container, shielded_container, allow_all=True)
         assert shield.state(shielded_container) == ShieldState.DISENGAGED
 
     def test_state_up_after_shield_up(self, shielded_container: str) -> None:
         """State returns to UP after shield.down() then shield.up()."""
         shield = _shield()
-        shield.down(shielded_container)
+        shield.down(shielded_container, shielded_container)
         assert shield.state(shielded_container) == ShieldState.DOWN
 
-        shield.up(shielded_container)
+        shield.up(shielded_container, shielded_container)
         assert shield.state(shielded_container) == ShieldState.UP
 
 

--- a/tests/integration/bypass/test_traffic.py
+++ b/tests/integration/bypass/test_traffic.py
@@ -49,10 +49,10 @@ class TestBypassTrafficDNS:
     def test_dns_blocked_again_after_up(self, shielded_container: str) -> None:
         """DNS connectivity is blocked again after restoring the shield."""
         shield = _shield()
-        shield.down(shielded_container)
+        shield.down(shielded_container, shielded_container)
         assert_connectable(shielded_container, BLOCKED_TARGET_IP, BLOCKED_TARGET_DNS_PORT)
 
-        shield.up(shielded_container)
+        shield.up(shielded_container, shielded_container)
         assert_not_connectable(shielded_container, BLOCKED_TARGET_IP, BLOCKED_TARGET_DNS_PORT)
 
 
@@ -73,10 +73,10 @@ class TestBypassTrafficHTTP:
     def test_http_blocked_again_after_up(self, shielded_container: str) -> None:
         """HTTP traffic to non-allowed target is blocked after restoring shield."""
         shield = _shield()
-        shield.down(shielded_container)
+        shield.down(shielded_container, shielded_container)
         assert_reachable(shielded_container, CONNCHECK_HTTP)
 
-        shield.up(shielded_container)
+        shield.up(shielded_container, shielded_container)
         assert_blocked(shielded_container, CONNCHECK_HTTP)
 
 
@@ -97,10 +97,10 @@ class TestBypassTrafficHTTPS:
     def test_https_blocked_again_after_up(self, shielded_container: str) -> None:
         """HTTPS traffic to non-allowed target is blocked after restoring shield."""
         shield = _shield()
-        shield.down(shielded_container)
+        shield.down(shielded_container, shielded_container)
         assert_reachable(shielded_container, CONNCHECK_HTTPS)
 
-        shield.up(shielded_container)
+        shield.up(shielded_container, shielded_container)
         assert_blocked(shielded_container, CONNCHECK_HTTPS)
 
 
@@ -131,14 +131,14 @@ class TestBypassRuleset:
     def test_bypass_ruleset_has_log_prefix(self, shielded_container: str) -> None:
         """The bypass ruleset contains the TEROK_SHIELD_BYPASS log prefix."""
         shield = _shield()
-        shield.down(shielded_container)
+        shield.down(shielded_container, shielded_container)
         rules = shield.rules(shielded_container)
         assert BYPASS_LOG_PREFIX in rules
 
     def test_bypass_ruleset_has_accept_policy(self, shielded_container: str) -> None:
         """The bypass ruleset output chain has policy accept."""
         shield = _shield()
-        shield.down(shielded_container)
+        shield.down(shielded_container, shielded_container)
         rules = shield.rules(shielded_container)
         assert "policy accept" in rules
 
@@ -155,7 +155,7 @@ class TestBypassRFC1918:
     def test_rfc1918_rules_present_in_default_bypass(self, shielded_container: str) -> None:
         """Default bypass (no --all) keeps RFC1918 reject rules."""
         shield = _shield()
-        shield.down(shielded_container)
+        shield.down(shielded_container, shielded_container)
         rules = shield.rules(shielded_container)
         for net in RFC1918:
             assert net in rules, f"RFC1918 reject rule for {net} missing in bypass"
@@ -163,7 +163,7 @@ class TestBypassRFC1918:
     def test_rfc1918_rules_absent_in_allow_all_bypass(self, shielded_container: str) -> None:
         """Bypass with allow_all=True removes RFC1918 reject rules."""
         shield = _shield()
-        shield.down(shielded_container, allow_all=True)
+        shield.down(shielded_container, shielded_container, allow_all=True)
         rules = shield.rules(shielded_container)
         for net in RFC1918:
             assert (
@@ -178,7 +178,7 @@ class TestBypassRFC1918:
         (which guarantees ICMP admin-prohibited responses).
         """
         shield = _shield()
-        shield.down(shielded_container)
+        shield.down(shielded_container, shielded_container)
         rules = shield.rules(shielded_container)
         assert "admin-prohibited" in rules
 
@@ -195,7 +195,7 @@ class TestBypassIPv6Private:
     def test_ipv6_private_rules_present_in_default_bypass(self, shielded_container: str) -> None:
         """Default bypass keeps IPv6 private reject rules."""
         shield = _shield()
-        shield.down(shielded_container)
+        shield.down(shielded_container, shielded_container)
         rules = shield.rules(shielded_container)
         for net in IPV6_PRIVATE:
             assert net in rules, f"IPv6 private reject rule for {net} missing in bypass"
@@ -203,7 +203,7 @@ class TestBypassIPv6Private:
     def test_ipv6_private_rules_absent_in_allow_all_bypass(self, shielded_container: str) -> None:
         """Bypass with allow_all=True removes IPv6 private reject rules."""
         shield = _shield()
-        shield.down(shielded_container, allow_all=True)
+        shield.down(shielded_container, shielded_container, allow_all=True)
         rules = shield.rules(shielded_container)
         for net in IPV6_PRIVATE:
             assert (

--- a/tests/integration/launch/test_hook_entrypoint.py
+++ b/tests/integration/launch/test_hook_entrypoint.py
@@ -71,7 +71,7 @@ class TestHookEntrypointStory:
         assert_blocked(name, BLOCKED_TARGET_HTTP)
 
         # 4. shield_up re-applies the ruleset cleanly
-        shield.up(name)
+        shield.up(name, name)
         assert "terok_shield" in shield.rules(name)
         assert_blocked(name, BLOCKED_TARGET_HTTP)
 

--- a/tests/integration/observability/test_rules.py
+++ b/tests/integration/observability/test_rules.py
@@ -81,7 +81,7 @@ class TestRulesBypassAPI:
     def test_rules_contain_bypass_prefix(self, shielded_container: str) -> None:
         """Bypass ruleset contains the TEROK_SHIELD_BYPASS log prefix."""
         shield = _shield()
-        shield.down(shielded_container)
+        shield.down(shielded_container, shielded_container)
         rules = shield.rules(shielded_container)
         assert BYPASS_LOG_PREFIX in rules
         assert "policy accept" in rules
@@ -89,10 +89,10 @@ class TestRulesBypassAPI:
     def test_rules_restored_after_up(self, shielded_container: str) -> None:
         """Rules revert to deny-all after shield.up()."""
         shield = _shield()
-        shield.down(shielded_container)
+        shield.down(shielded_container, shielded_container)
         assert "policy accept" in shield.rules(shielded_container)
 
-        shield.up(shielded_container)
+        shield.up(shielded_container, shielded_container)
         rules = shield.rules(shielded_container)
         assert "policy drop" in rules
         assert BYPASS_LOG_PREFIX not in rules

--- a/tests/integration/setup/test_environment.py
+++ b/tests/integration/setup/test_environment.py
@@ -79,29 +79,29 @@ class TestGlobalHooksSetup:
     """Test global hooks installation with real filesystem."""
 
     def test_setup_user_hooks(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        """``HooksInstaller`` (user scope) installs hooks and updates containers.conf."""
+        """``HooksInstaller`` installs hooks and updates containers.conf."""
         monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "share"))
-        hooks_dir = tmp_path / "hooks.d"
+        target = tmp_path / "hooks"
         conf_dir = tmp_path / "config" / "containers"
         monkeypatch.setattr(
             "terok_shield.hooks.install._user_containers_conf",
             lambda: conf_dir / "containers.conf",
         )
 
-        HooksInstaller(target_dir=hooks_dir, register_in_containers_conf=True).install()
-        assert (hooks_dir / "terok-shield-createRuntime.json").is_file()
-        assert (hooks_dir / "terok-shield-poststop.json").is_file()
-        assert (hooks_dir / "terok-shield-hook").is_file()
+        HooksInstaller(target_dir=target).install()
+        assert (target / "terok-shield-createRuntime.json").is_file()
+        assert (target / "terok-shield-poststop.json").is_file()
+        assert (target / "terok-shield-hook").is_file()
 
         # Verify entrypoint is executable
-        hook = hooks_dir / "terok-shield-hook"
+        hook = target / "terok-shield-hook"
         assert hook.stat().st_mode & 0o100
 
-        # containers.conf was patched as part of the user-scope install.
+        # containers.conf was patched as part of the install.
         conf = conf_dir / "containers.conf"
         assert conf.is_file()
         text = conf.read_text()
-        assert str(hooks_dir) in text
+        assert str(target) in text
         assert text.count("[engine]") == 1
 
     def test_has_global_hooks_after_setup(
@@ -109,17 +109,25 @@ class TestGlobalHooksSetup:
     ) -> None:
         """``has_global_hooks`` flips True once ``HooksInstaller.install()`` runs."""
         monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "share"))
-        hooks_dir = tmp_path / "hooks.d"
-        assert not has_global_hooks([hooks_dir])
-        HooksInstaller(target_dir=hooks_dir).install()
-        assert has_global_hooks([hooks_dir])
+        target = tmp_path / "hooks"
+        monkeypatch.setattr(
+            "terok_shield.hooks.install._user_containers_conf",
+            lambda: tmp_path / "containers.conf",
+        )
+        assert not has_global_hooks([target])
+        HooksInstaller(target_dir=target).install()
+        assert has_global_hooks([target])
 
     def test_setup_idempotent(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """Running install twice doesn't break anything — file contents stay stable."""
         monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "share"))
-        hooks_dir = tmp_path / "hooks.d"
-        installer = HooksInstaller(target_dir=hooks_dir)
+        target = tmp_path / "hooks"
+        monkeypatch.setattr(
+            "terok_shield.hooks.install._user_containers_conf",
+            lambda: tmp_path / "containers.conf",
+        )
+        installer = HooksInstaller(target_dir=target)
         installer.install()
-        first_content = (hooks_dir / "terok-shield-hook").read_text()
+        first_content = (target / "terok-shield-hook").read_text()
         installer.install()
-        assert (hooks_dir / "terok-shield-hook").read_text() == first_content
+        assert (target / "terok-shield-hook").read_text() == first_content

--- a/tests/testfs.py
+++ b/tests/testfs.py
@@ -44,6 +44,16 @@ VOLUME_MOUNT_HOST = "/host:/ctr"
 VOLUME_MOUNT_DATA = "/data:/data"
 STATE_DIR_WITH_SPACES = "/path/with spaces/dir"
 
+# ── XDG runtime fallback prefix (rootless socket base) ──
+# When ``XDG_RUNTIME_DIR`` is unset, shield/reader paths fall back to
+# ``/run/user/<uid>/...``.  Tests assert against this prefix.
+
+RUN_USER_PREFIX = "/run/user/"
+
+# ── Installer-baked reader script path (templated by ``terok-shield setup``) ──
+# A representative absolute path the setup step bakes into the reader hook.
+READER_SCRIPT_BAKED_PATH = "/opt/terok/shield/nflog-reader.py"
+
 # ── Binary paths (for mocking shutil.which results) ──
 
 NFT_BINARY = "/usr/bin/nft"

--- a/tests/unit/podman_info/test_hooks_dir.py
+++ b/tests/unit/podman_info/test_hooks_dir.py
@@ -13,10 +13,8 @@ from terok_shield.podman_info.hooks_dir import (
     find_hooks_dirs,
     global_hooks_hint,
     has_global_hooks,
-    system_hooks_dir,
 )
 from tests.testfs import (
-    NONEXISTENT_DIR,
     SINGLE_HOOKS_PATH_LITERAL,
     SYSTEM_HOOKS_DIR_LITERAL,
     USER_HOOKS_DIR_LITERAL,
@@ -42,26 +40,25 @@ class TestFindHooksDirs:
             "terok_shield.podman_info.hooks_dir._SYSTEM_CONF_PATHS",
             (tmp_path / "nonexistent",),
         )
-        monkeypatch.setattr("terok_shield.podman_info.hooks_dir._SYSTEM_HOOKS_DIRS", ())
 
         dirs = find_hooks_dirs()
         assert dirs == [Path(USER_HOOKS_DIR_LITERAL)]
 
-    def test_falls_back_to_system_dirs(
+    def test_returns_empty_when_no_config(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Falls back to existing system dirs when no config."""
+        """Returns empty when neither user nor system config has hooks_dir.
+
+        terok always patches containers.conf at setup time, so an empty
+        result implies setup has not run — the caller (e.g.
+        ``check_environment``) treats it as ``setup-needed``.
+        """
         monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "no-config"))
         monkeypatch.setattr(
             "terok_shield.podman_info.hooks_dir._SYSTEM_CONF_PATHS",
             (tmp_path / "nonexistent",),
         )
-        system_dir = tmp_path / "system-hooks"
-        system_dir.mkdir()
-        monkeypatch.setattr("terok_shield.podman_info.hooks_dir._SYSTEM_HOOKS_DIRS", (system_dir,))
-
-        dirs = find_hooks_dirs()
-        assert dirs == [system_dir]
+        assert find_hooks_dirs() == []
 
     def test_system_conf_used_when_no_user_conf(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -71,7 +68,6 @@ class TestFindHooksDirs:
         sys_conf = tmp_path / "system.conf"
         sys_conf.write_text(f'[engine]\nhooks_dir = ["{SYSTEM_HOOKS_DIR_LITERAL}"]\n')
         monkeypatch.setattr("terok_shield.podman_info.hooks_dir._SYSTEM_CONF_PATHS", (sys_conf,))
-        monkeypatch.setattr("terok_shield.podman_info.hooks_dir._SYSTEM_HOOKS_DIRS", ())
         dirs = find_hooks_dirs()
         assert dirs == [Path(SYSTEM_HOOKS_DIR_LITERAL)]
 
@@ -154,28 +150,6 @@ class TestParseHooksDirFromConf:
         conf = tmp_path / "containers.conf"
         conf.write_text("[engine]\nhooks_dir = 42\n")
         assert _parse_hooks_dir_from_conf(conf) == []
-
-
-# ── system_hooks_dir tests ───────────────────────────────
-
-
-class TestSystemHooksDir:
-    """Tests for system hooks directory detection."""
-
-    def test_returns_existing_dir(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Returns an existing system dir when available."""
-        d = tmp_path / "hooks.d"
-        d.mkdir()
-        monkeypatch.setattr("terok_shield.podman_info.hooks_dir._SYSTEM_HOOKS_DIRS", (d,))
-        assert system_hooks_dir() == d
-
-    def test_fallback_when_none_exist(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Falls back to last entry when no system dir exists."""
-        monkeypatch.setattr(
-            "terok_shield.podman_info.hooks_dir._SYSTEM_HOOKS_DIRS",
-            (NONEXISTENT_DIR / "a", NONEXISTENT_DIR / "b"),
-        )
-        assert system_hooks_dir() == NONEXISTENT_DIR / "b"
 
 
 # ── global_hooks_hint tests ──────────────────────────────

--- a/tests/unit/test_api_surface.py
+++ b/tests/unit/test_api_surface.py
@@ -38,9 +38,9 @@ EXPECTED_ALL = [
     "ShieldNeedsSetup",
     "ShieldRuntime",
     "ShieldState",
-    "USER_HOOKS_DIR",
     "check_firewall_binaries",
     "check_krun_binaries",
+    "ensure_user_hooks_dir_configured",
 ]
 
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -50,6 +50,7 @@ from ..testnet import TEST_DOMAIN, TEST_IP1
 from .helpers import write_jsonl
 
 _CONTAINER = "test"
+_CONTAINER_ID = "deadbeefcafe1234"
 _IMAGE = "alpine:latest"
 
 
@@ -131,8 +132,8 @@ def force_hook_mode(monkeypatch: pytest.MonkeyPatch) -> None:
         pytest.param(["status"], "status", id="status"),
         pytest.param(["rules", _CONTAINER], "rules", id="rules"),
         pytest.param(["logs"], "logs", id="logs"),
-        pytest.param(["down", _CONTAINER], "down", id="down"),
-        pytest.param(["up", _CONTAINER], "up", id="up"),
+        pytest.param(["down", _CONTAINER, "--container-id", _CONTAINER_ID], "down", id="down"),
+        pytest.param(["up", _CONTAINER, "--container-id", _CONTAINER_ID], "up", id="up"),
         pytest.param(["preview"], "preview", id="preview"),
         pytest.param(["profiles"], "profiles", id="profiles"),
     ],
@@ -227,8 +228,30 @@ def test_logs_parser_supports_optional_container_and_count(parser: argparse.Argu
 
 def test_down_parser_supports_allow_all(parser: argparse.ArgumentParser) -> None:
     """down defaults to allow_all=False and flips with --all."""
-    assert not parser.parse_args(["down", "ctr"]).allow_all
-    assert parser.parse_args(["down", "ctr", "--all"]).allow_all
+    base = ["down", "ctr", "--container-id", _CONTAINER_ID]
+    assert not parser.parse_args(base).allow_all
+    assert parser.parse_args([*base, "--all"]).allow_all
+
+
+@pytest.mark.parametrize(
+    "verb",
+    [pytest.param("up", id="up"), pytest.param("down", id="down")],
+)
+def test_emit_verbs_require_container_id(parser: argparse.ArgumentParser, verb: str) -> None:
+    """The hub-emitting verbs reject argv without ``--container-id``.
+
+    The shield CLI has no host-wide fallback hub socket; every emit
+    needs the routing key supplied by the caller.  Argparse enforces
+    this via ``required=True`` on the ``--container-id`` option.
+    """
+    with pytest.raises(SystemExit):
+        parser.parse_args([verb, "ctr"])
+
+
+def test_container_id_parses_as_attribute(parser: argparse.ArgumentParser) -> None:
+    """``--container-id <uuid>`` lands on ``args.container_id``."""
+    parsed = parser.parse_args(["up", "ctr", "--container-id", _CONTAINER_ID])
+    assert parsed.container_id == _CONTAINER_ID
 
 
 @pytest.mark.parametrize(
@@ -527,15 +550,23 @@ def test_allow_and_deny_dispatch_to_shield(
     ("argv", "method_name", "expected_call"),
     [
         pytest.param(
-            ["down", _CONTAINER], "down", mock.call(_CONTAINER, allow_all=False), id="down"
+            ["down", _CONTAINER, "--container-id", _CONTAINER_ID],
+            "down",
+            mock.call(_CONTAINER, _CONTAINER_ID, allow_all=False),
+            id="down",
         ),
         pytest.param(
-            ["down", _CONTAINER, "--all"],
+            ["down", _CONTAINER, "--container-id", _CONTAINER_ID, "--all"],
             "down",
-            mock.call(_CONTAINER, allow_all=True),
+            mock.call(_CONTAINER, _CONTAINER_ID, allow_all=True),
             id="down-all",
         ),
-        pytest.param(["up", _CONTAINER], "up", mock.call(_CONTAINER), id="up"),
+        pytest.param(
+            ["up", _CONTAINER, "--container-id", _CONTAINER_ID],
+            "up",
+            mock.call(_CONTAINER, _CONTAINER_ID),
+            id="up",
+        ),
         pytest.param(
             ["preview"],
             "preview",
@@ -884,19 +915,18 @@ def test_build_config_loads_yaml(
     isolated_roots: tuple[Path, Path],
     write_config: Callable[[str], Path],
 ) -> None:
-    """_build_config() loads mode, profiles, ports, and audit settings from YAML."""
+    """_build_config() loads mode, profiles, and audit settings from YAML.
+
+    ``loopback_ports`` is *not* a config-file knob in the per-container
+    model — it lives in the state bundle, written by ``pre_start`` from
+    the caller-supplied ``ShieldConfig``.
+    """
     state_root, _ = isolated_roots
-    write_config(
-        "mode: hook\n"
-        "default_profiles: [base, dev-python]\n"
-        "loopback_ports: [1234, 5678]\n"
-        "audit:\n"
-        "  enabled: false\n"
-    )
+    write_config("mode: hook\ndefault_profiles: [base, dev-python]\naudit:\n  enabled: false\n")
     config = _build_config("ctr", state_dir_override=state_root)
     assert config.mode == ShieldMode.HOOK
     assert config.default_profiles == ("base", "dev-python")
-    assert config.loopback_ports == (1234, 5678)
+    assert config.loopback_ports == ()
     assert not config.audit_enabled
 
 
@@ -1048,35 +1078,26 @@ class TestSetupCommand:
     """Tests for the setup CLI command."""
 
     @mock.patch("terok_shield.hooks.install.HooksInstaller.install")
-    def test_setup_user(
+    def test_setup_installs(
         self,
         install: mock.Mock,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
-        """``setup --user`` dispatches to the user-scope installer."""
-        main(["setup", "--user"])
+        """``setup`` installs hooks to the canonical user-owned dir."""
+        main(["setup"])
         install.assert_called_once()
         out = capsys.readouterr().out
         assert "Done" in out
-        assert "user" in out
 
-    @mock.patch("terok_shield.hooks.install.HooksInstaller.install")
-    def test_setup_root(
-        self,
-        install: mock.Mock,
-        capsys: pytest.CaptureFixture[str],
-    ) -> None:
-        """``setup --root`` dispatches to the system-scope installer with sudo."""
-        main(["setup", "--root"])
-        install.assert_called_once()
-        out = capsys.readouterr().out
-        assert "Done" in out
-        assert "sudo" in out
-
-    def test_setup_root_and_user_rejected(self) -> None:
-        """setup --root --user raises."""
+    def test_setup_rejects_root_flag(self) -> None:
+        """``--root`` is gone; passing it is a parser error."""
         with pytest.raises(SystemExit):
-            main(["setup", "--root", "--user"])
+            main(["setup", "--root"])
+
+    def test_setup_rejects_user_flag(self) -> None:
+        """``--user`` is gone; the single layout is implicit."""
+        with pytest.raises(SystemExit):
+            main(["setup", "--user"])
 
 
 # ── check-environment command test ───────────────────────
@@ -1136,49 +1157,6 @@ def test_version_flag_podman_missing(
     out = capsys.readouterr().out
     assert "podman not found" in out
     assert "nft not found" in out
-
-
-# ── interactive setup test ───────────────────────────────
-
-
-class TestSetupInteractive:
-    """Tests for interactive setup mode."""
-
-    @mock.patch("terok_shield.hooks.install.HooksInstaller.install")
-    @mock.patch("builtins.input", return_value="u")
-    def test_interactive_user_choice(
-        self,
-        _input: mock.Mock,
-        install: mock.Mock,
-        capsys: pytest.CaptureFixture[str],
-    ) -> None:
-        """Interactive setup with 'u' choice installs user hooks."""
-        main(["setup"])
-        install.assert_called_once()
-        assert "Done" in capsys.readouterr().out
-
-    @mock.patch("builtins.input", return_value="x")
-    def test_interactive_cancel(
-        self,
-        _input: mock.Mock,
-        capsys: pytest.CaptureFixture[str],
-    ) -> None:
-        """Interactive setup with invalid choice cancels."""
-        main(["setup"])
-        assert "Cancelled" in capsys.readouterr().out
-
-    @mock.patch("terok_shield.hooks.install.HooksInstaller.install")
-    @mock.patch("builtins.input", return_value="r")
-    def test_interactive_root_choice(
-        self,
-        _input: mock.Mock,
-        install: mock.Mock,
-        capsys: pytest.CaptureFixture[str],
-    ) -> None:
-        """Interactive setup with 'r' choice uses sudo."""
-        main(["setup"])
-        install.assert_called_once()
-        assert "sudo" in capsys.readouterr().out
 
 
 def test_simple_clearance_command_routes_to_handler(cli_dispatch: CliDispatchHarness) -> None:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -11,7 +11,6 @@ from pydantic import ValidationError
 
 from terok_shield.config import (
     ANNOTATION_KEY,
-    ANNOTATION_LOOPBACK_PORTS_KEY,
     ANNOTATION_NAME_KEY,
     ANNOTATION_STATE_DIR_KEY,
     ANNOTATION_VERSION_KEY,
@@ -102,7 +101,6 @@ class TestAnnotationConstants:
         assert ANNOTATION_KEY == "terok.shield.profiles"
         assert ANNOTATION_NAME_KEY == "terok.shield.name"
         assert ANNOTATION_STATE_DIR_KEY == "terok.shield.state_dir"
-        assert ANNOTATION_LOOPBACK_PORTS_KEY == "terok.shield.loopback_ports"
         assert ANNOTATION_VERSION_KEY == "terok.shield.version"
 
 
@@ -117,7 +115,6 @@ class TestShieldFileConfigDefaults:
         cfg = ShieldFileConfig()
         assert cfg.mode == "auto"
         assert cfg.default_profiles == ["dev-standard"]
-        assert cfg.loopback_ports == []
         assert cfg.audit.enabled is True
 
     def test_audit_defaults(self) -> None:
@@ -133,23 +130,11 @@ class TestShieldFileConfigValid:
         cfg = ShieldFileConfig(
             mode="hook",
             default_profiles=["base", "dev-python"],
-            loopback_ports=[8080, 9090],
             audit=AuditFileConfig(enabled=False),
         )
         assert cfg.mode == "hook"
         assert cfg.default_profiles == ["base", "dev-python"]
-        assert cfg.loopback_ports == [8080, 9090]
         assert cfg.audit.enabled is False
-
-    def test_single_port_int_coerced_to_list(self) -> None:
-        """A bare integer is accepted and wrapped in a list."""
-        cfg = ShieldFileConfig(loopback_ports=1234)
-        assert cfg.loopback_ports == [1234]
-
-    def test_boundary_ports(self) -> None:
-        """Port 1 and 65535 are both valid."""
-        cfg = ShieldFileConfig(loopback_ports=[1, 65535])
-        assert cfg.loopback_ports == [1, 65535]
 
 
 class TestShieldFileConfigUnknownKeys:
@@ -165,34 +150,10 @@ class TestShieldFileConfigUnknownKeys:
         with pytest.raises(ValidationError, match="enbled"):
             ShieldFileConfig(audit={"enbled": True})  # type: ignore[arg-type]
 
-
-class TestShieldFileConfigPortValidation:
-    """Port range and type enforcement."""
-
-    def test_port_zero_rejected(self) -> None:
-        """Port 0 is out of range."""
-        with pytest.raises(ValidationError, match="out of range"):
-            ShieldFileConfig(loopback_ports=[0])
-
-    def test_port_too_high_rejected(self) -> None:
-        """Port above 65535 is rejected."""
-        with pytest.raises(ValidationError, match="out of range"):
-            ShieldFileConfig(loopback_ports=[99999])
-
-    def test_bool_in_ports_rejected(self) -> None:
-        """Booleans in port list are rejected (not silently coerced to 0/1)."""
-        with pytest.raises(ValidationError, match="bool"):
-            ShieldFileConfig(loopback_ports=[True])
-
-    def test_bare_bool_rejected(self) -> None:
-        """A bare boolean instead of a list is rejected."""
-        with pytest.raises(ValidationError, match="bool"):
-            ShieldFileConfig(loopback_ports=True)
-
-    def test_string_rejected(self) -> None:
-        """A string instead of a port list is rejected."""
-        with pytest.raises(ValidationError, match="expected list"):
-            ShieldFileConfig(loopback_ports="not-a-list")
+    def test_loopback_ports_rejected(self) -> None:
+        """``loopback_ports`` is per-container state (state bundle), not config — reject if seen."""
+        with pytest.raises(ValidationError, match="loopback_ports"):
+            ShieldFileConfig(loopback_ports=[8080])  # type: ignore[call-arg]
 
 
 class TestShieldFileConfigProfileValidation:

--- a/tests/unit/test_hook_mode_class.py
+++ b/tests/unit/test_hook_mode_class.py
@@ -696,16 +696,18 @@ def test_pre_start_writes_ruleset_nft(
     assert "terok_shield" in content
 
 
-def test_hooks_installer_non_sudo_writes_role_files(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """A non-sudo install lays down nft + reader hooks, ballast, and reader resource."""
+def test_hooks_installer_writes_role_files(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``HooksInstaller.install()`` lays down nft + reader hooks, ballast, and reader resource."""
     from terok_shield.hooks.install import HooksInstaller
 
     # Reader resource lands at ``$XDG_DATA_HOME/terok/shield/nflog-reader.py``;
     # redirect it under tmp_path so the test stays hermetic.
     monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "share"))
-    target = tmp_path / "hooks.d"
+    monkeypatch.setattr(
+        "terok_shield.hooks.install._user_containers_conf",
+        lambda: tmp_path / "containers.conf",
+    )
+    target = tmp_path / "hooks"
     HooksInstaller(target_dir=target).install()
 
     # Shared ballast lands once — both role scripts import from it.
@@ -766,26 +768,6 @@ def test_install_hooks_honors_custom_entrypoint_name(tmp_path: Path) -> None:
     assert (target / "terok-shield-bridge-hook").is_file()
     bridge_json = json.loads((target / "terok-shield-bridge-createRuntime.json").read_text())
     assert bridge_json["hook"]["path"] == str(target / "terok-shield-bridge-hook")
-
-
-def test_hooks_installer_sudo_uses_subprocess(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """``HooksInstaller(use_sudo=True).install()`` escalates writes via sudo."""
-    from unittest import mock
-
-    from terok_shield.hooks.install import HooksInstaller
-
-    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "share"))
-    target = tmp_path / "system-hooks"
-    with mock.patch("terok_shield.hooks.install.subprocess.run") as mock_run:
-        HooksInstaller(target_dir=target, use_sudo=True).install()
-        # sudo mkdir + sudo cp + sudo chmod (reader install runs in-process).
-        assert mock_run.call_count == 3
-        cmds = [call.args[0] for call in mock_run.call_args_list]
-        assert all(cmd[0] == "sudo" for cmd in cmds)
-    # Reader resource still lands locally (no sudo for the per-user path).
-    assert (tmp_path / "share" / "terok" / "shield" / "nflog-reader.py").is_file()
 
 
 @mock.patch("terok_shield.hooks.mode.has_global_hooks", return_value=True)

--- a/tests/unit/test_hub_events.py
+++ b/tests/unit/test_hub_events.py
@@ -14,9 +14,16 @@ from pathlib import Path
 
 import pytest
 
-from terok_shield._hub_events import HubEventEmitter, hub_socket_path
+from terok_shield._hub_events import HubEventEmitter, _per_container_hub_socket
+
+from ..testfs import RUN_USER_PREFIX
 
 _CONTAINER = "test-ctr"
+# Shorter than the canonical 64-char podman UUID — the unix-socket
+# 108-byte path limit (sun_path) makes long ids unusable under deep
+# pytest tmp_path trees.  The routing logic is character-agnostic;
+# the path-length test pins the real path shape independently.
+_CONTAINER_ID = "deadbeefcafe1234"
 
 
 class _SocketRecorder:
@@ -25,6 +32,7 @@ class _SocketRecorder:
     def __init__(self, path: Path) -> None:
         self.path = path
         self.received: list[bytes] = []
+        path.parent.mkdir(parents=True, exist_ok=True)
         self._sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         self._sock.bind(str(path))
         self._sock.listen(1)
@@ -59,9 +67,16 @@ class _SocketRecorder:
 
 
 @pytest.fixture
-def hub_socket(tmp_path: Path) -> Iterator[_SocketRecorder]:
-    """Spin up a throwaway AF_UNIX listener the emitter can hit."""
-    recorder = _SocketRecorder(tmp_path / "hub.sock")
+def hub_socket(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Iterator[_SocketRecorder]:
+    """Spin up a throwaway AF_UNIX listener bound to the per-container path.
+
+    Points ``XDG_RUNTIME_DIR`` at *tmp_path* so the emitter resolves to
+    ``tmp_path/terok/events/<container_id>.sock`` — the very path the
+    recorder is listening on.
+    """
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+    path = tmp_path / "terok" / "events" / f"{_CONTAINER_ID[:12]}.sock"
+    recorder = _SocketRecorder(path)
     recorder.start()
     try:
         yield recorder
@@ -69,32 +84,46 @@ def hub_socket(tmp_path: Path) -> Iterator[_SocketRecorder]:
         recorder.stop()
 
 
-class TestHubSocketPath:
-    """Canonical socket path resolution."""
+class TestPerContainerHubSocket:
+    """Per-container socket path resolution."""
 
     def test_uses_xdg_runtime_dir(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-        """The canonical path sits directly under XDG_RUNTIME_DIR."""
+        """The per-container path sits under ``$XDG_RUNTIME_DIR/terok/events``."""
         monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
-        assert hub_socket_path() == tmp_path / "terok-shield-events.sock"
+        assert _per_container_hub_socket(_CONTAINER_ID) == (
+            tmp_path / "terok" / "events" / f"{_CONTAINER_ID[:12]}.sock"
+        )
 
     def test_falls_back_to_run_user_uid(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Without XDG_RUNTIME_DIR we fall back to ``/run/user/<uid>``."""
         monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
-        assert hub_socket_path() == Path(f"/run/user/{os.getuid()}/terok-shield-events.sock")
+        assert _per_container_hub_socket(_CONTAINER_ID) == Path(
+            f"{RUN_USER_PREFIX}{os.getuid()}/terok/events/{_CONTAINER_ID[:12]}.sock"
+        )
+
+    def test_distinct_container_ids_route_to_distinct_sockets(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Two containers under one operator land on two different sockets."""
+        monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+        a = _per_container_hub_socket("aaaa1111")
+        b = _per_container_hub_socket("bbbb2222")
+        assert a != b
+        assert a.parent == b.parent
 
 
 class TestHubEventEmitter:
-    """End-to-end emitter behaviour against a real unix socket."""
+    """End-to-end emitter behaviour against a real per-container unix socket."""
 
     def test_shield_up_writes_single_json_line(self, hub_socket: _SocketRecorder) -> None:
         """``shield_up`` produces one newline-terminated JSON payload."""
-        HubEventEmitter(hub_socket.path).shield_up(_CONTAINER)
+        HubEventEmitter().shield_up(_CONTAINER, _CONTAINER_ID)
         line = _received_one_line(hub_socket)
         assert json.loads(line) == {"type": "shield_up", "container": _CONTAINER}
 
     def test_shield_down_default_is_plain_down(self, hub_socket: _SocketRecorder) -> None:
         """``shield_down`` without ``allow_all`` maps to ``shield_down``."""
-        HubEventEmitter(hub_socket.path).shield_down(_CONTAINER)
+        HubEventEmitter().shield_down(_CONTAINER, _CONTAINER_ID)
         assert json.loads(_received_one_line(hub_socket)) == {
             "type": "shield_down",
             "container": _CONTAINER,
@@ -102,17 +131,20 @@ class TestHubEventEmitter:
 
     def test_shield_down_allow_all_maps_to_disengaged(self, hub_socket: _SocketRecorder) -> None:
         """``allow_all=True`` flips the event type to ``shield_disengaged``."""
-        HubEventEmitter(hub_socket.path).shield_down(_CONTAINER, allow_all=True)
+        HubEventEmitter().shield_down(_CONTAINER, _CONTAINER_ID, allow_all=True)
         assert json.loads(_received_one_line(hub_socket)) == {
             "type": "shield_disengaged",
             "container": _CONTAINER,
         }
 
-    def test_missing_socket_is_fail_silent(self, tmp_path: Path) -> None:
+    def test_missing_socket_is_fail_silent(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
         """Emission against a missing hub must not raise."""
-        emitter = HubEventEmitter(tmp_path / "does-not-exist.sock")
-        emitter.shield_up(_CONTAINER)  # must not raise
-        emitter.shield_down(_CONTAINER, allow_all=True)  # must not raise
+        monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+        emitter = HubEventEmitter()
+        emitter.shield_up(_CONTAINER, "nonexistent-container-id")  # must not raise
+        emitter.shield_down(_CONTAINER, "nonexistent-container-id", allow_all=True)
 
     def test_dossier_is_attached_when_present(self, hub_socket: _SocketRecorder) -> None:
         """A non-empty dossier rides under the ``dossier`` key on the wire.
@@ -121,8 +153,9 @@ class TestHubEventEmitter:
         ``connection_blocked`` events — keeps every event for one
         container rendering with the same identity bundle.
         """
-        HubEventEmitter(hub_socket.path).shield_up(
+        HubEventEmitter().shield_up(
             _CONTAINER,
+            _CONTAINER_ID,
             dossier={"project": "terok", "task": "abc", "name": "diligent-octopus"},
         )
         assert json.loads(_received_one_line(hub_socket)) == {
@@ -132,35 +165,59 @@ class TestHubEventEmitter:
         }
 
     def test_empty_dossier_omits_the_key(self, hub_socket: _SocketRecorder) -> None:
-        """Empty / missing dossier preserves the pre-v12 wire shape — no ``dossier`` key.
+        """Empty / missing dossier yields a flat wire payload — no ``dossier`` key.
 
-        Old hub ingesters that don't know about ``dossier`` will keep
-        round-tripping standalone-container events without seeing an
-        unknown key during the rollout window.
+        Hub ingesters that don't know about ``dossier`` keep round-tripping
+        standalone-container events without seeing an unknown key.
         """
-        HubEventEmitter(hub_socket.path).shield_down(_CONTAINER, dossier={})
+        HubEventEmitter().shield_down(_CONTAINER, _CONTAINER_ID, dossier={})
         assert json.loads(_received_one_line(hub_socket)) == {
             "type": "shield_down",
             "container": _CONTAINER,
         }
 
-    def test_attacker_bytes_in_container_id_are_sanitised(
+    def test_attacker_bytes_in_container_name_are_sanitised(
         self, hub_socket: _SocketRecorder
     ) -> None:
         """A crafted container name can't smuggle control chars onto the wire."""
-        HubEventEmitter(hub_socket.path).shield_up("evil\x00\x1bfoo")
+        HubEventEmitter().shield_up("evil\x00\x1bfoo", _CONTAINER_ID)
         parsed = json.loads(_received_one_line(hub_socket))
         assert parsed["container"] == "evil  foo"
 
     def test_dossier_values_are_sanitised(self, hub_socket: _SocketRecorder) -> None:
         """Producer-side belt-and-braces: dossier strings hit the wire as printable ASCII."""
-        HubEventEmitter(hub_socket.path).shield_up(
+        HubEventEmitter().shield_up(
             _CONTAINER,
+            _CONTAINER_ID,
             dossier={"name": "p1\nProtocol: spoof", "task": "café"},
         )
         parsed = json.loads(_received_one_line(hub_socket))
         assert parsed["dossier"]["name"] == "p1 Protocol: spoof"
         assert parsed["dossier"]["task"] == "caf "
+
+    def test_routes_to_per_container_socket(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """An emit for container A must not reach the listener for container B.
+
+        Two listeners, two container ids: only the matching one sees the
+        payload.  Guards the routing key — if the path scheme regresses to
+        a single global socket both listeners would receive everything.
+        """
+        monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+        cid_a = "a" * 16
+        cid_b = "b" * 16
+        rec_a = _SocketRecorder(tmp_path / "terok" / "events" / f"{cid_a[:12]}.sock")
+        rec_b = _SocketRecorder(tmp_path / "terok" / "events" / f"{cid_b[:12]}.sock")
+        rec_a.start()
+        rec_b.start()
+        try:
+            HubEventEmitter().shield_up(_CONTAINER, cid_a)
+            assert _received_one_line(rec_a)
+            assert not rec_b.received
+        finally:
+            rec_a.stop()
+            rec_b.stop()
 
 
 def _received_one_line(recorder: _SocketRecorder) -> str:

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -3,55 +3,26 @@
 
 """Unit tests for HooksInstaller and the containers.conf patcher.
 
-Covers the system/user factory pair, the symmetric install/uninstall
-lifecycle, and the line-based containers.conf editing that user-scope
-installs trigger.  The per-container [`install_hooks`][terok_shield.hooks.install.install_hooks]
-path and the role-file generators are exercised by ``test_hook_mode_class``.
+Covers the single-layout install/uninstall lifecycle and the line-based
+containers.conf editing that install triggers.  The per-container
+[`install_hooks`][terok_shield.hooks.install.install_hooks] path and the
+role-file generators are exercised by ``test_hook_mode_class``.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
-from unittest import mock
 
 import pytest
 
 from terok_shield.hooks.install import (
-    _INSTALLED_FILES,
+    _DESCRIPTOR_FILES,
+    _SCRIPT_FILES,
     HooksInstaller,
-    _register_hooks_dir_in_containers_conf,
+    ensure_user_hooks_dir_configured,
 )
 
 from ..testfs import PLACEHOLDER_ALT_HOOKS_DIR, PLACEHOLDER_HOOKS_DIR
-
-# ── Factory constructors ─────────────────────────────────
-
-
-class TestFactories:
-    """The ``system`` / ``user`` classmethods bind the right scope defaults."""
-
-    def test_system_uses_sudo(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """``system()`` escalates writes and skips containers.conf registration."""
-        monkeypatch.setattr(
-            "terok_shield.hooks.install.system_hooks_dir",
-            lambda: Path("/fake/system"),
-        )
-        installer = HooksInstaller.system()
-        assert installer.target_dir == Path("/fake/system")
-        assert installer.use_sudo is True
-        assert installer.register_in_containers_conf is False
-
-    def test_user_does_not_use_sudo(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """``user()`` writes directly and registers in containers.conf."""
-        monkeypatch.setattr(
-            "terok_shield.hooks.install.USER_HOOKS_DIR",
-            Path("/fake/user"),
-        )
-        installer = HooksInstaller.user()
-        assert installer.target_dir == Path("/fake/user")
-        assert installer.use_sudo is False
-        assert installer.register_in_containers_conf is True
-
 
 # ── Install / uninstall lifecycle ────────────────────────
 
@@ -62,11 +33,15 @@ class TestInstallLifecycle:
     def test_install_writes_every_hook_file(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """A fresh non-sudo install lays down every name in ``_INSTALLED_FILES``."""
+        """A fresh install lays down every name in ``_SCRIPT_FILES`` + ``_DESCRIPTOR_FILES``."""
         monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "share"))
-        installer = HooksInstaller(target_dir=tmp_path / "hooks.d")
+        monkeypatch.setattr(
+            "terok_shield.hooks.install._user_containers_conf",
+            lambda: tmp_path / "containers.conf",
+        )
+        installer = HooksInstaller(target_dir=tmp_path / "hooks")
         installer.install()
-        for name in _INSTALLED_FILES:
+        for name in (*_SCRIPT_FILES, *_DESCRIPTOR_FILES):
             assert (installer.target_dir / name).is_file(), f"missing {name}"
 
     def test_install_marks_entrypoints_executable(
@@ -74,7 +49,11 @@ class TestInstallLifecycle:
     ) -> None:
         """The two role scripts get the executable bit; the ballast does not."""
         monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "share"))
-        installer = HooksInstaller(target_dir=tmp_path / "hooks.d")
+        monkeypatch.setattr(
+            "terok_shield.hooks.install._user_containers_conf",
+            lambda: tmp_path / "containers.conf",
+        )
+        installer = HooksInstaller(target_dir=tmp_path / "hooks")
         installer.install()
         assert (installer.target_dir / "terok-shield-hook").stat().st_mode & 0o100
         assert (installer.target_dir / "terok-shield-bridge-hook").stat().st_mode & 0o100
@@ -82,7 +61,11 @@ class TestInstallLifecycle:
     def test_install_is_idempotent(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """A second install overwrites without raising; file contents stay stable."""
         monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "share"))
-        installer = HooksInstaller(target_dir=tmp_path / "hooks.d")
+        monkeypatch.setattr(
+            "terok_shield.hooks.install._user_containers_conf",
+            lambda: tmp_path / "containers.conf",
+        )
+        installer = HooksInstaller(target_dir=tmp_path / "hooks")
         installer.install()
         first = (installer.target_dir / "terok-shield-hook").read_text()
         installer.install()
@@ -93,10 +76,14 @@ class TestInstallLifecycle:
     ) -> None:
         """``uninstall`` clears what ``install`` wrote — symmetric cleanup."""
         monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "share"))
-        installer = HooksInstaller(target_dir=tmp_path / "hooks.d")
+        monkeypatch.setattr(
+            "terok_shield.hooks.install._user_containers_conf",
+            lambda: tmp_path / "containers.conf",
+        )
+        installer = HooksInstaller(target_dir=tmp_path / "hooks")
         installer.install()
         installer.uninstall()
-        for name in _INSTALLED_FILES:
+        for name in (*_SCRIPT_FILES, *_DESCRIPTOR_FILES):
             assert not (installer.target_dir / name).exists()
 
     def test_uninstall_tolerates_missing_files(self, tmp_path: Path) -> None:
@@ -108,52 +95,16 @@ class TestInstallLifecycle:
     ) -> None:
         """The presence probe flips True after install, False after uninstall."""
         monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "share"))
-        installer = HooksInstaller(target_dir=tmp_path / "hooks.d")
+        monkeypatch.setattr(
+            "terok_shield.hooks.install._user_containers_conf",
+            lambda: tmp_path / "containers.conf",
+        )
+        installer = HooksInstaller(target_dir=tmp_path / "hooks")
         assert not installer.is_installed()
         installer.install()
         assert installer.is_installed()
         installer.uninstall()
         assert not installer.is_installed()
-
-
-# ── Sudo escalation path ─────────────────────────────────
-
-
-class TestSudoEscalation:
-    """``use_sudo=True`` routes writes and removals through ``sudo``."""
-
-    def test_install_runs_sudo_subprocess_chain(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """sudo mkdir + sudo cp + sudo chmod fire in that order."""
-        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "share"))
-        target = tmp_path / "system-hooks"
-        installer = HooksInstaller(target_dir=target, use_sudo=True)
-        with mock.patch("terok_shield.hooks.install.subprocess.run") as run:
-            installer.install()
-        argv0s = [call.args[0][0] for call in run.call_args_list]
-        assert argv0s == ["sudo", "sudo", "sudo"]
-        verbs = [call.args[0][1] for call in run.call_args_list]
-        assert verbs == ["mkdir", "cp", "chmod"]
-
-    def test_uninstall_runs_sudo_rm(self, tmp_path: Path) -> None:
-        """Sudo uninstall fires a single ``sudo rm -f`` listing every hook file."""
-        target = tmp_path / "system-hooks"
-        installer = HooksInstaller(target_dir=target, use_sudo=True)
-        with mock.patch("terok_shield.hooks.install.subprocess.run") as run:
-            installer.uninstall()
-        [(call,)] = [(c,) for c in run.call_args_list]
-        argv = call.args[0]
-        assert argv[:3] == ["sudo", "rm", "-f"]
-        assert {Path(p).name for p in argv[3:]} == set(_INSTALLED_FILES)
-
-    def test_remove_via_sudo_empty_list_short_circuits(self) -> None:
-        """Empty paths list returns without shelling out — defensive guard."""
-        from terok_shield.hooks.install import _remove_via_sudo
-
-        with mock.patch("terok_shield.hooks.install.subprocess.run") as run:
-            _remove_via_sudo([])
-        run.assert_not_called()
 
 
 # ── containers.conf registration ─────────────────────────
@@ -169,7 +120,7 @@ class TestRegisterHooksDir:
             "terok_shield.hooks.install._user_containers_conf",
             lambda: conf_dir / "containers.conf",
         )
-        _register_hooks_dir_in_containers_conf(Path(PLACEHOLDER_HOOKS_DIR))
+        ensure_user_hooks_dir_configured(Path(PLACEHOLDER_HOOKS_DIR))
         text = (conf_dir / "containers.conf").read_text()
         assert f'hooks_dir = ["{PLACEHOLDER_HOOKS_DIR}"]' in text
         assert text.count("[engine]") == 1
@@ -184,111 +135,82 @@ class TestRegisterHooksDir:
             "terok_shield.hooks.install._user_containers_conf",
             lambda: conf,
         )
-        _register_hooks_dir_in_containers_conf(Path(PLACEHOLDER_HOOKS_DIR))
+        ensure_user_hooks_dir_configured(Path(PLACEHOLDER_HOOKS_DIR))
         text = conf.read_text()
         assert text.count("[engine]") == 1
         assert f'hooks_dir = ["{PLACEHOLDER_HOOKS_DIR}"]' in text
         assert 'image_copy_tmp_dir = "/data/tmp"' in text
 
     def test_preserves_comments(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Comments in the file are preserved across the insert."""
+        """Existing comments around [engine] are preserved verbatim."""
         conf = tmp_path / "containers.conf"
-        conf.write_text('# My config\n[engine]\n# temp dir\nimage_copy_tmp_dir = "/data"\n')
+        conf.write_text("# preamble\n[engine]\n# inner comment\n")
         monkeypatch.setattr(
             "terok_shield.hooks.install._user_containers_conf",
             lambda: conf,
         )
-        _register_hooks_dir_in_containers_conf(Path(PLACEHOLDER_HOOKS_DIR))
+        ensure_user_hooks_dir_configured(Path(PLACEHOLDER_HOOKS_DIR))
         text = conf.read_text()
-        assert "# My config" in text
-        assert "# temp dir" in text
+        assert "# preamble" in text
+        assert "# inner comment" in text
 
-    def test_ignores_engine_in_comment(
+    def test_idempotent_on_same_value(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """A literal ``[engine]`` inside a comment doesn't trigger the insert."""
+        """A second call with the same value is a no-op."""
         conf = tmp_path / "containers.conf"
-        conf.write_text('# see [engine] docs\n[engine]\nfoo = "bar"\n')
         monkeypatch.setattr(
             "terok_shield.hooks.install._user_containers_conf",
             lambda: conf,
         )
-        _register_hooks_dir_in_containers_conf(Path(PLACEHOLDER_HOOKS_DIR))
-        text = conf.read_text()
-        assert text.count("[engine]") == 2  # one in comment, one real
-        assert text.count("hooks_dir") == 1
+        ensure_user_hooks_dir_configured(Path(PLACEHOLDER_HOOKS_DIR))
+        first = conf.read_text()
+        ensure_user_hooks_dir_configured(Path(PLACEHOLDER_HOOKS_DIR))
+        assert conf.read_text() == first
 
-    def test_skips_if_already_configured(
+    def test_appends_to_existing_other_path(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """No-op when hooks_dir already points to the right path."""
-        conf = tmp_path / "containers.conf"
-        conf.write_text(f'[engine]\nhooks_dir = ["{PLACEHOLDER_HOOKS_DIR}"]\n')
-        monkeypatch.setattr(
-            "terok_shield.hooks.install._user_containers_conf",
-            lambda: conf,
-        )
-        _register_hooks_dir_in_containers_conf(Path(PLACEHOLDER_HOOKS_DIR))
-        assert conf.read_text().count("hooks_dir") == 1
-
-    def test_appends_engine_when_no_section(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """Appends [engine] when the file has other sections but no [engine]."""
-        conf = tmp_path / "containers.conf"
-        conf.write_text("[containers]\nlabel = false\n")
-        monkeypatch.setattr(
-            "terok_shield.hooks.install._user_containers_conf",
-            lambda: conf,
-        )
-        _register_hooks_dir_in_containers_conf(Path(PLACEHOLDER_HOOKS_DIR))
-        text = conf.read_text()
-        assert "[containers]" in text
-        assert "[engine]" in text
-        assert f'hooks_dir = ["{PLACEHOLDER_HOOKS_DIR}"]' in text
-
-    def test_warns_when_different_hooks_dir_configured(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
-    ) -> None:
-        """Warns (does not modify) when hooks_dir is already set differently."""
+        """When containers.conf lists a different hooks_dir, ours is appended to the list."""
         conf = tmp_path / "containers.conf"
         conf.write_text(f'[engine]\nhooks_dir = ["{PLACEHOLDER_ALT_HOOKS_DIR}"]\n')
         monkeypatch.setattr(
             "terok_shield.hooks.install._user_containers_conf",
             lambda: conf,
         )
-        _register_hooks_dir_in_containers_conf(Path(PLACEHOLDER_HOOKS_DIR))
-        assert "Warning" in capsys.readouterr().out
-        assert conf.read_text().count("hooks_dir") == 1  # unchanged
+        ensure_user_hooks_dir_configured(Path(PLACEHOLDER_HOOKS_DIR))
+        text = conf.read_text()
+        assert PLACEHOLDER_ALT_HOOKS_DIR in text
+        assert PLACEHOLDER_HOOKS_DIR in text
+
+    def test_appends_to_list_with_inline_comment(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A hooks_dir line carrying a trailing ``#`` comment still gets ours appended."""
+        conf = tmp_path / "containers.conf"
+        conf.write_text(f'[engine]\nhooks_dir = ["{PLACEHOLDER_ALT_HOOKS_DIR}"]  # keep me\n')
+        monkeypatch.setattr(
+            "terok_shield.hooks.install._user_containers_conf",
+            lambda: conf,
+        )
+        ensure_user_hooks_dir_configured(Path(PLACEHOLDER_HOOKS_DIR))
+        text = conf.read_text()
+        assert PLACEHOLDER_ALT_HOOKS_DIR in text
+        assert PLACEHOLDER_HOOKS_DIR in text
+        assert "# keep me" in text
 
 
-# ── User-scope install registers in containers.conf ──────
+# ── Install also patches containers.conf ─────────────────
 
 
-def test_user_install_registers_in_containers_conf(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """``register_in_containers_conf=True`` patches containers.conf as part of install."""
+def test_install_patches_containers_conf(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``HooksInstaller.install()`` adds its target_dir to containers.conf."""
     monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "share"))
     conf = tmp_path / "containers.conf"
     monkeypatch.setattr(
         "terok_shield.hooks.install._user_containers_conf",
         lambda: conf,
     )
-    installer = HooksInstaller(target_dir=tmp_path / "hooks.d", register_in_containers_conf=True)
+    installer = HooksInstaller(target_dir=tmp_path / "hooks")
     installer.install()
     assert str(installer.target_dir) in conf.read_text()
-
-
-def test_non_user_install_skips_containers_conf(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """``register_in_containers_conf=False`` leaves containers.conf untouched."""
-    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "share"))
-    conf = tmp_path / "containers.conf"
-    monkeypatch.setattr(
-        "terok_shield.hooks.install._user_containers_conf",
-        lambda: conf,
-    )
-    HooksInstaller(target_dir=tmp_path / "hooks.d").install()
-    assert not conf.exists()

--- a/tests/unit/test_nflog_reader.py
+++ b/tests/unit/test_nflog_reader.py
@@ -21,7 +21,12 @@ import pytest
 
 from terok_shield.resources import nflog_reader as reader
 
-from ..testfs import AUDIT_FILENAME, DNSMASQ_LOG_FILENAME, READER_EVENTS_SOCK_FILENAME
+from ..testfs import (
+    AUDIT_FILENAME,
+    DNSMASQ_LOG_FILENAME,
+    READER_EVENTS_SOCK_FILENAME,
+    RUN_USER_PREFIX,
+)
 from ..testnet import (
     DNSMASQ_DOMAIN,
     IPV6_MCAST_ALL_ROUTERS,
@@ -142,8 +147,38 @@ class TestSelectEmitter:
     def test_json_mode_returns_json_emitter(self) -> None:
         assert isinstance(reader._select_emitter("json"), reader.JsonEmitter)
 
-    def test_default_mode_returns_socket_emitter(self) -> None:
-        assert isinstance(reader._select_emitter("socket"), reader.SocketEmitter)
+    def test_default_mode_returns_socket_emitter(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+        assert isinstance(
+            reader._select_emitter("socket", container_id="c" * 64),
+            reader.SocketEmitter,
+        )
+
+    def test_socket_emitter_uses_per_container_path(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """A non-empty ``container_id`` routes the socket emitter at the per-container path.
+
+        The basename uses the 12-char short ID so the path fits within
+        AF_UNIX's 108-byte ``sun_path`` limit.
+        """
+        monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+        cid = "cafef00d" * 8
+        emitter = reader._select_emitter("socket", container_id=cid)
+        assert isinstance(emitter, reader.SocketEmitter)
+        assert emitter._path == tmp_path / "terok" / "events" / f"{cid[:12]}.sock"
+
+    def test_socket_emitter_uses_explicit_hub_socket(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """An explicit ``hub_socket`` wins over the per-container default."""
+        monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+        override = tmp_path / "custom.sock"
+        emitter = reader._select_emitter("socket", container_id="abc", hub_socket=str(override))
+        assert isinstance(emitter, reader.SocketEmitter)
+        assert emitter._path == override
 
 
 class TestParseAnnotations:
@@ -337,18 +372,51 @@ class TestIsNoiseDest:
         assert reader._is_noise_dest("not-an-ip") is False
 
 
-class TestEventsSocketPath:
-    """``_events_socket_path`` honours XDG, falls back to /run/user/<uid>."""
+class TestResolveHubSocketPath:
+    """``_resolve_hub_socket_path`` picks the per-container path or the explicit override.
 
-    def test_xdg_runtime_dir_wins(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    Resolution order is the contract the OCI bridge hook and the
+    per-container supervisor rely on — explicit ``--hub-socket`` first,
+    then ``--container-id`` derived per-container path.  Neither
+    supplied is a programming error and must raise loudly rather than
+    silently picking a global default.
+    """
+
+    def test_explicit_hub_socket_wins(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """An explicit ``hub_socket`` is used verbatim even when a container id is also set."""
         monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
-        assert reader._events_socket_path() == tmp_path / "terok-shield-events.sock"
+        override = tmp_path / "explicit.sock"
+        assert (
+            reader._resolve_hub_socket_path(container_id="ignored", hub_socket=str(override))
+            == override
+        )
+
+    def test_container_id_builds_per_container_path(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """The 12-char short ID becomes the basename — AF_UNIX path limit avoidance."""
+        monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+        cid = "f" * 64  # full podman UUID shape
+        assert reader._resolve_hub_socket_path(container_id=cid) == (
+            tmp_path / "terok" / "events" / f"{cid[:12]}.sock"
+        )
+
+    def test_neither_raises(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """Missing both arguments must surface a clear, specific error."""
+        monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+        with pytest.raises(SystemExit) as excinfo:
+            reader._resolve_hub_socket_path()
+        assert "neither --hub-socket nor --container-id supplied" in str(excinfo.value)
 
     def test_xdg_missing_falls_back_to_run_user(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Direct CLI invocation without ``XDG_RUNTIME_DIR`` lands under ``/run/user/<uid>``."""
         monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
-        path = reader._events_socket_path()
-        assert str(path).startswith("/run/user/")
-        assert path.name == "terok-shield-events.sock"
+        # Per-container branch still composes the path beneath /run/user/<uid>.
+        path = reader._resolve_hub_socket_path(container_id="abc")
+        assert str(path).startswith(RUN_USER_PREFIX)
+        assert path.name == "abc.sock"
 
 
 class TestResolveBinary:

--- a/tests/unit/test_reader_hook.py
+++ b/tests/unit/test_reader_hook.py
@@ -23,7 +23,7 @@ import pytest
 
 from terok_shield.resources import _oci_state, reader_hook
 
-from ..testfs import HOOK_ENTRYPOINT_PATH
+from ..testfs import HOOK_ENTRYPOINT_PATH, READER_SCRIPT_BAKED_PATH
 
 _CONTAINER_ID = "c" * 64
 _SHORT_ID = _CONTAINER_ID[:12]
@@ -77,7 +77,7 @@ class TestBridgeDispatch:
         oci = _oci_json(str(tmp_path))
         with mock.patch.object(reader_hook, "_spawn_reader") as spawn:
             _run_bridge(oci, stage="createRuntime")
-        spawn.assert_called_once_with(tmp_path, _SHORT_ID, {})
+        spawn.assert_called_once_with(tmp_path, _SHORT_ID, {}, _CONTAINER_ID)
 
     def test_createruntime_extracts_dossier_annotations(self, tmp_path: Path) -> None:
         """``dossier.*`` annotations are stripped of their prefix and passed through."""
@@ -107,6 +107,7 @@ class TestBridgeDispatch:
                 "project": "terok",
                 "meta_path": "/var/lib/terok/tasks/abc.json",
             },
+            _CONTAINER_ID,
         )
 
     def test_poststop_invokes_reap_reader(self, tmp_path: Path) -> None:
@@ -301,7 +302,7 @@ class TestSpawnReader:
             ),
             mock.patch.object(_oci_state.subprocess, "Popen", return_value=fake_proc) as popen,
         ):
-            reader_hook._spawn_reader(tmp_path, _SHORT_ID)
+            reader_hook._spawn_reader(tmp_path, _SHORT_ID, full_container_id=_CONTAINER_ID)
         assert (tmp_path / "reader.pid").read_text().strip() == "12345"
         cmd = popen.call_args[0][0]
         assert cmd[:2] == ["/usr/bin/python3", str(reader)]
@@ -310,6 +311,8 @@ class TestSpawnReader:
         assert "--emit=socket" in cmd
         # Default-empty dossier is still serialised so the reader's argparse always sees the flag.
         assert "--annotations={}" in cmd
+        # Full UUID flows through so the reader resolves the per-container hub socket.
+        assert f"--container-id={_CONTAINER_ID}" in cmd
         env = popen.call_args[1]["env"]
         assert env["DBUS_SESSION_BUS_ADDRESS"] == "unix:path=/run/user/1000/bus"
         assert popen.call_args[1]["start_new_session"] is True
@@ -331,6 +334,23 @@ class TestSpawnReader:
         cmd = popen.call_args[0][0]
         ann_arg = next(a for a in cmd if a.startswith("--annotations="))
         assert json.loads(ann_arg.removeprefix("--annotations=")) == dossier
+
+    def test_full_container_id_is_forwarded_as_container_id_argv(self, tmp_path: Path) -> None:
+        """The full UUID lands as ``--container-id=<uuid>`` so the reader can key the per-container hub socket."""
+        reader = tmp_path / "reader.py"
+        reader.touch()
+        fake_proc = mock.MagicMock(pid=12345)
+        with (
+            mock.patch.object(reader_hook, "_reader_script_path", return_value=reader),
+            mock.patch.object(
+                reader_hook, "_session_bus_address", return_value="unix:path=/run/user/1000/bus"
+            ),
+            mock.patch.object(_oci_state.subprocess, "Popen", return_value=fake_proc) as popen,
+        ):
+            reader_hook._spawn_reader(tmp_path, _SHORT_ID, full_container_id=_CONTAINER_ID)
+        cmd = popen.call_args[0][0]
+        cid_arg = next(a for a in cmd if a.startswith("--container-id="))
+        assert cid_arg.removeprefix("--container-id=") == _CONTAINER_ID
 
     def test_idempotent_when_reader_already_alive(self, tmp_path: Path) -> None:
         reader = tmp_path / "reader.py"
@@ -473,6 +493,9 @@ class TestIsOurReader:
             + b"\x00"
             + str(tmp_path).encode()
             + b"\x00cccccccccccc\x00--emit=socket\x00--annotations={}\x00"
+            + b"--container-id="
+            + _CONTAINER_ID.encode()
+            + b"\x00"
         )
         with (
             mock.patch.object(reader_hook, "_reader_script_path", return_value=reader),
@@ -661,22 +684,17 @@ class TestPidExists:
 
 
 class TestReaderScriptPath:
-    """``_reader_script_path`` honours XDG, falls back under HOME."""
+    """``_reader_script_path`` returns the installer-baked path verbatim.
 
-    def test_xdg_data_home_wins(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
-        assert reader_hook._reader_script_path() == (
-            tmp_path / "terok" / "shield" / "nflog-reader.py"
-        )
+    The hook script no longer guesses an XDG location at runtime;
+    ``terok-shield setup`` writes a templated copy with the resolved
+    [`reader_script_path()`][terok_shield.paths.reader_script_path]
+    (which honours ``paths.root``) baked into ``_READER_SCRIPT_PATH``.
+    """
 
-    def test_falls_back_to_home_local_share(
-        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-    ) -> None:
-        monkeypatch.delenv("XDG_DATA_HOME", raising=False)
-        monkeypatch.setenv("HOME", str(tmp_path))
-        assert reader_hook._reader_script_path() == (
-            tmp_path / ".local" / "share" / "terok" / "shield" / "nflog-reader.py"
-        )
+    def test_returns_baked_constant(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(reader_hook, "_READER_SCRIPT_PATH", READER_SCRIPT_BAKED_PATH)
+        assert reader_hook._reader_script_path() == Path(READER_SCRIPT_BAKED_PATH)
 
 
 class TestPersistMetaPath:

--- a/tests/unit/test_shield_facade.py
+++ b/tests/unit/test_shield_facade.py
@@ -250,23 +250,23 @@ def test_down_delegates_and_logs(
 ) -> None:
     """down() delegates to the backend, logs, and pings the hub."""
     harness = make_shield()
-    harness.shield.down("test-ctr", allow_all=allow_all)
+    harness.shield.down("test-ctr", "ctr-uuid-1", allow_all=allow_all)
     harness.mode.shield_down.assert_called_once_with("test-ctr", allow_all=allow_all)
     harness.audit.log_event.assert_called_once_with(
         "test-ctr", "shield_down", detail=expected_detail
     )
     harness.hub_events.shield_down.assert_called_once_with(
-        "test-ctr", allow_all=allow_all, dossier={}
+        "test-ctr", "ctr-uuid-1", allow_all=allow_all, dossier={}
     )
 
 
 def test_up_delegates_and_logs(make_shield: ShieldHarnessFactory) -> None:
     """up() delegates to the backend, logs, and pings the hub."""
     harness = make_shield()
-    harness.shield.up("test-ctr")
+    harness.shield.up("test-ctr", "ctr-uuid-1")
     harness.mode.shield_up.assert_called_once_with("test-ctr")
     harness.audit.log_event.assert_called_once_with("test-ctr", "shield_up")
-    harness.hub_events.shield_up.assert_called_once_with("test-ctr", dossier={})
+    harness.hub_events.shield_up.assert_called_once_with("test-ctr", "ctr-uuid-1", dossier={})
 
 
 def test_up_resolves_dossier_via_meta_path(
@@ -284,9 +284,10 @@ def test_up_resolves_dossier_via_meta_path(
     meta.write_text(json.dumps({"project": "terok", "task": "abc", "name": "diligent-octopus"}))
     StateBundle(state_dir).meta_path.write_text(str(meta))
     harness = make_shield()
-    harness.shield.up("test-ctr")
+    harness.shield.up("test-ctr", "ctr-uuid-1")
     harness.hub_events.shield_up.assert_called_once_with(
         "test-ctr",
+        "ctr-uuid-1",
         dossier={"project": "terok", "task": "abc", "name": "diligent-octopus"},
     )
 
@@ -299,9 +300,10 @@ def test_down_resolves_dossier_via_meta_path(
     meta.write_text(json.dumps({"project": "terok", "task": "xyz"}))
     StateBundle(state_dir).meta_path.write_text(str(meta))
     harness = make_shield()
-    harness.shield.down("test-ctr", allow_all=True)
+    harness.shield.down("test-ctr", "ctr-uuid-1", allow_all=True)
     harness.hub_events.shield_down.assert_called_once_with(
         "test-ctr",
+        "ctr-uuid-1",
         allow_all=True,
         dossier={"project": "terok", "task": "xyz"},
     )
@@ -454,12 +456,31 @@ def _run_side_effect(podman_version: str = "5.8.0"):
 class TestCheckEnvironment:
     """Tests for Shield.check_environment()."""
 
+    @staticmethod
+    def _write_hook_layout(hooks_dir: Path, ballast_body: str) -> None:
+        """Write a JSON descriptor + ballast in the layout the version probe expects.
+
+        The probe follows the descriptor's ``hook.path`` to find the
+        script, then reads ``_oci_state.py`` next to it.  Single-flavor
+        installs put descriptors and scripts in the same dir, so the
+        helper just lays both there.
+        """
+        import json
+
+        from terok_shield.podman_info.hooks_dir import HOOK_JSON_FILENAME
+
+        hooks_dir.mkdir(parents=True, exist_ok=True)
+        script_path = hooks_dir / "terok-shield-hook"
+        script_path.write_text("#!/usr/bin/env python3\n")
+        (hooks_dir / "_oci_state.py").write_text(ballast_body)
+        (hooks_dir / HOOK_JSON_FILENAME).write_text(
+            json.dumps({"hook": {"path": str(script_path), "args": []}})
+        )
+
     @mock.patch("terok_shield.find_hooks_dirs", return_value=[Path("/fake/hooks")])
     @mock.patch("terok_shield.has_global_hooks", return_value=True)
-    @mock.patch("terok_shield.system_hooks_dir", return_value=Path("/fake/hooks"))
     def test_dig_missing_reports_issue(
         self,
-        _sys_dir: mock.Mock,
         _has_hooks: mock.Mock,
         _find_dirs: mock.Mock,
         make_shield: ShieldHarnessFactory,
@@ -492,10 +513,8 @@ class TestCheckEnvironment:
 
     @mock.patch("terok_shield.find_hooks_dirs", return_value=[Path("/fake/hooks")])
     @mock.patch("terok_shield.has_global_hooks", return_value=True)
-    @mock.patch("terok_shield.system_hooks_dir", return_value=Path("/fake/hooks"))
     def test_stale_hooks_on_persistent_podman(
         self,
-        _sys_dir: mock.Mock,
         _has_hooks: mock.Mock,
         _find_dirs: mock.Mock,
         make_shield: ShieldHarnessFactory,
@@ -514,51 +533,25 @@ class TestCheckEnvironment:
     @mock.patch("terok_shield._read_installed_hook_version", return_value=state.BUNDLE_VERSION)
     @mock.patch("terok_shield.find_hooks_dirs", return_value=[Path("/fake/hooks")])
     @mock.patch("terok_shield.has_global_hooks", return_value=True)
-    @mock.patch("terok_shield.system_hooks_dir", return_value=Path("/fake/hooks"))
-    def test_global_system_hooks(
+    def test_global_hooks_installed(
         self,
-        _sys_dir: mock.Mock,
         _has_hooks: mock.Mock,
         _find_dirs: mock.Mock,
         _hook_ver: mock.Mock,
         make_shield: ShieldHarnessFactory,
     ) -> None:
-        """System global hooks → ok/global-system."""
+        """Global hooks present + version match → ok/global."""
         harness = make_shield()
         harness.runner.run.side_effect = _run_side_effect("5.8.0")
         env = harness.shield.check_environment()
         assert env.ok
         assert env.health == "ok"
-        assert env.hooks == "global-system"
-
-    @mock.patch("terok_shield._read_installed_hook_version", return_value=state.BUNDLE_VERSION)
-    @mock.patch("terok_shield.find_hooks_dirs", return_value=[Path("/user/hooks")])
-    @mock.patch("terok_shield.system_hooks_dir", return_value=Path("/nonexistent"))
-    def test_global_user_hooks(
-        self,
-        _sys_dir: mock.Mock,
-        _find_dirs: mock.Mock,
-        _hook_ver: mock.Mock,
-        make_shield: ShieldHarnessFactory,
-    ) -> None:
-        """User global hooks (not system) → ok/global-user."""
-        harness = make_shield()
-        harness.runner.run.side_effect = _run_side_effect("5.8.0")
-
-        # First call (hooks_dirs from find_hooks_dirs) -> True (hooks exist)
-        # Second call ([sys_dir]) -> False (not in system dir)
-        with mock.patch("terok_shield.has_global_hooks", side_effect=[True, False]):
-            env = harness.shield.check_environment()
-        assert env.ok
-        assert env.health == "ok"
-        assert env.hooks == "global-user"
+        assert env.hooks == "global"
 
     @mock.patch("terok_shield.find_hooks_dirs")
     @mock.patch("terok_shield.has_global_hooks", return_value=True)
-    @mock.patch("terok_shield.system_hooks_dir", return_value=Path("/fake/hooks"))
     def test_stale_hook_version_detected(
         self,
-        _sys_dir: mock.Mock,
         _has_hooks: mock.Mock,
         _find_dirs: mock.Mock,
         make_shield: ShieldHarnessFactory,
@@ -566,8 +559,7 @@ class TestCheckEnvironment:
     ) -> None:
         """Mismatched ballast version → stale-hooks health status."""
         hooks_dir = tmp_path / "hooks.d"
-        hooks_dir.mkdir()
-        (hooks_dir / "_oci_state.py").write_text("BUNDLE_VERSION = 1\n")
+        self._write_hook_layout(hooks_dir, "BUNDLE_VERSION = 1\n")
         _find_dirs.return_value = [hooks_dir]
 
         harness = make_shield()
@@ -578,10 +570,8 @@ class TestCheckEnvironment:
 
     @mock.patch("terok_shield.find_hooks_dirs")
     @mock.patch("terok_shield.has_global_hooks", return_value=True)
-    @mock.patch("terok_shield.system_hooks_dir", return_value=Path("/fake/hooks"))
     def test_unreadable_hook_version_treated_as_stale(
         self,
-        _sys_dir: mock.Mock,
         _has_hooks: mock.Mock,
         _find_dirs: mock.Mock,
         make_shield: ShieldHarnessFactory,
@@ -589,8 +579,7 @@ class TestCheckEnvironment:
     ) -> None:
         """Ballast file without ``BUNDLE_VERSION`` line → stale-hooks (not silently ok)."""
         hooks_dir = tmp_path / "hooks.d"
-        hooks_dir.mkdir()
-        (hooks_dir / "_oci_state.py").write_text("# no version here\n")
+        self._write_hook_layout(hooks_dir, "# no version here\n")
         _find_dirs.return_value = [hooks_dir]
 
         harness = make_shield()
@@ -604,21 +593,39 @@ class TestCheckEnvironment:
 
 
 class TestReadInstalledHookVersion:
-    """Tests for the _read_installed_hook_version helper."""
+    """Tests for the _read_installed_hook_version helper.
+
+    User-scope installs split scripts from descriptors: the JSON
+    descriptor in ``hooks_dir`` carries the absolute ``path`` of the
+    role script, and the ballast lives next to that script.  The fixture
+    helpers mirror that layout: ``_write_layout`` writes a descriptor in
+    ``hooks_dir`` and a ballast in a sibling ``script_dir``.
+    """
+
+    @staticmethod
+    def _write_layout(hooks_dir: Path, script_dir: Path, ballast_body: str) -> None:
+        import json
+
+        from terok_shield.podman_info.hooks_dir import HOOK_JSON_FILENAME
+
+        hooks_dir.mkdir(parents=True, exist_ok=True)
+        script_dir.mkdir(parents=True, exist_ok=True)
+        script_path = script_dir / "terok-shield-hook"
+        script_path.write_text("#!/usr/bin/env python3\n")
+        (script_dir / "_oci_state.py").write_text(ballast_body)
+        (hooks_dir / HOOK_JSON_FILENAME).write_text(
+            json.dumps({"hook": {"path": str(script_path), "args": []}})
+        )
 
     def test_reads_version_from_hook(self, tmp_path: Path) -> None:
-        """Extracts ``BUNDLE_VERSION`` from the installed ballast module."""
+        """Extracts ``BUNDLE_VERSION`` via the descriptor's script-path reference."""
         from terok_shield import _read_installed_hook_version
 
-        hooks_dir = tmp_path / "hooks.d"
-        hooks_dir.mkdir()
-        # The version lives in the shared ``_oci_state.py`` ballast that
-        # the role scripts import from at runtime.
-        (hooks_dir / "_oci_state.py").write_text("BUNDLE_VERSION = 42\n")
-        assert _read_installed_hook_version([hooks_dir]) == 42
+        self._write_layout(tmp_path / "hooks.d", tmp_path / "scripts", "BUNDLE_VERSION = 42\n")
+        assert _read_installed_hook_version([tmp_path / "hooks.d"]) == 42
 
-    def test_returns_none_when_no_hook(self, tmp_path: Path) -> None:
-        """Returns None when no hook entrypoint is found."""
+    def test_returns_none_when_no_descriptor(self, tmp_path: Path) -> None:
+        """Returns None when no shield JSON descriptor is found."""
         from terok_shield import _read_installed_hook_version
 
         assert _read_installed_hook_version([tmp_path]) is None
@@ -627,21 +634,16 @@ class TestReadInstalledHookVersion:
         """Returns None when the ballast file cannot be read."""
         from terok_shield import _read_installed_hook_version
 
-        hooks_dir = tmp_path / "hooks.d"
-        hooks_dir.mkdir()
-        ballast = hooks_dir / "_oci_state.py"
-        ballast.write_text("BUNDLE_VERSION = 5\n")
+        self._write_layout(tmp_path / "hooks.d", tmp_path / "scripts", "BUNDLE_VERSION = 5\n")
         with mock.patch.object(Path, "read_text", side_effect=OSError("boom")):
-            assert _read_installed_hook_version([hooks_dir]) is None
+            assert _read_installed_hook_version([tmp_path / "hooks.d"]) is None
 
     def test_returns_none_on_no_match(self, tmp_path: Path) -> None:
         """Returns None when the ballast file has no ``BUNDLE_VERSION`` line."""
         from terok_shield import _read_installed_hook_version
 
-        hooks_dir = tmp_path / "hooks.d"
-        hooks_dir.mkdir()
-        (hooks_dir / "_oci_state.py").write_text("# no version here\n")
-        assert _read_installed_hook_version([hooks_dir]) is None
+        self._write_layout(tmp_path / "hooks.d", tmp_path / "scripts", "# no version here\n")
+        assert _read_installed_hook_version([tmp_path / "hooks.d"]) is None
 
 
 from terok_shield.state import StateBundle


### PR DESCRIPTION
Per-container NFLOG reader sockets; single user-owned install layout (no `--root`). Reader hook passes the container ID through so per-container clearance hubs receive the right events.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shield up/down now require a per-container identifier and deliver hub events to per-container sockets.
  * CLI: down/up subcommands now require --container-id.

* **Bug Fixes**
  * Loopback ports are persisted per-container (state bundle), improving isolation and correctness.

* **Refactor**
  * Setup/install simplified to a single non-interactive install path (no --root/--user).
  * Wire protocol/state layout bumped to v14; installer embeds reader path and uses a canonical hooks location.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->