### PR TITLE
docs: add PyPI version badge and logo, fix architecture SVG on PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://terok-ai.github.io/terok/terok-logo-w.svg">
+    <img src="https://terok-ai.github.io/terok/terok-logo-b.svg" alt="terok-shield" width="120">
+  </picture>
+</p>
+
 # terok-shield
 
+[![PyPI](https://img.shields.io/pypi/v/terok-shield)](https://pypi.org/project/terok-shield/)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![REUSE status](https://api.reuse.software/badge/github.com/terok-ai/terok-shield)](https://api.reuse.software/info/github.com/terok-ai/terok-shield)
 [![codecov](https://codecov.io/gh/terok-ai/terok-shield/branch/master/graph/badge.svg?token=D74Q7lvnIF)](https://codecov.io/gh/terok-ai/terok-shield)
@@ -13,7 +21,7 @@ explicitly allowed destinations — everything else is rejected with
 an ICMP error and a per-packet audit entry.
 
 <p align="center">
-  <img src="docs/img/architecture.svg" alt="terok ecosystem — terok-shield is the security boundary at the bottom of the stack">
+  <img src="https://terok-ai.github.io/terok/img/architecture.svg" alt="terok ecosystem — terok-shield is the security boundary at the bottom of the stack">
 </p>
 
 ## Where it sits in the stack


### PR DESCRIPTION
Part of an ecosystem-wide README pass across the 7 terok PyPI projects.

- **PyPI version badge** — links to the PyPI project page. shields.io auto-colors it (orange while pre-1.0, blue at ≥1.0), so it doubles as an at-a-glance maturity signal.
- **terok logo** — adds the shared light/dark `<picture>` block already used by the main `terok` README.
- **Architecture diagram now renders on PyPI** — the image used a *relative* path (`docs/…`), which PyPI cannot resolve (it has no repo base to anchor relatives against), so the diagram showed broken on the project page while the logo — an absolute URL — rendered fine. It was **never** an SVG-vs-PNG issue. Switched to the canonical absolute URL `https://terok-ai.github.io/terok/img/architecture.svg` (byte-identical image, already served as `image/svg+xml`); it renders on PyPI, GitHub, and IDE markdown previews alike.

Takes effect on the live PyPI page at this package's next release — the `long_description` is baked into the published artifact, so existing releases are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
