### PR TITLE
docs: homepage URL, terok cross-link, and docs-dependency refresh

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # terok-shield
 
-Default-deny egress firewall for rootless Podman containers.
+Default-deny egress firewall for rootless Podman containers — part of the [terok](https://terok-ai.github.io/terok/) ecosystem.
 
 terok-shield enforces **default-deny outbound** network filtering on
 Podman containers using nftables.  Containers can only reach

--- a/poetry.lock
+++ b/poetry.lock
@@ -2425,4 +2425,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "82231b6d7f1356542bea8172347baf41cf87e35fb841a3cf2297e5380644dfcd"
+content-hash = "729b42fc235f49a230d921fb4fcd01d8496831b2c69f1c3aee3e238273ad8847"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://terok.ai/"
+Homepage = "https://terok-ai.github.io/terok-shield/"
 Repository = "https://github.com/terok-ai/terok-shield"
 Documentation = "https://terok-ai.github.io/terok-shield/"
 Issues = "https://github.com/terok-ai/terok-shield/issues"
@@ -72,8 +72,8 @@ pytest-cov = ">=4.0"
 
 [tool.poetry.group.docs.dependencies]
 properdocs = ">=1.6.7"
-mkdocs-material = ">=9.0"
-mkdocstrings = {extras = ["python"], version = ">=0.24"}
+mkdocs-material = ">=9.7.6"
+mkdocstrings = {extras = ["python"], version = ">=0.26"}
 mkdocs-literate-nav = ">=0.6"
 mkdocs-section-index = ">=0.3"
 mkdocs-gen-files = ">=0.5"


### PR DESCRIPTION
Aligns this repo's docs metadata with the rest of the terok ecosystem:

- `docs/index.md`: cross-link to the main terok docs site.
- `[project.urls] Homepage`: `https://terok.ai/` → `https://terok-ai.github.io/terok-shield/` (verified link on PyPI).
- Bump `mkdocs-material >=9.7.6` and `mkdocstrings >=0.26`.


**complexipy / tach are intentionally _not_ added to the `docs` group** (revising the original title/plan, per CodeRabbit review): they already live in the `dev` group that's installed during docs builds, mkdocs-terok degrades gracefully when a generator's optional tool is absent, and duplicating the pins here would add a second place to keep versions in sync. The cognitive-complexity report fix itself ships in **mkdocs-terok 0.7.1** (complexipy v5.x cache-format support).