### PR TITLE
fix(dns): fall back to dig when AppArmor confines dnsmasq

### DIFF
--- a/docs/apparmor.md
+++ b/docs/apparmor.md
@@ -1,0 +1,67 @@
+# AppArmor & the dnsmasq DNS tier
+
+shield's strongest DNS-egress mode runs a per-container **dnsmasq** that
+auto-populates the nft allow sets from live DNS replies (the `dnsmasq`
+tier — it handles domains with rotating IPs). That dnsmasq reads its
+config and writes its pid/log under the per-task shield state directory
+in your home (`~/.local/share/terok/.../shield/`).
+
+## On AppArmor-enforcing hosts
+
+Distributions that ship an **enforcing AppArmor profile for
+`/usr/sbin/dnsmasq`** (Arch/Manjaro, and anywhere the [`apparmor.d`][1]
+profile set is installed) confine dnsmasq to the conventional server
+paths and forbid your home directory, so the confined dnsmasq is denied
+reading its config there.
+
+shield handles this automatically: at pre-start it probes whether a
+confined dnsmasq can read the state dir (running `dnsmasq --test` — no
+root needed) and, if not, **falls back to the `dig` tier**. Egress
+filtering stays fully enforced; only DNS handling degrades — domain
+allowlists resolve statically at pre-start instead of tracking IP
+rotation live. The fallback is recorded in the per-container audit log.
+
+## Keeping the dnsmasq tier
+
+Extend the host's `dnsmasq` profile to allow the shield state tree.
+Substitute your sandbox root for `STATE_ROOT` (default
+`~/.local/share/terok/sandbox-live`):
+
+```
+owner STATE_ROOT/tasks/*/*/shield/dnsmasq.conf r,
+owner STATE_ROOT/tasks/*/*/shield/dnsmasq.pid rwk,
+owner STATE_ROOT/tasks/*/*/shield/dnsmasq.log rwk,
+/usr/share/iproute2/* r,
+```
+
+Drop the rules into the profile's local include and reload:
+
+- Debian/Ubuntu (`/etc/apparmor.d/usr.sbin.dnsmasq`): edit
+  `/etc/apparmor.d/local/usr.sbin.dnsmasq`, then
+  `sudo apparmor_parser -r -W /etc/apparmor.d/usr.sbin.dnsmasq`.
+- `apparmor.d` / Arch (profile named `dnsmasq`): edit
+  `/etc/apparmor.d/local/dnsmasq`, then
+  `sudo apparmor_parser -r -W /etc/apparmor.d/dnsmasq`.
+
+`sudo aa-status` should still show `dnsmasq` in enforce mode; re-run a
+task and `dns.tier` in the shield state dir returns to `dnsmasq`.
+
+> AppArmor mediates by pathname, so the addendum names your state root —
+> regenerate it if you move the sandbox dir (`TEROK_*_DIR` /
+> `XDG_DATA_HOME`).
+
+## If you can't install the profile
+
+The automatic `dig` fallback keeps you working unprivileged; no action
+needed. shield does not bypass the profile (e.g. by running dnsmasq
+unconfined), as that would override a policy the host administrator set.
+
+## Not yet implemented
+
+- **Installer / setup advertising** for the addendum above — it is
+  currently a manual step. Generating it belongs to the orchestrator
+  (terok), which owns the per-task directory layout.
+- **Explicit DNS-tier pinning** — tier selection is automatic; there is
+  no config knob to force or disable a tier yet.
+
+[1]: https://github.com/roddhjav/apparmor.d

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ packages = [
 include = [
   { path = "src/terok_shield/resources/nflog_reader.py", format = ["sdist", "wheel"] },
 ]
-version = "0.6.42a9"
+version = "0.6.42a10"
 
 [tool.poetry.group.dev.dependencies]
 ruff = ">=0.15.15"

--- a/src/terok_shield/__init__.py
+++ b/src/terok_shield/__init__.py
@@ -33,7 +33,6 @@ from .config import (
     ShieldModeBackend,
     ShieldRuntime,
     ShieldState,
-    detect_dns_tier,
 )
 from .paths import HOOK_ENTRYPOINT_NAME
 from .podman_info import (
@@ -234,7 +233,7 @@ class Shield:
         Does not raise — the caller decides how to handle issues.
         """
         from . import state
-        from .dns import dnsmasq
+        from .dns import apparmor
 
         output = self.runner.run(["podman", "info", "-f", "json"], check=False)
         info = parse_podman_info(output)
@@ -244,9 +243,18 @@ class Shield:
         hooks = "per-container"
         health = "ok"
 
-        tier = detect_dns_tier(self.runner.has, lambda: dnsmasq.has_nftset_support(self.runner))
+        tier, apparmor_blocked = apparmor.detect_dns_tier_under_apparmor(
+            self.runner, self.config.state_dir
+        )
         dns_tier = tier.value
-        if tier == DnsTier.DIG:
+        if apparmor_blocked:
+            issues.append(
+                "dnsmasq is present but AppArmor confines it from the shield "
+                f"state directory — domain allowlisting falls back to static {tier.value} "
+                "resolution (no IP rotation handling). Install the terok AppArmor "
+                "profile to enable the dnsmasq tier (see docs/apparmor.md)"
+            )
+        elif tier == DnsTier.DIG:
             issues.append(
                 "dnsmasq not found — domain allowlisting uses static pre-start "
                 "resolution (no IP rotation handling). "

--- a/src/terok_shield/config.py
+++ b/src/terok_shield/config.py
@@ -58,19 +58,26 @@ class DnsTier(enum.Enum):
 def detect_dns_tier(
     has: Callable[[str], bool],
     dnsmasq_nftset_ok: Callable[[], bool] = lambda: True,
+    dnsmasq_state_readable: Callable[[], bool] = lambda: True,
 ) -> DnsTier:
     """Detect the best available DNS resolution tier.
 
     Probes for executables in priority order: dnsmasq (with nftset
-    support) > dig > getent.
+    support, and able to read its config) > dig > getent.
 
     Args:
         has: Returns True if the named executable exists on PATH.
         dnsmasq_nftset_ok: Returns True if installed dnsmasq supports
             ``--nftset``.  Defaults to ``lambda: True`` (skip probe);
             production callers should pass a real capability check.
+        dnsmasq_state_readable: Returns True if dnsmasq can read its
+            config from the shield state directory.  Returns False when
+            an enforcing AppArmor profile confines dnsmasq away from it,
+            so we fall back to ``dig`` rather than fail the launch.
+            Defaults to ``lambda: True``; production callers pass a real
+            probe.
     """
-    if has("dnsmasq") and dnsmasq_nftset_ok():
+    if has("dnsmasq") and dnsmasq_nftset_ok() and dnsmasq_state_readable():
         return DnsTier.DNSMASQ
     if has("dig"):
         return DnsTier.DIG

--- a/src/terok_shield/dns/apparmor.py
+++ b/src/terok_shield/dns/apparmor.py
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+"""AppArmor awareness for the per-container dnsmasq DNS tier.
+
+Some distros (Arch/Manjaro, the ``apparmor.d`` profile set) ship an
+enforcing AppArmor profile for ``/usr/sbin/dnsmasq`` that forbids the
+shield state directory under the operator's home, so the per-container
+dnsmasq cannot read its config and the container would fail to launch.
+This module probes for that confinement behaviourally (via ``dnsmasq
+--test`` — no root needed) and drives a fallback to the ``dig`` tier.
+The profile addendum that lets operators keep the dnsmasq tier is
+documented in ``docs/apparmor.md``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ..config import DnsTier, detect_dns_tier
+from ..run import CommandRunner, ExecError
+from . import dnsmasq
+
+# Throwaway config dnsmasq --test reads to probe state-dir access.
+_PROBE_NAME = ".apparmor-probe.conf"
+_PROBE_CONTENT = "# terok-shield AppArmor access probe\n"
+_PROBE_TIMEOUT_S = 10  # dnsmasq --test only parses and exits
+
+
+def detect_dns_tier_under_apparmor(runner: CommandRunner, state_dir: Path) -> tuple[DnsTier, bool]:
+    """Pick the DNS tier and report whether AppArmor blocked dnsmasq.
+
+    Returns ``(tier, apparmor_blocked)``.  *apparmor_blocked* is True when
+    an otherwise-eligible dnsmasq was rejected because AppArmor confines
+    it from *state_dir*, so *tier* dropped to a static fallback (dig or
+    getent).  The confinement probe runs only once dnsmasq is otherwise
+    eligible, so it is skipped when dnsmasq is already out.
+    """
+    nftset_ok = runner.has("dnsmasq") and dnsmasq.has_nftset_support(runner)
+    readable = dnsmasq_can_read_state_dir(runner, state_dir) if nftset_ok else True
+    tier = detect_dns_tier(runner.has, lambda: nftset_ok, lambda: readable)
+    return tier, nftset_ok and not readable
+
+
+def dnsmasq_can_read_state_dir(runner: CommandRunner, state_dir: Path) -> bool:
+    """Return True if dnsmasq can read a config file inside *state_dir*.
+
+    Writes a throwaway probe config and runs ``dnsmasq --test`` on it; a
+    permission denial (AppArmor) returns False.  Parse errors, a missing
+    binary, or an unwritable probe return True so tier selection never
+    downgrades spuriously.
+    """
+    probe = state_dir / _PROBE_NAME
+    try:
+        probe.write_text(_PROBE_CONTENT)
+    except OSError:
+        return True
+    try:
+        runner.run(
+            ["dnsmasq", "--test", f"--conf-file={probe}"],
+            check=True,
+            timeout=_PROBE_TIMEOUT_S,
+        )
+        return True
+    except ExecError as exc:
+        # AppArmor-denied open() surfaces as EACCES → "...: Permission denied".
+        return "permission denied" not in exc.stderr.lower()
+    finally:
+        probe.unlink(missing_ok=True)

--- a/src/terok_shield/hooks/mode.py
+++ b/src/terok_shield/hooks/mode.py
@@ -39,9 +39,8 @@ from ..config import (
     ShieldConfig,
     ShieldRuntime,
     ShieldState,
-    detect_dns_tier,
 )
-from ..dns import dnsmasq
+from ..dns import apparmor, dnsmasq
 from ..nft.constants import (
     DNSMASQ_BIND_DEFAULT,
     DNSMASQ_BIND_KRUN,
@@ -138,7 +137,7 @@ class HookMode:
         )
 
         # Detect DNS tier, upstream DNS, and gateway addresses
-        tier = self._detect_dns_tier()
+        tier = self._detect_dns_tier(container, sd)
         mode = info.network_mode or "pasta"
         upstream_dns = _upstream_dns_for_mode(mode)
         gw_v4, gw_v6 = self._gateways = _gateways_for_mode(mode)
@@ -292,9 +291,20 @@ class HookMode:
             f"host.containers.internal:{PASTA_HOST_LOOPBACK_MAP}",
         ]
 
