### PR TITLE
docs: fix module map, dependency list, log-prefix taxonomy, stale paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@
 
 ## Repo layout
 
-- `src/terok_shield/`: Python package (CLI in `cli.py`, command registry in `registry.py`, engine modules at top level)
+- `src/terok_shield/`: Python package (CLI in `cli/main.py`, command registry in `commands.py`, nft ruleset engine in `nft/` — `rules.py` + `constants.py`, hook orchestration in `hooks/`, OCI hook entrypoint in `resources/nft_hook.py`)
 - `tests/`: `pytest` test suite
 - `src/terok_shield/resources/dns/`: Bundled DNS domain allowlists
 
@@ -210,4 +210,4 @@ Path functions in `state.py` derive all paths from `state_dir`. `BUNDLE_VERSION`
 - **Allowlisting**: Both IP addresses and DNS domains are supported in `.txt` allowlists; bundled defaults use DNS names because they are more stable and easier to audit
 - **Minimal changes**: Make surgical, focused changes
 - **Existing tests**: Never remove or modify unrelated tests
-- **Dependencies**: Use Poetry; the only runtime dependency is PyYAML
+- **Dependencies**: Use Poetry; runtime dependencies are PyYAML, pydantic, and terok-util

--- a/docs/design.md
+++ b/docs/design.md
@@ -12,8 +12,9 @@ Lifecycle: `Shield.pre_start()` installs the OCI hook (idempotent), resolves DNS
 writes `profile.allowed`, pre-generates the complete nft ruleset to `ruleset.nft`,
 and returns podman args with annotations. On each container start, the OCI hook
 reads `state_dir` from annotations, applies the pre-generated `ruleset.nft` inside
-the container's network namespace, discovers the gateway from `/proc/{pid}/net/route`,
-and optionally starts a per-container *dnsmasq* instance.
+the container's network namespace, and optionally starts a per-container *dnsmasq*
+instance.  Gateway addresses are baked into the ruleset at generation time — no
+runtime `/proc` discovery.
 
 ## Allowlisting
 
@@ -80,7 +81,6 @@ across state files are reliable regardless of input notation (e.g.
 │   └── terok-shield-poststop.json        # only if per-container hooks are supported
 ├── terok-shield-hook              # entrypoint script (stdlib-only), for per-container hooks
 ├── ruleset.nft                    # pre-generated nft ruleset (written by pre_start)
-├── gateway                        # discovered gateway IP (written by OCI hook)
 ├── profile.allowed                # IPs from DNS resolution (preset)
 ├── profile.domains                # domain names for dnsmasq config
 ├── live.allowed                   # IPs from manual allow/deny
@@ -188,8 +188,10 @@ operations.
 nftables log rules generate per-packet entries in dmesg/journald:
 
 - `TEROK_SHIELD_ALLOWED:` traffic hitting the allow set (rate-limited)
-- `TEROK_SHIELD_DENIED:` traffic rejected by the deny-all rule
+- `TEROK_SHIELD_DENIED:` traffic rejected by the explicit deny set (operator refused)
 - `TEROK_SHIELD_PRIVATE:` non-allowlisted private-range traffic rejected (RFC 1918/RFC 4193)
+- `TEROK_SHIELD_BLOCKED:` traffic rejected by the terminal default-deny rule (unclassified)
+- `TEROK_SHIELD_BYPASS:` traffic passing while the shield is bypassed
 
 ## Public API
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -45,7 +45,7 @@ dnsmasq compile-time nftset support.
 | `dev-node.txt` | npm, Yarn, jsDelivr, unpkg |
 | `nvidia-hpc.txt` | CUDA toolkit, NGC, NVIDIA repos |
 
-Users can add custom profiles in `$XDG_CONFIG_HOME/terok-shield/profiles/`.
+Users can add custom profiles in `$XDG_CONFIG_HOME/terok/shield/profiles/`.
 
 ## Persistent deny
 
@@ -187,9 +187,10 @@ operations.
 
 nftables log rules generate per-packet entries in dmesg/journald:
 
-- `TEROK_SHIELD_ALLOWED:` traffic hitting the allow set (rate-limited)
+- `TEROK_SHIELD_ALLOWED:` new connections to the allow set, logged and counted
+  (not rate-limited -- established traffic is accepted earlier in the chain)
 - `TEROK_SHIELD_DENIED:` traffic rejected by the explicit deny set (operator refused)
-- `TEROK_SHIELD_PRIVATE:` non-allowlisted private-range traffic rejected (RFC 1918/RFC 4193)
+- `TEROK_SHIELD_PRIVATE:` non-allowlisted private-range traffic rejected (RFC 1918 + RFC 4193/4291)
 - `TEROK_SHIELD_BLOCKED:` traffic rejected by the terminal default-deny rule (unclassified)
 - `TEROK_SHIELD_BYPASS:` traffic passing while the shield is bypassed
 

--- a/docs/guide/logging.md
+++ b/docs/guide/logging.md
@@ -6,7 +6,7 @@ logs and kernel-level per-packet nftables logs.
 ## Application logs (JSON-lines)
 
 Each container has its own audit log at `{state_dir}/audit.jsonl` (e.g.
-`~/.local/state/terok-shield/containers/my-container/audit.jsonl`).
+`~/.local/state/terok/shield/containers/my-container/audit.jsonl`).
 
 Each line is a JSON object:
 