-    def _detect_dns_tier(self) -> DnsTier:
-        """Detect the best available DNS resolution tier."""
-        return detect_dns_tier(self._runner.has, lambda: dnsmasq.has_nftset_support(self._runner))
+    def _detect_dns_tier(self, container: str, state_dir: Path) -> DnsTier:
+        """Pick the DNS tier, logging an advisory when AppArmor downgrades dnsmasq."""
+        tier, apparmor_blocked = apparmor.detect_dns_tier_under_apparmor(self._runner, state_dir)
+        if apparmor_blocked:
+            self._audit.log_event(
+                container,
+                "setup",
+                detail=(
+                    f"DNS tier fell back to {tier.value}: AppArmor confines dnsmasq "
+                    f"from {state_dir}. Install the terok AppArmor profile to keep "
+                    "the dnsmasq tier — see docs/apparmor.md."
+                ),
+            )
+        return tier
 
     def _get_podman_info(self) -> PodmanInfo:
         """Get podman info, caching the result for the lifetime of this instance."""

--- a/tach.toml
+++ b/tach.toml
@@ -132,6 +132,14 @@ layer = "core"
 depends_on = [
 ]
 
+# AppArmor confinement probe + dnsmasq-tier selection
+[[modules]]
+path = "terok_shield.dns.apparmor"
+layer = "core"
+depends_on = [
+    "terok_shield.dns.dnsmasq",
+]
+
 # hooks domain package
 [[modules]]
 path = "terok_shield.hooks"
@@ -157,6 +165,7 @@ depends_on = []
 path = "terok_shield.hooks.mode"
 layer = "core"
 depends_on = [
+    "terok_shield.dns.apparmor",
     "terok_shield.dns.dnsmasq",
     "terok_shield.hooks.install",
     "terok_shield.nft.rules",

--- a/tests/unit/test_apparmor.py
+++ b/tests/unit/test_apparmor.py
@@ -1,0 +1,146 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for terok_shield.dns.apparmor and the tier fallback it feeds."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest import mock
+
+from terok_shield.config import DnsTier, detect_dns_tier
+from terok_shield.dns.apparmor import (
+    detect_dns_tier_under_apparmor,
+    dnsmasq_can_read_state_dir,
+)
+from terok_shield.run import ExecError
+
+_NFTSET_VERSION = "Dnsmasq version 2.92\nCompile time options: nftset DNSSEC\n"
+_NO_NFTSET_VERSION = "Dnsmasq version 2.92\nCompile time options: no-nftset DNSSEC\n"
+
+
+def _fake_runner(*, present=("dnsmasq", "dig"), nftset=True, readable=True):
+    """A MagicMock runner whose ``--version``/``--test`` answers are scriptable."""
+    runner = mock.MagicMock()
+    runner.has.side_effect = lambda name: name in present
+
+    def _run(cmd: list[str], **_kw: object) -> str:
+        if "--version" in cmd:
+            return _NFTSET_VERSION if nftset else _NO_NFTSET_VERSION
+        if "--test" in cmd:
+            if readable:
+                return "dnsmasq: syntax check OK.\n"
+            raise ExecError(cmd, 3, "dnsmasq: cannot read config: Permission denied\n")
+        return ""
+
+    runner.run.side_effect = _run
+    return runner
+
+
+def _probed_apparmor(runner: mock.MagicMock) -> bool:
+    """True if the runner was asked to run the ``dnsmasq --test`` probe."""
+    return any("--test" in call.args[0] for call in runner.run.call_args_list)
+
+
+# ── detect_dns_tier: the new state-readable gate ─────────
+
+
+def test_tier_is_dnsmasq_when_present_capable_and_readable() -> None:
+    """dnsmasq wins when it exists, supports nftset, and can read its config."""
+    tier = detect_dns_tier(lambda _n: True, lambda: True, lambda: True)
+    assert tier is DnsTier.DNSMASQ
+
+
+def test_tier_falls_back_to_dig_when_confined() -> None:
+    """dnsmasq present + nftset-capable but AppArmor-confined → dig."""
+    has = lambda n: n in {"dnsmasq", "dig"}  # noqa: E731
+    tier = detect_dns_tier(has, lambda: True, lambda: False)
+    assert tier is DnsTier.DIG
+
+
+def test_tier_falls_back_to_getent_when_confined_and_no_dig() -> None:
+    """Confined dnsmasq with no dig present drops all the way to getent."""
+    tier = detect_dns_tier(lambda n: n == "dnsmasq", lambda: True, lambda: False)
+    assert tier is DnsTier.GETENT
+
+
+# ── dnsmasq_can_read_state_dir: behavioural probe ────────
+
+
+def test_can_read_true_when_test_succeeds(tmp_path: Path) -> None:
+    """A clean ``dnsmasq --test`` means the state dir is readable; probe is cleaned up."""
+    runner = mock.MagicMock()
+    runner.run.return_value = "dnsmasq: syntax check OK.\n"
+    assert dnsmasq_can_read_state_dir(runner, tmp_path) is True
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_can_read_false_on_permission_denied(tmp_path: Path) -> None:
+    """A permission-denied stderr (AppArmor) downgrades the tier."""
+    runner = mock.MagicMock()
+    runner.run.side_effect = ExecError(
+        ["dnsmasq", "--test"], 3, "dnsmasq: cannot read config: Permission denied\n"
+    )
+    assert dnsmasq_can_read_state_dir(runner, tmp_path) is False
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_can_read_true_on_non_permission_error(tmp_path: Path) -> None:
+    """A parse error (not a denial) must not trigger a spurious downgrade."""
+    runner = mock.MagicMock()
+    runner.run.side_effect = ExecError(
+        ["dnsmasq", "--test"], 1, "dnsmasq: bad command line options\n"
+    )
+    assert dnsmasq_can_read_state_dir(runner, tmp_path) is True
+
+
+def test_can_read_true_when_probe_unwritable(tmp_path: Path) -> None:
+    """An unwritable state dir is not an AppArmor read problem — do not downgrade."""
+    runner = mock.MagicMock()
+    missing = tmp_path / "absent-parent" / "shield"  # parent missing → write fails
+    assert dnsmasq_can_read_state_dir(runner, missing) is True
+    runner.run.assert_not_called()
+
+
+# ── detect_dns_tier_under_apparmor: wiring + apparmor_blocked flag ──
+
+
+def test_helper_keeps_dnsmasq_when_usable(tmp_path: Path) -> None:
+    """Present, nftset-capable, readable dnsmasq → dnsmasq tier, not blocked."""
+    tier, apparmor_blocked = detect_dns_tier_under_apparmor(_fake_runner(), tmp_path)
+    assert tier is DnsTier.DNSMASQ
+    assert apparmor_blocked is False
+
+
+def test_helper_downgrades_to_dig_when_confined(tmp_path: Path) -> None:
+    """AppArmor-confined dnsmasq with dig present → dig tier, flagged, after probing."""
+    runner = _fake_runner(readable=False)
+    tier, apparmor_blocked = detect_dns_tier_under_apparmor(runner, tmp_path)
+    assert tier is DnsTier.DIG
+    assert apparmor_blocked is True
+    assert _probed_apparmor(runner)
+
+
+def test_helper_flags_block_even_when_falling_to_getent(tmp_path: Path) -> None:
+    """Confined dnsmasq with no dig → getent, still flagged (not a dig-only signal)."""
+    runner = _fake_runner(present=("dnsmasq",), readable=False)
+    tier, apparmor_blocked = detect_dns_tier_under_apparmor(runner, tmp_path)
+    assert tier is DnsTier.GETENT
+    assert apparmor_blocked is True
+
+
+def test_helper_skips_probe_when_nftset_unsupported(tmp_path: Path) -> None:
+    """dnsmasq without nftset is disqualified first — the AppArmor probe never runs."""
+    runner = _fake_runner(nftset=False)
+    tier, apparmor_blocked = detect_dns_tier_under_apparmor(runner, tmp_path)
+    assert tier is DnsTier.DIG
+    assert apparmor_blocked is False
+    assert not _probed_apparmor(runner)
+
+
+def test_helper_absent_dnsmasq_is_not_blocked(tmp_path: Path) -> None:
+    """No dnsmasq → dig, not flagged, and no probe runs."""
+    runner = _fake_runner(present=("dig",))
+    tier, apparmor_blocked = detect_dns_tier_under_apparmor(runner, tmp_path)
+    assert tier is DnsTier.DIG
+    assert apparmor_blocked is False
+    assert not _probed_apparmor(runner)

--- a/tests/unit/test_hook_mode_class.py
+++ b/tests/unit/test_hook_mode_class.py
@@ -14,6 +14,7 @@ import pytest
 from terok_shield.config import (
     ANNOTATION_AUDIT_ENABLED_KEY,
     ANNOTATION_STATE_DIR_KEY,
+    DnsTier,
     ShieldConfig,
     ShieldRuntime,
     ShieldState,
@@ -1442,3 +1443,28 @@ def test_shield_down_repopulates_deny_sets(
 
 
 from terok_shield.state import StateBundle
+
+
+def test_detect_dns_tier_audits_advisory_when_apparmor_blocks(
+    make_hook_mode: HookModeHarnessFactory, tmp_path: Path
+) -> None:
+    """_detect_dns_tier falls back and audits the AppArmor advisory when dnsmasq is confined."""
+    harness = make_hook_mode()
+    harness.runner.has.side_effect = lambda name: name in ("dnsmasq", "dig")
+
+    def _run(cmd: list[str], **_kw: object) -> str:
+        if "--version" in cmd:
+            return "Dnsmasq version 2.92\nCompile time options: nftset\n"
+        if "--test" in cmd:
+            raise ExecError(cmd, 3, "dnsmasq: cannot read config: Permission denied\n")
+        return ""
+
+    harness.runner.run.side_effect = _run
+
+    tier = harness.mode._detect_dns_tier("some-task", tmp_path)
+
+    assert tier is DnsTier.DIG
+    harness.audit.log_event.assert_called_once()
+    detail = harness.audit.log_event.call_args.kwargs["detail"]
+    assert "AppArmor" in detail
+    assert "dig" in detail

--- a/tests/unit/test_shield_facade.py
+++ b/tests/unit/test_shield_facade.py
@@ -472,6 +472,35 @@ class TestCheckEnvironment:
         assert any("dig" in i for i in env.issues)
         assert env.dns_tier == "getent"
 
+    @mock.patch("terok_shield.find_hooks_dirs", return_value=[Path("/fake/hooks")])
+    @mock.patch("terok_shield.has_global_hooks", return_value=True)
+    @mock.patch("terok_shield.system_hooks_dir", return_value=Path("/fake/hooks"))
+    def test_apparmor_confined_dnsmasq_reports_issue(
+        self,
+        _sys_dir: mock.Mock,
+        _has_hooks: mock.Mock,
+        _find_dirs: mock.Mock,
+        make_shield: ShieldHarnessFactory,
+        tmp_path: Path,
+    ) -> None:
+        """dnsmasq present but AppArmor-confined from the state dir → dig + advisory."""
+        harness = make_shield(ShieldConfig(state_dir=tmp_path))
+        harness.runner.has.side_effect = lambda cmd: cmd in ("dnsmasq", "dig")
+
+        def _run(cmd: list[str], **_kw: object) -> str:
+            if cmd[0] == "podman":
+                return _podman_info_json("5.8.0")
+            if "--version" in cmd:
+                return "Dnsmasq version 2.92\nCompile time options: nftset\n"
+            if "--test" in cmd:
+                raise ExecError(cmd, 3, "dnsmasq: cannot read config: Permission denied\n")
+            return ""
+
+        harness.runner.run.side_effect = _run
+        env = harness.shield.check_environment()
+        assert env.dns_tier == "dig"
+        assert any("AppArmor" in i for i in env.issues)
+
     @mock.patch("terok_shield.find_hooks_dirs", return_value=[])
     @mock.patch("terok_shield.has_global_hooks", return_value=False)
     def test_no_global_hooks(


### PR DESCRIPTION
## Problem

On Arch/Manjaro (and any host running the `apparmor.d` profile set), launching a task fails with a cryptic:

```
Error: OCI runtime error: crun: error executing hook ... (exit 1)
dnsmasq: cannot read .../shield/dnsmasq.conf: Permission denied
```

## Root cause

It's an **AppArmor** denial — not DAC, SELinux, the OCI runtime, dnsmasq version, or file caps (all ruled out via `strace`: dnsmasq runs full-root, stats the `0644` conf fine, but `open()` returns `EACCES` while `cat` in the same context succeeds → MAC, not DAC). The enforced stock `dnsmasq` profile confines `/usr/sbin/dnsmasq` to the conventional server paths, so shield's per-container dnsmasq can't read its config or write its pid/log under `~/.local/share/terok/.../shield/`:

```
apparmor="DENIED" operation="open" profile="dnsmasq"
  name=".../shield/dnsmasq.conf" requested_mask="r"
```

Fedora is unaffected: there dnsmasq runs as `container_runtime_t` (no confining transition).

## Fix

- **Detect it behaviourally** — `dns/apparmor.dnsmasq_can_read_state_dir` runs `dnsmasq --test` against the state dir. Unprivileged (no `aa-status`/root), and it tests the exact condition that matters rather than parsing loaded profiles.
- **Fall back to the `dig` tier** when confined, with an advisory (an audit event in the hook, an issue in `check_environment`) instead of failing the launch. Egress filtering stays fully enforced; only live `nftset` IP-rotation handling is lost.
- `config.detect_dns_tier` gains a `dnsmasq_state_readable` gate (parallel to the existing `dnsmasq_nftset_ok`); a single `dns.apparmor.detect_dns_tier_under_apparmor(runner, state_dir) -> (tier, downgraded)` helper wires the probes for both call sites, ordered so the AppArmor probe is skipped when nftset support already disqualifies dnsmasq.
- `docs/apparmor.md` documents the AppArmor profile addendum operators install to **keep** the dnsmasq tier on enforcing hosts.

## Not in this PR (follow-ups)

- Automated installer for the profile addendum + terok-side advertising (sickbay / `terok setup` / TUI), mirroring the SELinux `terok_socket` flow. Rendering the addendum belongs in terok, which owns the per-task `tasks/*/*/shield` layout (shield treats `state_dir` as opaque).
- Longer term: relocate dnsmasq's runtime files to a predictable `/run/user/*/terok/dnsmasq/**` so the profile can be static (path-independent), splitting the bundle into runtime vs persistent.

## Testing

- 10 unit tests covering the probe (success / permission-denied / parse-error / unwritable), the new tier gate, and the helper (incl. the probe-skip short-circuit).
- Full suite: **1213 unit tests pass**. `ruff`, `ruff format`, `tach`, `docstr-coverage` (100% on the new module), `reuse`, `bandit`, and `mypy` all clean.
- Podman integration not run here (per repo policy — run on a real host). To verify on an AppArmor host: a task now launches with `dns.tier` = `dig` and the advisory in `audit.jsonl`; after installing the `docs/apparmor.md` addendum + `sudo apparmor_parser -r`, `dns.tier` returns to `dnsmasq`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DNS tier detection now respects AppArmor: the app will automatically fall back from dnsmasq to dig if confinement prevents dnsmasq from reading per-container state, and it records this downgrade in the per-container audit log while keeping egress filtering enforced.
  * When downgrades occur, the app surfaces an advisory with guidance to restore dnsmasq functionality.

* **Documentation**
  * New AppArmor integration guide with optional profile addendum instructions to retain the dnsmasq tier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->