@@ -55,9 +55,11 @@ prefixes:
 
 | Prefix | Meaning |
 |--------|---------|
-| `TEROK_SHIELD_DENIED:` | Packet dropped by deny-all rule |
-| `TEROK_SHIELD_ALLOWED:` | Packet accepted by allow set (rate-limited: 10/sec) |
-| `TEROK_SHIELD_PRIVATE:` | Packet rejected by private-range rule (RFC 1918 / RFC 4193) |
+| `TEROK_SHIELD_ALLOWED:` | New connection accepted by allow set (not rate-limited; established traffic is accepted earlier in the chain and not logged) |
+| `TEROK_SHIELD_DENIED:` | Packet rejected by the explicit deny set (operator refused) |
+| `TEROK_SHIELD_PRIVATE:` | Packet rejected by private-range rule (RFC 1918 + RFC 4193/4291) |
+| `TEROK_SHIELD_BLOCKED:` | Packet rejected by the terminal default-deny rule (unclassified) |
+| `TEROK_SHIELD_BYPASS:` | Packet accepted while the shield is bypassed |
 
 View with:
 
@@ -67,7 +69,7 @@ journalctl -k --grep TEROK_SHIELD
 
 ## Disabling audit logging
 
-In `~/.config/terok-shield/config.yml`:
+In `~/.config/terok/shield/config.yml`:
 
 ```yaml
 audit:

--- a/docs/guide/modes.md
+++ b/docs/guide/modes.md
@@ -110,7 +110,7 @@ uses terok-shield as a library):
 
 ```python
 from terok_shield import Shield, ShieldConfig
-shield = Shield(ShieldConfig(state_dir=Path("~/.local/state/terok-shield/containers/my-ctr")))
+shield = Shield(ShieldConfig(state_dir=Path("~/.local/state/terok/shield/containers/my-ctr")))
 extra_args = shield.pre_start("my-ctr", ["dev-standard"])
 # pass extra_args to podman run
 ```

--- a/docs/guide/profiles.md
+++ b/docs/guide/profiles.md
@@ -45,9 +45,9 @@ cdn.example.com
 To create a custom profile, place a `.txt` file in your profiles directory:
 
 ```bash
-mkdir -p ~/.config/terok-shield/profiles
+mkdir -p ~/.config/terok/shield/profiles
 
-cat > ~/.config/terok-shield/profiles/my-project.txt << 'EOF'
+cat > ~/.config/terok/shield/profiles/my-project.txt << 'EOF'
 # APIs my project needs
 api.example.com
 webhooks.example.com
@@ -67,7 +67,7 @@ terok-shield status
 ### Overriding bundled profiles
 
 If you create a custom profile with the same name as a bundled one
-(e.g. `~/.config/terok-shield/profiles/dev-standard.txt`), your version
+(e.g. `~/.config/terok/shield/profiles/dev-standard.txt`), your version
 takes precedence. The bundled version is ignored.
 
 ## Using profiles
@@ -100,7 +100,7 @@ terok-shield resolve my-container --force   # bypass cache freshness
 
 ### Changing the default profile
 
-Edit `~/.config/terok-shield/config.yml`:
+Edit `~/.config/terok/shield/config.yml`:
 
 ```yaml
 default_profiles:


### PR DESCRIPTION
Part of a docs-vs-source audit across the terok stack (companion to terok-ai/terok#1080).

- AGENTS.md named modules that no longer exist (`cli.py`, `registry.py`, top-level engine modules); now points at the real layout (`cli/main.py`, `commands.py`, `nft/`, `hooks/`, `resources/nft_hook.py`). Runtime deps are PyYAML + pydantic + terok-util, not PyYAML alone.
- `docs/design.md`: gateway addresses are baked into the ruleset at generation time (`resources/nft_hook.py`); the `/proc/net/route` discovery and the `gateway` state file are gone. The log-prefix list now covers all five prefixes with their actual semantics — `DENIED` is the explicit deny set; the terminal default-deny logs `BLOCKED` (`nft/constants.py`).
- `docs/guide/profiles.md`: user config lives under `~/.config/terok/shield/` (`cli/main.py` `_resolve_config_root`), not `~/.config/terok-shield/`.

Markdown-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Configuration directory paths updated to `~/.config/terok/shield/` for profile customization
  * Design documentation refreshed for Hook mode gateway address handling
  * Repository layout and dependency information updated

<!-- end of auto-generated comment: release notes by coderabbit.ai -->