### PR TITLE
test(matrix): non-systemd + Mageia slots; integration test fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,10 @@ jobs:
         with:
           args: format --check
 
+      - name: ASCII-only pyproject
+        run: |
+          ! LC_ALL=C grep -nP '[^\x00-\x7F]' pyproject.toml
+
   docstring-coverage:
     if: github.repository == 'terok-ai/terok-shield'
     runs-on: ubuntu-latest

--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distro: [debian12, ubuntu2404, debian13, fedora43]
+        distro: [debian12, ubuntu2404, debian13, fedora43, alpine]
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distro: [debian12, ubuntu2404, debian13, fedora43, alpine]
+        distro: [debian12, ubuntu2404, debian13, fedora43, alpine, void, mageia]
     steps:
       - uses: actions/checkout@v7
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -222,13 +222,18 @@ version:
 - **Third-party, major 0 (`0.y.z`)** → pin to an **exact patch**
   (`pkg==0.y.z`). Pre-1.0 packages promise no compatibility across either
   minors *or* patches, so a floating range invites silent breakage.
-- **Third-party, major ≥ 1** → pin by **range** (e.g. `pkg>=2.6`), trusting
-  the package to honour semver. If a specific `>=1` dependency is known to
-  break semver, tighten it deliberately.
-- **Sibling `terok-*` deps** → **exempt**: keep ranges (or their
-  release-wheel URL pin). We guarantee patch-level API stability across the
-  sibling packages, so a `0.y` range there will not silently break — do
-  *not* exact-pin them (it would fight the multi-repo release/PR-chain flow).
+- **Third-party, major ≥ 1** → **compatible-release at the tested
+  baseline**: `pkg~=X.Y` where `X.Y` is the locked major.minor (floor =
+  what we test against, cap = next major). Use the patch-series form
+  `pkg~=X.Y.Z` only where a specific patch floor is required — note the
+  PEP 440 truncation rule: the cap is one level above the last written
+  component (`~=2.13` → `<3`, `~=8.2.5` → `<8.3`). Prefer `~=` over a
+  hand-rolled `>=,<` pair: it states the baseline as one fact with the
+  ceiling derived by construction, so the bounds cannot drift apart.
+- **Sibling `terok-*` deps** → `~=0.y.z` (or their release-wheel URL pin).
+  We guarantee patch-level API stability across the sibling packages, so
+  the patch-series form is exactly right — do *not* exact-pin them (it
+  would fight the multi-repo release/PR-chain flow).
 
 Dev / test / docs / tooling dependencies (the `[tool.poetry.group.*]` groups)
 are **exempt** — they are not shipped to installers and exact-pinning them is

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -241,12 +241,13 @@ an unwarranted maintenance burden the developers can absorb. After changing
 any pin, run `poetry lock` and commit `pyproject.toml` and `poetry.lock`
 together.
 
-**No comments in `pyproject.toml`.** Do **not** add comments to
-`pyproject.toml`, with the single exception of the standing dependency-pinning
-policy note above the `dependencies` table. In particular **never** add a
-comment about a dependency that is temporarily pinned to a git branch during a
-multi-repo PR chain, and never mention the PR-chain workflow in
-`pyproject.toml` at all. Cross-repo merges are performed by a script that does
-not understand comments, so any stray dev-cycle comment is carried straight
-into a production release. Keep such rationale in commit messages, PR
-descriptions, or this file.
+**Comment discipline in `pyproject.toml`.** The dependency tables stay
+comment-free and self-documenting, apart from the standing policy pointer
+above them. **Never** comment on why a dependency -- especially a sibling
+`terok-*` package -- is pinned a certain way, and never mention dev-cycle
+state (temporary git-branch pins, the multi-repo PR chain): cross-repo
+merges are performed by a script that does not understand comments, so any
+such note is carried straight into a production release. Keep pin
+rationale in commit messages, PR descriptions, or this file. Ordinary
+explanatory comments in `[tool.*]` sections are fine. `pyproject.toml`
+stays ASCII-only.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -211,3 +211,37 @@ Path functions in `state.py` derive all paths from `state_dir`. `BUNDLE_VERSION`
 - **Minimal changes**: Make surgical, focused changes
 - **Existing tests**: Never remove or modify unrelated tests
 - **Dependencies**: Use Poetry; runtime dependencies are PyYAML, pydantic, and terok-util
+
+## Dependency Pinning & `pyproject.toml` Hygiene
+
+**Version pinning policy.** Runtime/production dependencies — those pulled in
+by a plain `pip install` / `pipx install` of this package (the
+`[project].dependencies` table) — are pinned by the dependency's major
+version:
+
+- **Third-party, major 0 (`0.y.z`)** → pin to an **exact patch**
+  (`pkg==0.y.z`). Pre-1.0 packages promise no compatibility across either
+  minors *or* patches, so a floating range invites silent breakage.
+- **Third-party, major ≥ 1** → pin by **range** (e.g. `pkg>=2.6`), trusting
+  the package to honour semver. If a specific `>=1` dependency is known to
+  break semver, tighten it deliberately.
+- **Sibling `terok-*` deps** → **exempt**: keep ranges (or their
+  release-wheel URL pin). We guarantee patch-level API stability across the
+  sibling packages, so a `0.y` range there will not silently break — do
+  *not* exact-pin them (it would fight the multi-repo release/PR-chain flow).
+
+Dev / test / docs / tooling dependencies (the `[tool.poetry.group.*]` groups)
+are **exempt** — they are not shipped to installers and exact-pinning them is
+an unwarranted maintenance burden the developers can absorb. After changing
+any pin, run `poetry lock` and commit `pyproject.toml` and `poetry.lock`
+together.
+
+**No comments in `pyproject.toml`.** Do **not** add comments to
+`pyproject.toml`, with the single exception of the standing dependency-pinning
+policy note above the `dependencies` table. In particular **never** add a
+comment about a dependency that is temporarily pinned to a git branch during a
+multi-repo PR chain, and never mention the PR-chain workflow in
+`pyproject.toml` at all. Cross-repo merges are performed by a script that does
+not understand comments, so any stray dev-cycle comment is carried straight
+into a production release. Keep such rationale in commit messages, PR
+descriptions, or this file.

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ test-integration:
 	mkdir -p $(REPORTS_DIR)
 	poetry run pytest tests/integration/ -v --junitxml=$(INTEGRATION_JUNIT_XML) -o junit_family=legacy
 
-# Multi-distro integration test matrix (Debian 12/13, Ubuntu 24.04/26.04, Fedora 43/44, podman:stable)
+# Multi-distro integration test matrix (Debian 12/13, Ubuntu 24.04/26.04, Fedora 43/44, Alpine (non-systemd), podman:stable)
 # Options (env vars):
 #   NO_CACHE=1    Rebuild images from scratch (ignore layer cache)
 #   BUILD_ONLY=1  Build images without running tests

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ test: test-unit
 
 # Run linter and format checker (fast, run before commits)
 lint:
+	@if LC_ALL=C grep -nP '[^\x00-\x7F]' pyproject.toml; then echo "pyproject.toml must be ASCII-only"; exit 1; fi
 	mkdir -p $(REPORTS_DIR)
 	poetry run ruff check --exit-zero --output-format=json --output-file=$(RUFF_REPORT) .
 	poetry run ruff check .

--- a/poetry.lock
+++ b/poetry.lock
@@ -2441,4 +2441,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "11592008750a94ead33d23a94f395e47d008f90b86320da68a53aceb1b9c567a"
+content-hash = "995ca852664c4974fc5932bd660bbeb3c73bc30de2c89a9425d32de0ef5fcabd"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1834,14 +1834,14 @@ test = ["pytest", "pytest-cov"]
 
 [[package]]
 name = "python-discovery"
-version = "1.4.0"
+version = "1.4.2"
 description = "Python interpreter discovery"
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
 files = [
-    {file = "python_discovery-1.4.0-py3-none-any.whl", hash = "sha256:26ed78d703e234879a66244c7d4114563fb13ec5cd30a2d1357e5fb4850782da"},
-    {file = "python_discovery-1.4.0.tar.gz", hash = "sha256:eb8bc7daad3c226c147e45bb4e970a1feb1bf4048ee178e6db59e197b8010ce3"},
+    {file = "python_discovery-1.4.2-py3-none-any.whl", hash = "sha256:475803f53b7b2ed6e490e27373f9d8340f7d2eebf9acdaf645d7d714c97bb500"},
+    {file = "python_discovery-1.4.2.tar.gz", hash = "sha256:8f3746c4b4968d22afbb97d36e1a0e5b66e6c0f297290f2e95f05b9b8bf18690"},
 ]
 
 [package.dependencies]
@@ -1851,7 +1851,6 @@ platformdirs = ">=4.3.6,<5"
 [package.extras]
 docs = ["furo (>=2025.12.19)", "sphinx (>=9.1)", "sphinx-autodoc-typehints (>=3.6.3)", "sphinxcontrib-mermaid (>=2)", "sphinxcontrib-towncrier (>=0.4)", "towncrier (>=25.8)"]
 testing = ["covdefaults (>=2.3)", "coverage (>=7.5.4)", "pytest (>=8.3.5)", "pytest-mock (>=3.14)", "setuptools (>=75.1)"]
-
 [[package]]
 name = "python-magic"
 version = "0.4.27"
@@ -2355,22 +2354,21 @@ zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 
 [[package]]
 name = "virtualenv"
-version = "21.4.2"
+version = "21.5.1"
 description = "Virtual Python Environment builder"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["dev"]
 files = [
-    {file = "virtualenv-21.4.2-py3-none-any.whl", hash = "sha256:854210ca524a1a4d0d744734f4acbc721c3ffe163b85bbf5d56d14d5ae2f0fae"},
-    {file = "virtualenv-21.4.2.tar.gz", hash = "sha256:38e6ee0a555615c0ea9da2ac7e9998fe8dc3b911dd33ad8eaad2020957653b0c"},
+    {file = "virtualenv-21.5.1-py3-none-any.whl", hash = "sha256:55aa670b67bbfb991b03fda39bd3276d92c419d702376e98c5df1c9989a26783"},
+    {file = "virtualenv-21.5.1.tar.gz", hash = "sha256:dca3bf98275a59c652b69d68e73433e597d977c2da9198882479d1a7188009c8"},
 ]
 
 [package.dependencies]
 distlib = ">=0.3.7,<1"
 filelock = {version = ">=3.24.2,<4", markers = "python_version >= \"3.10\""}
 platformdirs = ">=3.9.1,<5"
-python-discovery = ">=1.4"
-
+python-discovery = ">=1.4.2"
 [[package]]
 name = "vulture"
 version = "2.16"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1851,6 +1851,7 @@ platformdirs = ">=4.3.6,<5"
 [package.extras]
 docs = ["furo (>=2025.12.19)", "sphinx (>=9.1)", "sphinx-autodoc-typehints (>=3.6.3)", "sphinxcontrib-mermaid (>=2)", "sphinxcontrib-towncrier (>=0.4)", "towncrier (>=25.8)"]
 testing = ["covdefaults (>=2.3)", "coverage (>=7.5.4)", "pytest (>=8.3.5)", "pytest-mock (>=3.14)", "setuptools (>=75.1)"]
+
 [[package]]
 name = "python-magic"
 version = "0.4.27"
@@ -2369,6 +2370,7 @@ distlib = ">=0.3.7,<1"
 filelock = {version = ">=3.24.2,<4", markers = "python_version >= \"3.10\""}
 platformdirs = ">=3.9.1,<5"
 python-discovery = ">=1.4.2"
+
 [[package]]
 name = "vulture"
 version = "2.16"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,10 +17,7 @@ keywords = ["podman", "containers", "firewall", "nftables", "security"]
 requires-python = ">=3.12,<4.0"
 dynamic = ["version", "classifiers"]
 # Dependency pins follow the policy in AGENTS.md ("Dependency Pinning &
-# pyproject.toml Hygiene").  Keep the dependency tables comment-free and
-# self-documenting -- in particular, never note here why a sibling
-# terok-* package is pinned a certain way, nor any transient dev-cycle
-# state: a comment-blind release script would ship such notes.
+# pyproject.toml Hygiene").  Keep the dependency list comment-free.
 dependencies = [
     "PyYAML~=6.0",
     "pydantic~=2.13",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,8 +17,10 @@ keywords = ["podman", "containers", "firewall", "nftables", "security"]
 requires-python = ">=3.12,<4.0"
 dynamic = ["version", "classifiers"]
 # Dependency pins follow the policy in AGENTS.md ("Dependency Pinning &
-# pyproject.toml Hygiene").  No other comments belong in this file — a
-# comment-blind release script would carry them into a production release.
+# pyproject.toml Hygiene").  Keep the dependency tables comment-free and
+# self-documenting -- in particular, never note here why a sibling
+# terok-* package is pinned a certain way, nor any transient dev-cycle
+# state: a comment-blind release script would ship such notes.
 dependencies = [
     "PyYAML~=6.0",
     "pydantic~=2.13",
@@ -132,7 +134,7 @@ quote-style = "double"
 indent-style = "space"
 docstring-code-format = true
 
-# Static type checking — see `make typecheck`.
+# Static type checking -- see `make typecheck`.
 [tool.mypy]
 python_version = "3.12"
 files = ["src/terok_shield"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,19 +17,20 @@ keywords = ["podman", "containers", "firewall", "nftables", "security"]
 requires-python = ">=3.12,<4.0"
 dynamic = ["version", "classifiers"]
 # ── Dependency pinning policy (see AGENTS.md) ───────────────────────
-# Third-party runtime deps at major 0 (0.y.z) are pinned to an exact
-# patch: pre-1.0 packages guarantee nothing across minors OR patches.
-# Major >= 1 deps use ranges (semver).  Sibling terok-* deps are exempt
-# — we guarantee patch-level API stability, so they keep ranges (or a
-# release-wheel URL pin).  Dev/test/docs groups are exempt.  This is the
-# ONLY comment permitted in this file — never add dev-cycle notes here,
-# and never mention temporary git-branch pins or the multi-repo PR chain
-# (a merge script rewrites deps and would leak such comments into a
-# production release).
+# Runtime deps use compatible-release pins at the tested baseline:
+# third-party major 0 → exact (==0.y.z; pre-1.0 guarantees nothing);
+# third-party major >= 1 → ~=X.Y (locked-minor floor, next-major cap;
+# ~=X.Y.Z patch-series only where a specific patch floor is required);
+# sibling terok-* → ~=0.y.z or a release-wheel URL pin (patch-level API
+# stability is guaranteed across siblings).  Dev/test/docs groups keep
+# simple floors.  This is the ONLY comment permitted in this file —
+# never add dev-cycle notes here, and never mention temporary git-branch
+# pins or the multi-repo PR chain (a merge script rewrites deps and
+# would leak such comments into a production release).
 dependencies = [
-    "PyYAML>=6.0",
-    "pydantic>=2.0",
-    "terok-util>=0.2.0,<0.3.0",
+    "PyYAML~=6.0",
+    "pydantic~=2.13",
+    "terok-util~=0.2.0",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,16 @@ maintainers = [
 keywords = ["podman", "containers", "firewall", "nftables", "security"]
 requires-python = ">=3.12,<4.0"
 dynamic = ["version", "classifiers"]
+# ── Dependency pinning policy (see AGENTS.md) ───────────────────────
+# Third-party runtime deps at major 0 (0.y.z) are pinned to an exact
+# patch: pre-1.0 packages guarantee nothing across minors OR patches.
+# Major >= 1 deps use ranges (semver).  Sibling terok-* deps are exempt
+# — we guarantee patch-level API stability, so they keep ranges (or a
+# release-wheel URL pin).  Dev/test/docs groups are exempt.  This is the
+# ONLY comment permitted in this file — never add dev-cycle notes here,
+# and never mention temporary git-branch pins or the multi-repo PR chain
+# (a merge script rewrites deps and would leak such comments into a
+# production release).
 dependencies = [
     "PyYAML>=6.0",
     "pydantic>=2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,17 +16,9 @@ maintainers = [
 keywords = ["podman", "containers", "firewall", "nftables", "security"]
 requires-python = ">=3.12,<4.0"
 dynamic = ["version", "classifiers"]
-# ── Dependency pinning policy (see AGENTS.md) ───────────────────────
-# Runtime deps use compatible-release pins at the tested baseline:
-# third-party major 0 → exact (==0.y.z; pre-1.0 guarantees nothing);
-# third-party major >= 1 → ~=X.Y (locked-minor floor, next-major cap;
-# ~=X.Y.Z patch-series only where a specific patch floor is required);
-# sibling terok-* → ~=0.y.z or a release-wheel URL pin (patch-level API
-# stability is guaranteed across siblings).  Dev/test/docs groups keep
-# simple floors.  This is the ONLY comment permitted in this file —
-# never add dev-cycle notes here, and never mention temporary git-branch
-# pins or the multi-repo PR chain (a merge script rewrites deps and
-# would leak such comments into a production release).
+# Dependency pins follow the policy in AGENTS.md ("Dependency Pinning &
+# pyproject.toml Hygiene").  No other comments belong in this file — a
+# comment-blind release script would carry them into a production release.
 dependencies = [
     "PyYAML~=6.0",
     "pydantic~=2.13",

--- a/src/terok_shield/__init__.py
+++ b/src/terok_shield/__init__.py
@@ -286,9 +286,10 @@ class Shield:
             )
         elif tier == DnsTier.DIG:
             issues.append(
-                "dnsmasq not found — domain allowlisting uses static pre-start "
-                "resolution (no IP rotation handling). "
-                "Install dnsmasq for dynamic domain-based egress control"
+                "dnsmasq unavailable (not installed, or without nftset support) — "
+                "domain allowlisting uses static pre-start resolution "
+                "(no IP rotation handling). "
+                "Install an nftset-capable dnsmasq for dynamic domain-based egress control"
             )
         elif tier == DnsTier.GETENT:
             issues.append(

--- a/src/terok_shield/dns/apparmor.py
+++ b/src/terok_shield/dns/apparmor.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from ..config import DnsTier, detect_dns_tier
-from ..run import CommandRunner, ExecError
+from ..run import CommandRunner, ExecError, which_sbin_aware
 from . import dnsmasq
 
 # Throwaway config dnsmasq --test reads to probe state-dir access.
@@ -56,7 +56,7 @@ def dnsmasq_can_read_state_dir(runner: CommandRunner, state_dir: Path) -> bool:
         return True
     try:
         runner.run(
-            ["dnsmasq", "--test", f"--conf-file={probe}"],
+            [which_sbin_aware("dnsmasq") or "dnsmasq", "--test", f"--conf-file={probe}"],
             check=True,
             timeout=_PROBE_TIMEOUT_S,
         )

--- a/src/terok_shield/dns/dnsmasq.py
+++ b/src/terok_shield/dns/dnsmasq.py
@@ -25,7 +25,7 @@ import signal
 from pathlib import Path
 
 from ..nft.constants import DNSMASQ_BIND_DEFAULT, NFT_TABLE_NAME
-from ..run import CommandRunner
+from ..run import CommandRunner, which_sbin_aware
 from ..state import StateBundle
 
 logger = logging.getLogger(__name__)
@@ -286,7 +286,8 @@ def has_nftset_support(runner: CommandRunner) -> bool:
     feature flag.  Returns False if dnsmasq is not installed or its
     output contains ``no-nftset`` (explicitly disabled).
     """
-    out = runner.run(["dnsmasq", "--version"], check=False)
+    dnsmasq_bin = which_sbin_aware("dnsmasq") or "dnsmasq"
+    out = runner.run([dnsmasq_bin, "--version"], check=False)
     return bool(re.search(r"\bnftset\b", out)) and not bool(re.search(r"\bno-nftset\b", out))
 
 

--- a/src/terok_shield/dns/resolver.py
+++ b/src/terok_shield/dns/resolver.py
@@ -7,10 +7,12 @@ Resolves domain names from allowlist profiles via ``dig`` and caches
 the results so containers do not block on DNS at every start.  Profiles
 prefer domain names over raw IPs because CDN addresses rotate.
 
-Falls back to ``getent hosts`` when ``dig`` is not installed — fewer
-IPs are captured (no parallel A + AAAA query), but resolution still
-works.  When the dnsmasq tier is active, domain resolution happens at
-runtime via ``--nftset``; this module then only handles raw IPs.
+Falls back to ``getent hosts`` when ``dig`` is not installed, and
+per-domain when ``dig`` runs but yields nothing (some environments break
+``dig`` while glibc resolution still works) — fewer IPs are captured
+(no parallel A + AAAA query), but resolution still works.  When the
+dnsmasq tier is active, domain resolution happens at runtime via
+``--nftset``; this module then only handles raw IPs.
 """
 # WAYPOINT: Shield (__init__), HookMode (hooks.mode)
 
@@ -83,6 +85,15 @@ class DnsResolver:
                 # dig missing — degrade gracefully for the rest of this batch
                 logger.warning("dig not found — falling back to getent for DNS resolution")
                 use_getent = True
+                ips = self._resolve_one(domain, use_getent=True)
+            if not ips and not use_getent:
+                # dig ran but produced nothing.  That is usually not a dead
+                # domain: some environments break dig specifically (a DNS
+                # forwarder rejecting its EDNS options, a hardened container
+                # path) while glibc resolution still works — so retry this
+                # one domain through getent before giving up.  Per-domain,
+                # not batch-wide: one genuinely dead domain must not demote
+                # the resolver for the rest.
                 ips = self._resolve_one(domain, use_getent=True)
             if not ips:
                 logger.warning("Domain %r resolved to no IPs (typo or DNS failure?)", domain)

--- a/src/terok_shield/prereqs.py
+++ b/src/terok_shield/prereqs.py
@@ -16,7 +16,10 @@ No subprocess invocation, no side effects.
 from __future__ import annotations
 
 import shutil
+
 from dataclasses import dataclass
+
+from .run import which_sbin_aware
 
 #: Directories searched after ``PATH`` when probing daemon binaries.
 #: rootless users regularly have neither on their login PATH; probing
@@ -78,18 +81,3 @@ def check_krun_binaries() -> tuple[BinaryCheck, ...]:
     )
 
 
-def which_sbin_aware(name: str) -> str:
-    """Resolve *name* like [`shutil.which`][shutil.which], falling back to sbin directories.
-
-    Returns the absolute path of the first match or an empty string
-    when the binary is not on ``PATH`` and not in ``/usr/sbin`` or
-    ``/sbin``.  The sbin fallback reuses [`shutil.which`][shutil.which] with an
-    explicit ``path=`` so executability (``os.X_OK``) is checked the
-    same way ``PATH`` resolution would — a regular non-executable file
-    in ``/usr/sbin`` shouldn't count as a hit.
-    """
-    for search_path in (None, *_SBIN_DIRS):
-        found = shutil.which(name, path=search_path)
-        if found:
-            return found
-    return ""

--- a/src/terok_shield/prereqs.py
+++ b/src/terok_shield/prereqs.py
@@ -16,7 +16,6 @@ No subprocess invocation, no side effects.
 from __future__ import annotations
 
 import shutil
-
 from dataclasses import dataclass
 
 from .run import which_sbin_aware
@@ -79,5 +78,3 @@ def check_krun_binaries() -> tuple[BinaryCheck, ...]:
             "in-netns IP assignment for the krun runtime",
         ),
     )
-
-

--- a/src/terok_shield/resources/nft_hook.py
+++ b/src/terok_shield/resources/nft_hook.py
@@ -26,6 +26,7 @@ import json
 import os
 import signal
 import sys
+import time
 from pathlib import Path
 
 # Sibling-module import: ``_oci_state.py`` lives next to this script in
@@ -218,13 +219,37 @@ def _poststop(sd: Path) -> None:
     except (ValueError, OSError):
         return
     if not _is_our_dnsmasq(pid_int, conf_path):
+        _oci_state.log(
+            f"poststop: stale dnsmasq pid file (pid {pid_int} recycled or gone) — removed",
+            sd / "hook-error.log",
+        )
         with contextlib.suppress(OSError):
             pid_file.unlink()
         return
+    # Escalate and report: a silently-leaked dnsmasq per container stop is
+    # invisible to the operator, and EPERM here (userns mismatch) would
+    # otherwise vanish into a bare except.
     try:
         os.kill(pid_int, signal.SIGTERM)
-    except OSError:
-        pass
+    except OSError as exc:
+        _oci_state.log(
+            f"poststop: SIGTERM dnsmasq[{pid_int}] failed: {exc}", sd / "hook-error.log"
+        )
+        return
+    for _ in range(20):  # up to 2s for dnsmasq to exit on its own
+        if not _is_our_dnsmasq(pid_int, conf_path):
+            return
+        time.sleep(0.1)
+    try:
+        os.kill(pid_int, signal.SIGKILL)
+        _oci_state.log(
+            f"poststop: dnsmasq[{pid_int}] survived SIGTERM — sent SIGKILL",
+            sd / "hook-error.log",
+        )
+    except OSError as exc:
+        _oci_state.log(
+            f"poststop: SIGKILL dnsmasq[{pid_int}] failed: {exc}", sd / "hook-error.log"
+        )
 
 
 def _our_dnsmasq_alive(pid_file: Path, conf_path: Path) -> bool:

--- a/src/terok_shield/resources/nft_hook.py
+++ b/src/terok_shield/resources/nft_hook.py
@@ -232,9 +232,7 @@ def _poststop(sd: Path) -> None:
     try:
         os.kill(pid_int, signal.SIGTERM)
     except OSError as exc:
-        _oci_state.log(
-            f"poststop: SIGTERM dnsmasq[{pid_int}] failed: {exc}", sd / "hook-error.log"
-        )
+        _oci_state.log(f"poststop: SIGTERM dnsmasq[{pid_int}] failed: {exc}", sd / "hook-error.log")
         return
     for _ in range(20):  # up to 2s for dnsmasq to exit on its own
         if not _is_our_dnsmasq(pid_int, conf_path):
@@ -247,9 +245,7 @@ def _poststop(sd: Path) -> None:
             sd / "hook-error.log",
         )
     except OSError as exc:
-        _oci_state.log(
-            f"poststop: SIGKILL dnsmasq[{pid_int}] failed: {exc}", sd / "hook-error.log"
-        )
+        _oci_state.log(f"poststop: SIGKILL dnsmasq[{pid_int}] failed: {exc}", sd / "hook-error.log")
 
 
 def _our_dnsmasq_alive(pid_file: Path, conf_path: Path) -> bool:

--- a/src/terok_shield/run.py
+++ b/src/terok_shield/run.py
@@ -125,9 +125,14 @@ class SubprocessRunner:
         return r.stdout or ""
 
     def has(self, name: str) -> bool:
-        """Return True if an executable is on PATH (cached per name)."""
+        """Return True if an executable is on PATH or a sbin dir (cached).
+
+        sbin-aware for the same reason as [`find_nft`][terok_shield.run.find_nft]: Debian-family login
+        shells omit /usr/sbin, and a plain which() there would silently
+        downgrade the DNS tier by "missing" dnsmasq.
+        """
         if name not in self._has_cache:
-            self._has_cache[name] = shutil.which(name) is not None
+            self._has_cache[name] = bool(which_sbin_aware(name))
         return self._has_cache[name]
 
     # ── nft ─────────────────────────────────────────────
@@ -255,17 +260,25 @@ class ShieldNeedsSetup(RuntimeError):
 _SBIN_DIRS = ("/usr/sbin", "/sbin")
 
 
+def which_sbin_aware(name: str) -> str:
+    """Resolve *name* like ``shutil.which``, falling back to the sbin dirs.
+
+    Login shells on the Debian family exclude ``/usr/sbin`` from PATH, so
+    a plain which() misses sbin-installed daemons (dnsmasq) — and the DNS
+    tier silently downgrades to dig.  ``shutil.which`` with an explicit
+    ``path=`` keeps the executability check identical to PATH resolution.
+    """
+    for search_path in (None, *_SBIN_DIRS):
+        found = shutil.which(name, path=search_path)
+        if found:
+            return found
+    return ""
+
+
 def find_nft() -> str:
     """Locate the nft binary, checking PATH then common sbin directories.
 
     sbin directories are checked explicitly because rootless users often
     lack them in PATH.  Returns empty string if not found.
     """
-    found = shutil.which("nft")
-    if found:
-        return found
-    for d in _SBIN_DIRS:
-        candidate = Path(d) / "nft"
-        if candidate.is_file():
-            return str(candidate)
-    return ""
+    return which_sbin_aware("nft")

--- a/src/terok_shield/run.py
+++ b/src/terok_shield/run.py
@@ -13,7 +13,6 @@ place.
 import ipaddress as _ipaddress
 import shutil
 import subprocess
-from pathlib import Path
 from typing import Protocol, runtime_checkable
 
 # ── CommandRunner protocol ──────────────────────────────

--- a/tach.toml
+++ b/tach.toml
@@ -67,12 +67,13 @@ path = "terok_shield.run"
 layer = "foundation"
 depends_on = []
 
-# Host binary prerequisite probes — zero internal deps, exported for
-# higher layers (terok-sandbox aggregator, operator diagnostics)
+# Host binary prerequisite probes — exported for higher layers
+# (terok-sandbox aggregator, operator diagnostics).  Depends on run for
+# the canonical sbin-aware binary lookup.
 [[modules]]
 path = "terok_shield.prereqs"
 layer = "foundation"
-depends_on = []
+depends_on = ["terok_shield.run"]
 
 # Hub event emitter — stdlib-only client for the terok-clearance unix ingester
 [[modules]]

--- a/tests/containers/Containerfile.alpine
+++ b/tests/containers/Containerfile.alpine
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+# Alpine (OpenRC, musl) — the non-systemd matrix slot.
+#
+# Purpose: prove shield's egress filtering (per-container OCI hooks +
+# nftables + NFLOG reader) works on a host with NO systemd at all — the
+# "shield-only headless" floor for OpenRC servers (Gentoo/Alpine),
+# runit/s6 images, and SLURM interactive jobs.  See terok-ai/terok#959
+# and #1113.
+#
+# Deliberately does NOT install systemd (the debian/fedora slots do).
+# The run-matrix.sh preflight asserts systemd is absent here, so the
+# slot can never silently regress into testing a systemd host.
+#
+# Alpine ships Python 3.12 natively; uv is used only for a fast,
+# ensurepip-independent venv (Alpine's stdlib venv ships no bundled
+# pip).  The uv binary in the official image is a static musl build.
+FROM docker.io/library/alpine:3.21
+
+# musl toolchain (build-base + *-dev) lets poetry build any dependency
+# that lacks a musllinux wheel; bind-tools provides dig for the DNS
+# allowlist probes; bash is required by the harness (busybox sh is not
+# bash).
+RUN apk add --no-cache \
+    podman slirp4netns nftables fuse-overlayfs crun \
+    shadow shadow-uidmap \
+    python3 \
+    git curl ca-certificates bind-tools bash \
+    build-base python3-dev libffi-dev
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+# ── Rootless podman nesting setup (mirrors the debian/fedora slots) ──
+# Subordinate UID/GID ranges MUST stay within 0-65535 so they fit inside
+# the outer rootless-podman container's user-namespace mapping.
+RUN useradd -m -s /bin/bash testrunner \
+    && uid=$(id -u testrunner) \
+    && printf "testrunner:1:%d\ntestrunner:%d:%d\n" \
+        $((uid - 1)) $((uid + 1)) $((65535 - uid)) > /etc/subuid \
+    && cp /etc/subuid /etc/subgid \
+    && chmod 4755 /usr/bin/newuidmap /usr/bin/newgidmap \
+    && mkdir -p /etc/containers \
+    && printf '[storage]\ndriver = "overlay"\n\n[storage.options.overlay]\nmount_program = "/usr/bin/fuse-overlayfs"\nmountopt = "nodev,fsync=0"\n' \
+        > /etc/containers/storage.conf \
+    && printf '[engine]\ncgroup_manager = "cgroupfs"\nevents_logger = "file"\n\n# Disable per-container kernel keyring \xe2\x80\x94 prevents keyring leak / EDQUOT\n[containers]\nkeyring = false\n' \
+        > /etc/containers/containers.conf \
+    && mkdir -p /run/user/$uid \
+    && chown testrunner:testrunner /run/user/$uid
+
+WORKDIR /src

--- a/tests/containers/Containerfile.alpine
+++ b/tests/containers/Containerfile.alpine
@@ -23,7 +23,7 @@ FROM docker.io/library/alpine:3.21
 # allowlist probes; bash is required by the harness (busybox sh is not
 # bash).
 RUN apk add --no-cache \
-    podman slirp4netns nftables fuse-overlayfs crun \
+    podman slirp4netns nftables dnsmasq fuse-overlayfs crun \
     shadow shadow-uidmap \
     python3 \
     git curl ca-certificates bind-tools bash \

--- a/tests/containers/Containerfile.alpine
+++ b/tests/containers/Containerfile.alpine
@@ -18,6 +18,11 @@
 # pip).  The uv binary in the official image is a static musl build.
 FROM docker.io/library/alpine:3.21
 
+# Ownership label: a Containerfile LABEL propagates into every
+# intermediate layer image, so the harness teardown can prune exactly
+# its own dangling generations (value = the harness IMAGE_PREFIX).
+LABEL "io.terok.matrix-test"="terok-shield-test"
+
 # musl toolchain (build-base + *-dev) lets poetry build any dependency
 # that lacks a musllinux wheel; bind-tools provides dig for the DNS
 # allowlist probes; bash is required by the harness (busybox sh is not

--- a/tests/containers/Containerfile.alpine
+++ b/tests/containers/Containerfile.alpine
@@ -48,7 +48,7 @@ RUN useradd -m -s /bin/bash testrunner \
     && mkdir -p /etc/containers \
     && printf '[storage]\ndriver = "overlay"\n\n[storage.options.overlay]\nmount_program = "/usr/bin/fuse-overlayfs"\nmountopt = "nodev,fsync=0"\n' \
         > /etc/containers/storage.conf \
-    && printf '[engine]\ncgroup_manager = "cgroupfs"\nevents_logger = "file"\n\n# Disable per-container kernel keyring \xe2\x80\x94 prevents keyring leak / EDQUOT\n[containers]\nkeyring = false\n' \
+    && printf '[engine]\ncgroup_manager = "cgroupfs"\nevents_logger = "file"\n\n# Disable per-container kernel keyring — prevents keyring leak / EDQUOT\n[containers]\nkeyring = false\n\n# On AppArmor hosts the passt profile attaches to the container pasta by\n# pathname (profiles are not container-namespaced) and denies its netns\n# and sysctl reads (dmesg: profile="passt" DENIED); slirp4netns is\n# unaffected.\n[network]\ndefault_rootless_network_cmd = "slirp4netns"\n' \
         > /etc/containers/containers.conf \
     && mkdir -p /run/user/$uid \
     && chown testrunner:testrunner /run/user/$uid

--- a/tests/containers/Containerfile.debian12
+++ b/tests/containers/Containerfile.debian12
@@ -5,7 +5,7 @@
 FROM docker.io/library/debian:12
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    podman slirp4netns nftables uidmap fuse-overlayfs crun \
+    podman slirp4netns nftables dnsmasq-base uidmap fuse-overlayfs crun \
     python3 \
     git curl ca-certificates dnsutils \
     && rm -rf /var/lib/apt/lists/*

--- a/tests/containers/Containerfile.debian12
+++ b/tests/containers/Containerfile.debian12
@@ -4,6 +4,11 @@
 # Debian 12 (Bookworm) — podman 4.3.1, slirp4netns only
 FROM docker.io/library/debian:12
 
+# Ownership label: a Containerfile LABEL propagates into every
+# intermediate layer image, so the harness teardown can prune exactly
+# its own dangling generations (value = the harness IMAGE_PREFIX).
+LABEL "io.terok.matrix-test"="terok-shield-test"
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
     podman slirp4netns nftables dnsmasq-base uidmap fuse-overlayfs crun \
     python3 \

--- a/tests/containers/Containerfile.debian13
+++ b/tests/containers/Containerfile.debian13
@@ -5,7 +5,7 @@
 FROM docker.io/library/debian:trixie
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    podman passt slirp4netns nftables uidmap fuse-overlayfs crun \
+    podman passt slirp4netns nftables dnsmasq-base uidmap fuse-overlayfs crun \
     python3 python3-pip python3-venv \
     git curl ca-certificates dnsutils \
     && rm -rf /var/lib/apt/lists/*

--- a/tests/containers/Containerfile.debian13
+++ b/tests/containers/Containerfile.debian13
@@ -4,6 +4,11 @@
 # Debian 13 (Trixie) — podman 5.4.x, pasta default
 FROM docker.io/library/debian:trixie
 
+# Ownership label: a Containerfile LABEL propagates into every
+# intermediate layer image, so the harness teardown can prune exactly
+# its own dangling generations (value = the harness IMAGE_PREFIX).
+LABEL "io.terok.matrix-test"="terok-shield-test"
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
     podman passt slirp4netns nftables dnsmasq-base uidmap fuse-overlayfs crun \
     python3 python3-pip python3-venv \

--- a/tests/containers/Containerfile.fedora43
+++ b/tests/containers/Containerfile.fedora43
@@ -4,6 +4,11 @@
 # Fedora 43 — podman 5.8.x, pasta default, modern everything
 FROM registry.fedoraproject.org/fedora:43
 
+# Ownership label: a Containerfile LABEL propagates into every
+# intermediate layer image, so the harness teardown can prune exactly
+# its own dangling generations (value = the harness IMAGE_PREFIX).
+LABEL "io.terok.matrix-test"="terok-shield-test"
+
 RUN dnf install -y \
     podman passt nftables dnsmasq slirp4netns fuse-overlayfs crun \
     python3 python3-pip \

--- a/tests/containers/Containerfile.fedora43
+++ b/tests/containers/Containerfile.fedora43
@@ -5,7 +5,7 @@
 FROM registry.fedoraproject.org/fedora:43
 
 RUN dnf install -y \
-    podman passt nftables slirp4netns fuse-overlayfs crun \
+    podman passt nftables dnsmasq slirp4netns fuse-overlayfs crun \
     python3 python3-pip \
     git curl bind-utils \
     && dnf clean all

--- a/tests/containers/Containerfile.fedora44
+++ b/tests/containers/Containerfile.fedora44
@@ -5,7 +5,7 @@
 FROM registry.fedoraproject.org/fedora:44
 
 RUN dnf install -y \
-    podman passt nftables slirp4netns fuse-overlayfs crun \
+    podman passt nftables dnsmasq slirp4netns fuse-overlayfs crun \
     python3 python3-pip \
     git curl bind-utils \
     && dnf clean all

--- a/tests/containers/Containerfile.fedora44
+++ b/tests/containers/Containerfile.fedora44
@@ -4,6 +4,11 @@
 # Fedora 44 — podman 5.x line, pasta default, looking forward
 FROM registry.fedoraproject.org/fedora:44
 
+# Ownership label: a Containerfile LABEL propagates into every
+# intermediate layer image, so the harness teardown can prune exactly
+# its own dangling generations (value = the harness IMAGE_PREFIX).
+LABEL "io.terok.matrix-test"="terok-shield-test"
+
 RUN dnf install -y \
     podman passt nftables dnsmasq slirp4netns fuse-overlayfs crun \
     python3 python3-pip \

--- a/tests/containers/Containerfile.mageia
+++ b/tests/containers/Containerfile.mageia
@@ -12,12 +12,16 @@
 # names differ from Fedora).
 FROM docker.io/mageia:9
 
+# Mageia 9 has no fuse-overlayfs package (only mga10/cauldron do), so the
+# inner rootless podman uses the vfs storage driver — reliable when nested
+# (no overlay-on-overlay), just slower.
+
 # Shield needs only the podman + nft egress stack plus a build toolchain
 # (gcc/python3-devel/libffi-devel) for any sdist lacking a manylinux
 # wheel; no dbus/glib build stack and no ssh client.  bind-utils provides
 # dig for the DNS allowlist probes; bash is required by the harness.
 RUN dnf install -y \
-        podman slirp4netns nftables fuse-overlayfs crun \
+        podman slirp4netns nftables crun \
         shadow-utils \
         python3 \
         git curl ca-certificates bind-utils bash \
@@ -39,7 +43,7 @@ RUN useradd -m testrunner \
     && cp /etc/subuid /etc/subgid \
     && chmod 4755 /usr/bin/newuidmap /usr/bin/newgidmap \
     && mkdir -p /etc/containers \
-    && printf '[storage]\ndriver = "overlay"\n\n[storage.options.overlay]\nmount_program = "/usr/bin/fuse-overlayfs"\nmountopt = "nodev,fsync=0"\n' \
+    && printf '[storage]\ndriver = "vfs"\n' \
         > /etc/containers/storage.conf \
     && printf '[engine]\ncgroup_manager = "cgroupfs"\nevents_logger = "file"\n\n# Disable per-container kernel keyring — prevents keyring leak / EDQUOT\n[containers]\nkeyring = false\n' \
         > /etc/containers/containers.conf \

--- a/tests/containers/Containerfile.mageia
+++ b/tests/containers/Containerfile.mageia
@@ -12,6 +12,11 @@
 # names differ from Fedora).
 FROM docker.io/mageia:9
 
+# Known 64K-page-kernel incompatibility: Mageia 9's aarch64 bind userland
+# (jemalloc built for 4K pages) SIGABRTs on 64K-page hosts (e.g. the
+# nvidia-64k DGX kernels) — dig dies before sending a query, so
+# dig-dependent paths rely on shield's getent fallback there.
+
 # Mageia 9 has no fuse-overlayfs package (only mga10/cauldron do), so the
 # inner rootless podman uses the vfs storage driver — reliable when nested
 # (no overlay-on-overlay), just slower.

--- a/tests/containers/Containerfile.mageia
+++ b/tests/containers/Containerfile.mageia
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+# Mageia (systemd, glibc, rpm) — broadens rpm-distro coverage beyond
+# Fedora after a recently-reported Mageia issue.
+#
+# Mageia uses systemd — this is NOT a non-systemd slot; the run-matrix.sh
+# preflight only records the init system here.
+#
+# NOTE: Mageia package names / base tag are best-effort and may need
+# adjustment on the first matrix run (dnf is available on Mageia; some
+# names differ from Fedora).
+FROM docker.io/mageia:9
+
+# Shield needs only the podman + nft egress stack plus a build toolchain
+# (gcc/python3-devel/libffi-devel) for any sdist lacking a manylinux
+# wheel; no dbus/glib build stack and no ssh client.  bind-utils provides
+# dig for the DNS allowlist probes; bash is required by the harness.
+RUN dnf install -y \
+        podman slirp4netns nftables fuse-overlayfs crun \
+        shadow-utils \
+        python3 \
+        git curl ca-certificates bind-utils bash \
+        gcc python3-devel libffi-devel \
+    && dnf clean all
+
+# Mageia 9 ships Python < 3.12 — use uv to get a 3.12 interpreter (mirrors
+# the debian12 slot).
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+RUN uv python install 3.12
+
+# ── Rootless podman nesting setup (mirrors the debian/fedora slots) ──
+# Subordinate UID/GID ranges MUST stay within 0-65535 so they fit inside
+# the outer rootless-podman container's user-namespace mapping.
+RUN useradd -m testrunner \
+    && uid=$(id -u testrunner) \
+    && printf "testrunner:1:%d\ntestrunner:%d:%d\n" \
+        $((uid - 1)) $((uid + 1)) $((65535 - uid)) > /etc/subuid \
+    && cp /etc/subuid /etc/subgid \
+    && chmod 4755 /usr/bin/newuidmap /usr/bin/newgidmap \
+    && mkdir -p /etc/containers \
+    && printf '[storage]\ndriver = "overlay"\n\n[storage.options.overlay]\nmount_program = "/usr/bin/fuse-overlayfs"\nmountopt = "nodev,fsync=0"\n' \
+        > /etc/containers/storage.conf \
+    && printf '[engine]\ncgroup_manager = "cgroupfs"\nevents_logger = "file"\n\n# Disable per-container kernel keyring — prevents keyring leak / EDQUOT\n[containers]\nkeyring = false\n' \
+        > /etc/containers/containers.conf \
+    && mkdir -p /run/user/$uid \
+    && chown testrunner:testrunner /run/user/$uid
+
+WORKDIR /src

--- a/tests/containers/Containerfile.mageia
+++ b/tests/containers/Containerfile.mageia
@@ -21,7 +21,7 @@ FROM docker.io/mageia:9
 # wheel; no dbus/glib build stack and no ssh client.  bind-utils provides
 # dig for the DNS allowlist probes; bash is required by the harness.
 RUN dnf install -y \
-        podman slirp4netns nftables crun \
+        podman slirp4netns nftables dnsmasq crun \
         shadow-utils \
         python3 \
         git curl ca-certificates bind-utils bash \

--- a/tests/containers/Containerfile.mageia
+++ b/tests/containers/Containerfile.mageia
@@ -12,6 +12,11 @@
 # names differ from Fedora).
 FROM docker.io/mageia:9
 
+# Ownership label: a Containerfile LABEL propagates into every
+# intermediate layer image, so the harness teardown can prune exactly
+# its own dangling generations (value = the harness IMAGE_PREFIX).
+LABEL "io.terok.matrix-test"="terok-shield-test"
+
 # Known 64K-page-kernel incompatibility: Mageia 9's aarch64 bind userland
 # (jemalloc built for 4K pages) SIGABRTs on 64K-page hosts (e.g. the
 # nvidia-64k DGX kernels) — dig dies before sending a query, so

--- a/tests/containers/Containerfile.podman
+++ b/tests/containers/Containerfile.podman
@@ -7,7 +7,7 @@
 FROM quay.io/podman/stable:latest
 
 RUN dnf install -y \
-    nftables python3 python3-pip \
+    nftables dnsmasq python3 python3-pip \
     git curl bind-utils \
     && dnf clean all
 

--- a/tests/containers/Containerfile.podman
+++ b/tests/containers/Containerfile.podman
@@ -12,7 +12,7 @@ FROM quay.io/podman/stable:latest
 LABEL "io.terok.matrix-test"="terok-shield-test"
 
 RUN dnf install -y \
-    nftables dnsmasq python3 python3-pip \
+    nftables dnsmasq slirp4netns python3 python3-pip \
     git curl bind-utils \
     && dnf clean all
 
@@ -24,6 +24,8 @@ RUN mkdir -p /run/user/$(id -u podman) && chown podman:podman /run/user/$(id -u 
 # main file, and TOML rejects a duplicate section header.
 RUN mkdir -p /etc/containers/containers.conf.d \
     && printf '[containers]\nkeyring = false\n' \
-        > /etc/containers/containers.conf.d/00-no-keyring.conf
+        > /etc/containers/containers.conf.d/00-no-keyring.conf \
+    && printf '# pasta-created netns rejects nsenter here (EPERM; host passt\n# AppArmor profile suspected) — the seven distro slots on slirp4netns\n# pass the same pre-check.\n[network]\ndefault_rootless_network_cmd = "slirp4netns"\n' \
+        > /etc/containers/containers.conf.d/01-slirp4netns.conf
 
 WORKDIR /src

--- a/tests/containers/Containerfile.podman
+++ b/tests/containers/Containerfile.podman
@@ -6,6 +6,11 @@
 # (subuid/subgid, storage.conf, containers.conf, setuid newuidmap).
 FROM quay.io/podman/stable:latest
 
+# Ownership label: a Containerfile LABEL propagates into every
+# intermediate layer image, so the harness teardown can prune exactly
+# its own dangling generations (value = the harness IMAGE_PREFIX).
+LABEL "io.terok.matrix-test"="terok-shield-test"
+
 RUN dnf install -y \
     nftables dnsmasq python3 python3-pip \
     git curl bind-utils \

--- a/tests/containers/Containerfile.podman
+++ b/tests/containers/Containerfile.podman
@@ -25,7 +25,7 @@ RUN mkdir -p /run/user/$(id -u podman) && chown podman:podman /run/user/$(id -u 
 RUN mkdir -p /etc/containers/containers.conf.d \
     && printf '[containers]\nkeyring = false\n' \
         > /etc/containers/containers.conf.d/00-no-keyring.conf \
-    && printf '# pasta-created netns rejects nsenter here (EPERM; host passt\n# AppArmor profile suspected) — the seven distro slots on slirp4netns\n# pass the same pre-check.\n[network]\ndefault_rootless_network_cmd = "slirp4netns"\n' \
-        > /etc/containers/containers.conf.d/01-slirp4netns.conf
+    && printf '# Align this image with the distro slots: its stock config uses\n# userns = "auto", which puts every container in its own sub-userns —\n# nsenter -n from podman unshare then fails with EPERM (the nft-in-netns\n# pre-check). userns = "host" matches how all other slots run.\n[containers]\nuserns = "host"\n\n[network]\ndefault_rootless_network_cmd = "slirp4netns"\n' \
+        > /etc/containers/containers.conf.d/01-matrix.conf
 
 WORKDIR /src

--- a/tests/containers/Containerfile.ubuntu2404
+++ b/tests/containers/Containerfile.ubuntu2404
@@ -5,7 +5,7 @@
 FROM docker.io/library/ubuntu:24.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    podman slirp4netns passt nftables uidmap fuse-overlayfs crun \
+    podman slirp4netns passt nftables dnsmasq-base uidmap fuse-overlayfs crun \
     python3 python3-pip python3-venv \
     git curl ca-certificates dnsutils \
     && rm -rf /var/lib/apt/lists/*

--- a/tests/containers/Containerfile.ubuntu2404
+++ b/tests/containers/Containerfile.ubuntu2404
@@ -4,6 +4,11 @@
 # Ubuntu 24.04 (Noble) — podman 4.9.3, slirp4netns + pasta available
 FROM docker.io/library/ubuntu:24.04
 
+# Ownership label: a Containerfile LABEL propagates into every
+# intermediate layer image, so the harness teardown can prune exactly
+# its own dangling generations (value = the harness IMAGE_PREFIX).
+LABEL "io.terok.matrix-test"="terok-shield-test"
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
     podman slirp4netns passt nftables dnsmasq-base uidmap fuse-overlayfs crun \
     python3 python3-pip python3-venv \

--- a/tests/containers/Containerfile.ubuntu2604
+++ b/tests/containers/Containerfile.ubuntu2604
@@ -4,6 +4,11 @@
 # Ubuntu 26.04 (Resolute) — next LTS, pulls in a newer podman than 24.04
 FROM docker.io/library/ubuntu:26.04
 
+# Ownership label: a Containerfile LABEL propagates into every
+# intermediate layer image, so the harness teardown can prune exactly
+# its own dangling generations (value = the harness IMAGE_PREFIX).
+LABEL "io.terok.matrix-test"="terok-shield-test"
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
     podman slirp4netns passt nftables dnsmasq-base uidmap fuse-overlayfs crun \
     python3 python3-pip python3-venv \

--- a/tests/containers/Containerfile.ubuntu2604
+++ b/tests/containers/Containerfile.ubuntu2604
@@ -5,7 +5,7 @@
 FROM docker.io/library/ubuntu:26.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    podman slirp4netns passt nftables uidmap fuse-overlayfs crun \
+    podman slirp4netns passt nftables dnsmasq-base uidmap fuse-overlayfs crun \
     python3 python3-pip python3-venv \
     git curl ca-certificates dnsutils \
     && rm -rf /var/lib/apt/lists/*

--- a/tests/containers/Containerfile.void
+++ b/tests/containers/Containerfile.void
@@ -49,7 +49,7 @@ RUN useradd -m -s /bin/bash testrunner \
     && mkdir -p /etc/containers \
     && printf '[storage]\ndriver = "overlay"\n\n[storage.options.overlay]\nmount_program = "/usr/bin/fuse-overlayfs"\nmountopt = "nodev,fsync=0"\n' \
         > /etc/containers/storage.conf \
-    && printf '[engine]\ncgroup_manager = "cgroupfs"\nevents_logger = "file"\n\n# Disable per-container kernel keyring — prevents keyring leak / EDQUOT\n[containers]\nkeyring = false\n' \
+    && printf '[engine]\ncgroup_manager = "cgroupfs"\nevents_logger = "file"\n\n# Disable per-container kernel keyring — prevents keyring leak / EDQUOT\n[containers]\nkeyring = false\n\n# On AppArmor hosts the passt profile attaches to the container pasta by\n# pathname (profiles are not container-namespaced) and denies its netns\n# and sysctl reads (dmesg: profile="passt" DENIED); slirp4netns is\n# unaffected.\n[network]\ndefault_rootless_network_cmd = "slirp4netns"\n' \
         > /etc/containers/containers.conf \
     && mkdir -p /run/user/$uid \
     && chown testrunner:testrunner /run/user/$uid

--- a/tests/containers/Containerfile.void
+++ b/tests/containers/Containerfile.void
@@ -17,6 +17,11 @@
 # toolchain).
 FROM ghcr.io/void-linux/void-glibc:latest
 
+# Ownership label: a Containerfile LABEL propagates into every
+# intermediate layer image, so the harness teardown can prune exactly
+# its own dangling generations (value = the harness IMAGE_PREFIX).
+LABEL "io.terok.matrix-test"="terok-shield-test"
+
 # Sync + self-update xbps first (rolling release), then install deps.
 # base-devel + *-devel covers any sdist that lacks a manylinux wheel
 # (e.g. cffi/libffi); bind-utils provides dig for the DNS allowlist

--- a/tests/containers/Containerfile.void
+++ b/tests/containers/Containerfile.void
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+# Void Linux (runit, glibc) — a non-systemd glibc matrix slot.
+#
+# Purpose: prove shield's egress filtering (per-container OCI hooks +
+# nftables + NFLOG reader) works on a non-systemd host that is *glibc*
+# (unlike the musl Alpine slot) — the shape of the real non-systemd
+# targets (Gentoo/OpenRC, runit/s6 images, SLURM nodes).  See
+# terok-ai/terok#959, #1113.
+#
+# Deliberately non-systemd (runit).  The run-matrix.sh preflight asserts
+# systemd is absent for this slot.
+#
+# NOTE: Void package names are best-effort and may need adjustment on the
+# first matrix run (Void uses xbps; -devel suffixes; base-devel for the
+# toolchain).
+FROM ghcr.io/void-linux/void-glibc:latest
+
+# Sync + self-update xbps first (rolling release), then install deps.
+# base-devel + *-devel covers any sdist that lacks a manylinux wheel
+# (e.g. cffi/libffi); bind-utils provides dig for the DNS allowlist
+# probes; bash is required by the harness.  Shield needs no dbus/glib
+# build stack and no ssh client — only the podman + nft egress stack.
+RUN xbps-install -Suy xbps \
+    && xbps-install -Sy \
+        podman slirp4netns nftables fuse-overlayfs crun \
+        shadow \
+        python3 python3-devel \
+        git curl ca-certificates bind-utils bash \
+        base-devel libffi-devel
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+# ── Rootless podman nesting setup (mirrors the debian/fedora slots) ──
+# Subordinate UID/GID ranges MUST stay within 0-65535 so they fit inside
+# the outer rootless-podman container's user-namespace mapping.
+RUN useradd -m -s /bin/bash testrunner \
+    && uid=$(id -u testrunner) \
+    && printf "testrunner:1:%d\ntestrunner:%d:%d\n" \
+        $((uid - 1)) $((uid + 1)) $((65535 - uid)) > /etc/subuid \
+    && cp /etc/subuid /etc/subgid \
+    && chmod 4755 /usr/bin/newuidmap /usr/bin/newgidmap \
+    && mkdir -p /etc/containers \
+    && printf '[storage]\ndriver = "overlay"\n\n[storage.options.overlay]\nmount_program = "/usr/bin/fuse-overlayfs"\nmountopt = "nodev,fsync=0"\n' \
+        > /etc/containers/storage.conf \
+    && printf '[engine]\ncgroup_manager = "cgroupfs"\nevents_logger = "file"\n\n# Disable per-container kernel keyring — prevents keyring leak / EDQUOT\n[containers]\nkeyring = false\n' \
+        > /etc/containers/containers.conf \
+    && mkdir -p /run/user/$uid \
+    && chown testrunner:testrunner /run/user/$uid
+
+WORKDIR /src

--- a/tests/containers/Containerfile.void
+++ b/tests/containers/Containerfile.void
@@ -24,7 +24,7 @@ FROM ghcr.io/void-linux/void-glibc:latest
 # build stack and no ssh client — only the podman + nft egress stack.
 RUN xbps-install -Suy xbps \
     && xbps-install -Sy \
-        podman slirp4netns nftables fuse-overlayfs crun \
+        podman slirp4netns nftables dnsmasq fuse-overlayfs crun \
         shadow util-linux findutils \
         python3 python3-devel \
         git curl ca-certificates bind-utils bash \

--- a/tests/containers/Containerfile.void
+++ b/tests/containers/Containerfile.void
@@ -25,7 +25,7 @@ FROM ghcr.io/void-linux/void-glibc:latest
 RUN xbps-install -Suy xbps \
     && xbps-install -Sy \
         podman slirp4netns nftables fuse-overlayfs crun \
-        shadow \
+        shadow util-linux findutils \
         python3 python3-devel \
         git curl ca-certificates bind-utils bash \
         base-devel libffi-devel

--- a/tests/containers/run-matrix.sh
+++ b/tests/containers/run-matrix.sh
@@ -49,6 +49,8 @@ else
 fi
 
 # Target distros: name -> Containerfile suffix
+# ``alpine`` is the non-systemd slot (OpenRC/musl) — it proves the stack
+# runs with no systemd at all.  See terok-ai/terok#959, #1113.
 declare -A DISTROS=(
     [debian12]="debian12"
     [ubuntu2404]="ubuntu2404"
@@ -57,6 +59,7 @@ declare -A DISTROS=(
     [fedora43]="fedora43"
     [fedora44]="fedora44"
     [podman]="podman"
+    [alpine]="alpine"
 )
 
 # Expected podman versions — pinned to the exact distro-shipped point
@@ -72,6 +75,7 @@ declare -A EXPECTED_VERSIONS=(
     [fedora43]="5.8.2"
     [fedora44]="5.8.2"
     [podman]="latest"
+    [alpine]="5.3.1"
 )
 
 # Print "expected podman X.Y.Z" for distros with a version pin, or
@@ -115,6 +119,7 @@ declare -A TEST_USERS=(
     [fedora43]="testrunner"
     [fedora44]="testrunner"
     [podman]="podman"
+    [alpine]="testrunner"
 )
 
 usage() {
@@ -204,6 +209,21 @@ run_tests() {
             # ── Prepare workspace (as root) ──
             cp -a $SOURCE_MOUNT $WORKSPACE_DIR
             chown -R $test_user:$test_user $WORKSPACE_DIR
+
+            # ── Non-systemd proof ──
+            # The alpine slot must run on a genuinely systemd-free host;
+            # fail loudly if a future base image regresses that.  Other
+            # slots just record their init system in the log.
+            echo \"--- init system: PID1=\$(cat /proc/1/comm 2>/dev/null || echo unknown) ---\"
+            if command -v systemctl >/dev/null 2>&1 || [ -d /run/systemd/system ]; then
+                echo \"systemd: present\"
+                if [ \"$name\" = alpine ]; then
+                    echo \"FATAL: 'alpine' is the non-systemd slot but systemd was detected\" >&2
+                    exit 1
+                fi
+            else
+                echo \"systemd: absent — non-systemd host confirmed\"
+            fi
 
             # Strip IPv6 zone-ID nameservers — they reference host interfaces
             # (e.g. eno1) that don't exist inside the container, causing dig

--- a/tests/containers/run-matrix.sh
+++ b/tests/containers/run-matrix.sh
@@ -144,6 +144,7 @@ usage() {
     echo "  --list         List available distros"
     echo "  --unit-only    Run only unit tests (fast)"
     echo "  --integ-only   Run only integration tests"
+    echo "  --keep-dangling  Skip the teardown prune of this harness's dangling layers"
     echo "  -h, --help     Show this help"
     echo ""
     echo "Default: install full infrastructure, run unit + integration tests."
@@ -350,6 +351,7 @@ BUILD_ONLY=false
 LIST_ONLY=false
 NO_CACHE=false
 TEST_SCOPE="all"
+KEEP_DANGLING=false
 TARGETS=()
 
 while [[ $# -gt 0 ]]; do
@@ -363,6 +365,7 @@ while [[ $# -gt 0 ]]; do
         --integ-only)
             [[ "$TEST_SCOPE" != "all" ]] && { echo "Error: --unit-only and --integ-only are mutually exclusive" >&2; exit 1; }
             TEST_SCOPE="integ" ;;
+        --keep-dangling) KEEP_DANGLING=true ;;
         -h|--help) usage; exit 0 ;;
         *) TARGETS+=("$1") ;;
     esac
@@ -428,6 +431,21 @@ done
 for target in "${FAILED[@]}"; do
     echo -e "  ${C_RED}FAIL${C_RESET}: $target $(version_summary "$target")"
 done
+
+
+# Teardown hygiene: dangling generations of exactly THIS harness's images
+# (Containerfile LABEL ownership) are pruned at idle IO priority — small
+# per-run increments instead of an hours-long backlog.  Opt out with
+# --keep-dangling.
+if ! $KEEP_DANGLING; then
+    echo ""
+    echo -e "${C_DIM}Pruning this harness's dangling image generations (idle io)…${C_RESET}"
+    prune=(podman image prune -f --filter "label=io.terok.matrix-test=$IMAGE_PREFIX")
+    command -v nice >/dev/null && prune=(nice -n19 "${prune[@]}")
+    command -v ionice >/dev/null && prune=(ionice -c3 "${prune[@]}")
+    pruned=$("${prune[@]}" | wc -l) || true
+    echo -e "${C_DIM}pruned ${pruned:-0} image record(s)${C_RESET}"
+fi
 
 if [[ ${#FAILED[@]} -gt 0 ]]; then
     exit 1

--- a/tests/containers/run-matrix.sh
+++ b/tests/containers/run-matrix.sh
@@ -209,6 +209,7 @@ run_tests() {
     # Privileged mode gives the outer container the capabilities needed
     # for nested podman, but tests run as uid 1000 (rootless podman).
     podman run --rm --name "$ctr_name" \
+        -e TERM=xterm \
         --privileged \
         --security-opt label=disable \
         --device /dev/fuse:rw \

--- a/tests/containers/run-matrix.sh
+++ b/tests/containers/run-matrix.sh
@@ -388,8 +388,14 @@ done
 
 warn_keyring
 
+# A slot whose image fails to build is recorded and reported as FAILED, but
+# does NOT abort the whole matrix — so one run surfaces every distro's issues.
+declare -A BUILD_FAILED_MAP=()
 for target in "${TARGETS[@]}"; do
-    build_image "$target"
+    if ! build_image "$target"; then
+        echo -e "${C_RED}==> Build FAILED for ${C_BOLD}$target${C_RED} — recording and continuing${C_RESET}" >&2
+        BUILD_FAILED_MAP[$target]=1
+    fi
 done
 
 if $BUILD_ONLY; then
@@ -401,6 +407,11 @@ PASSED=()
 FAILED=()
 
 for target in "${TARGETS[@]}"; do
+    if [[ -n "${BUILD_FAILED_MAP[$target]:-}" ]]; then
+        echo -e "${C_RED}==> $target: FAIL (image build failed)${C_RESET}" >&2
+        FAILED+=("$target")
+        continue
+    fi
     if run_tests "$target" "$TEST_SCOPE"; then
         PASSED+=("$target")
     else

--- a/tests/containers/run-matrix.sh
+++ b/tests/containers/run-matrix.sh
@@ -252,6 +252,7 @@ run_tests() {
             su - $test_user -c '
                 set -e
                 export XDG_RUNTIME_DIR=/run/user/\$(id -u)
+                export TEROK_MATRIX=1
 
                 cd $WORKSPACE_DIR
 

--- a/tests/containers/run-matrix.sh
+++ b/tests/containers/run-matrix.sh
@@ -253,7 +253,9 @@ run_tests() {
                 set -e
                 export XDG_RUNTIME_DIR=/run/user/\$(id -u)
                 export TEROK_MATRIX=1
-                export TEROK_EXPECT=podman,nft,dnsmasq,dig,getent,internet,hooks
+                # Image-capability contract only: hooks are phase state,
+                # appended below once setup has installed them.
+                export TEROK_EXPECT=podman,nft,dnsmasq,dig,getent,internet
 
                 cd $WORKSPACE_DIR
 
@@ -297,6 +299,7 @@ run_tests() {
                 echo \"\"
                 echo \"--- installing shield hooks ---\"
                 poetry run terok-shield setup
+                export TEROK_EXPECT=\${TEROK_EXPECT},hooks
 
                 echo \"\"
                 echo \"--- check-environment ---\"

--- a/tests/containers/run-matrix.sh
+++ b/tests/containers/run-matrix.sh
@@ -209,7 +209,7 @@ run_tests() {
     # install ALL infrastructure, run ALL tests as a rootless user.
     # Privileged mode gives the outer container the capabilities needed
     # for nested podman, but tests run as uid 1000 (rootless podman).
-    podman run --rm --name "$ctr_name" \
+    podman run --rm --replace --name "$ctr_name" \
         -e TERM=xterm \
         --privileged \
         --security-opt label=disable \

--- a/tests/containers/run-matrix.sh
+++ b/tests/containers/run-matrix.sh
@@ -73,9 +73,9 @@ declare -A EXPECTED_VERSIONS=(
     [ubuntu2604]="5.7.0"
     [debian13]="5.4.2"
     [fedora43]="5.8.2"
-    [fedora44]="5.8.2"
+    [fedora44]="5.8.3"
     [podman]="latest"
-    [alpine]="5.3.1"
+    [alpine]="5.3.2"
 )
 
 # Print "expected podman X.Y.Z" for distros with a version pin, or
@@ -279,7 +279,7 @@ run_tests() {
                 # ── Infrastructure setup ──
                 echo \"\"
                 echo \"--- installing shield hooks ---\"
-                poetry run terok-shield setup --user
+                poetry run terok-shield setup
 
                 echo \"\"
                 echo \"--- check-environment ---\"

--- a/tests/containers/run-matrix.sh
+++ b/tests/containers/run-matrix.sh
@@ -253,6 +253,7 @@ run_tests() {
                 set -e
                 export XDG_RUNTIME_DIR=/run/user/\$(id -u)
                 export TEROK_MATRIX=1
+                export TEROK_EXPECT=podman,nft,dnsmasq,dig,getent,internet,hooks
 
                 cd $WORKSPACE_DIR
 

--- a/tests/containers/run-matrix.sh
+++ b/tests/containers/run-matrix.sh
@@ -60,6 +60,15 @@ declare -A DISTROS=(
     [fedora44]="fedora44"
     [podman]="podman"
     [alpine]="alpine"
+    [void]="void"
+    [mageia]="mageia"
+)
+
+# Slots that are non-systemd (OpenRC/runit/musl): the run-time preflight
+# hard-fails these if systemd is unexpectedly present.
+declare -A NON_SYSTEMD_SLOTS=(
+    [alpine]=1
+    [void]=1
 )
 
 # Expected podman versions — pinned to the exact distro-shipped point
@@ -76,6 +85,8 @@ declare -A EXPECTED_VERSIONS=(
     [fedora44]="5.8.3"
     [podman]="latest"
     [alpine]="5.3.2"
+    [void]="latest"
+    [mageia]="latest"
 )
 
 # Print "expected podman X.Y.Z" for distros with a version pin, or
@@ -120,6 +131,8 @@ declare -A TEST_USERS=(
     [fedora44]="testrunner"
     [podman]="podman"
     [alpine]="testrunner"
+    [void]="testrunner"
+    [mageia]="testrunner"
 )
 
 usage() {
@@ -211,14 +224,14 @@ run_tests() {
             chown -R $test_user:$test_user $WORKSPACE_DIR
 
             # ── Non-systemd proof ──
-            # The alpine slot must run on a genuinely systemd-free host;
-            # fail loudly if a future base image regresses that.  Other
-            # slots just record their init system in the log.
+            # Non-systemd slots (alpine/void) must run on a genuinely
+            # systemd-free host; fail loudly if a future base image regresses
+            # that.  Other slots just record their init system in the log.
             echo \"--- init system: PID1=\$(cat /proc/1/comm 2>/dev/null || echo unknown) ---\"
             if command -v systemctl >/dev/null 2>&1 || [ -d /run/systemd/system ]; then
                 echo \"systemd: present\"
-                if [ \"$name\" = alpine ]; then
-                    echo \"FATAL: 'alpine' is the non-systemd slot but systemd was detected\" >&2
+                if [ \"${NON_SYSTEMD_SLOTS[$name]:-}\" = 1 ]; then
+                    echo \"FATAL: '$name' is a non-systemd slot but systemd was detected\" >&2
                     exit 1
                 fi
             else

--- a/tests/integration/bypass/test_cli.py
+++ b/tests/integration/bypass/test_cli.py
@@ -25,24 +25,24 @@ class TestBypassCLI:
 
     def test_cli_down(self, shielded_container: str, capsys: pytest.CaptureFixture) -> None:
         """``main(["down", container])`` switches to bypass mode."""
-        main(["down", shielded_container])
+        main(["down", shielded_container, "--container-id", shielded_container.id])
         captured = capsys.readouterr()
         assert "Shield down" in captured.out
         assert _shield().state(shielded_container) == ShieldState.DOWN
 
     def test_cli_disengaged(self, shielded_container: str, capsys: pytest.CaptureFixture) -> None:
         """``main(["down", container, "--all"])`` enables full bypass."""
-        main(["down", shielded_container, "--all"])
+        main(["down", shielded_container, "--all", "--container-id", shielded_container.id])
         captured = capsys.readouterr()
         assert "all traffic" in captured.out
         assert _shield().state(shielded_container) == ShieldState.DISENGAGED
 
     def test_cli_up(self, shielded_container: str, capsys: pytest.CaptureFixture) -> None:
         """``main(["up", container])`` restores deny-all mode."""
-        main(["down", shielded_container])
+        main(["down", shielded_container, "--container-id", shielded_container.id])
         assert _shield().state(shielded_container) == ShieldState.DOWN
 
-        main(["up", shielded_container])
+        main(["up", shielded_container, "--container-id", shielded_container.id])
         captured = capsys.readouterr()
         assert "Shield up" in captured.out
         assert _shield().state(shielded_container) == ShieldState.UP
@@ -51,10 +51,10 @@ class TestBypassCLI:
         """CLI down enables traffic; CLI up blocks it again."""
         assert_blocked(shielded_container, BLOCKED_TARGET_HTTP)
 
-        main(["down", shielded_container])
+        main(["down", shielded_container, "--container-id", shielded_container.id])
         assert_connectable(shielded_container, BLOCKED_TARGET_IP, BLOCKED_TARGET_DNS_PORT)
 
-        main(["up", shielded_container])
+        main(["up", shielded_container, "--container-id", shielded_container.id])
         assert_blocked(shielded_container, BLOCKED_TARGET_HTTP)
 
     def test_cli_rules_shows_state(
@@ -65,7 +65,7 @@ class TestBypassCLI:
         captured = capsys.readouterr()
         assert "State: up" in captured.out
 
-        main(["down", shielded_container])
+        main(["down", shielded_container, "--container-id", shielded_container.id])
         capsys.readouterr()  # Clear buffer
 
         main(["rules", shielded_container])

--- a/tests/integration/bypass/test_lifecycle.py
+++ b/tests/integration/bypass/test_lifecycle.py
@@ -57,26 +57,26 @@ class TestBypassBasicLifecycle:
         assert_blocked(shielded_container, BLOCKED_TARGET_HTTP)
 
         # Shield down: traffic allowed
-        shield.down(shielded_container, shielded_container)
+        shield.down(shielded_container, shielded_container.id)
         assert shield.state(shielded_container) == ShieldState.DOWN
         assert_connectable(shielded_container, BLOCKED_TARGET_IP, BLOCKED_TARGET_DNS_PORT)
 
         # Shield up: traffic blocked again
-        shield.up(shielded_container, shielded_container)
+        shield.up(shielded_container, shielded_container.id)
         assert shield.state(shielded_container) == ShieldState.UP
         assert_blocked(shielded_container, BLOCKED_TARGET_HTTP)
 
     def test_up_disengaged_up_cycle(self, shielded_container: str) -> None:
         """Full cycle with allow_all: UP -> DISENGAGED -> UP."""
         shield = _shield()
-        shield.down(shielded_container, shielded_container, allow_all=True)
+        shield.down(shielded_container, shielded_container.id, allow_all=True)
         assert shield.state(shielded_container) == ShieldState.DISENGAGED
 
         rules = shield.rules(shielded_container)
         assert "policy accept" in rules
         assert_connectable(shielded_container, BLOCKED_TARGET_IP, BLOCKED_TARGET_DNS_PORT)
 
-        shield.up(shielded_container, shielded_container)
+        shield.up(shielded_container, shielded_container.id)
         assert shield.state(shielded_container) == ShieldState.UP
         assert_blocked(shielded_container, BLOCKED_TARGET_HTTP)
 
@@ -93,10 +93,10 @@ class TestBypassIdempotency:
     def test_down_twice_stays_down(self, shielded_container: str) -> None:
         """Calling shield.down() twice does not break anything."""
         shield = _shield()
-        shield.down(shielded_container, shielded_container)
+        shield.down(shielded_container, shielded_container.id)
         assert shield.state(shielded_container) == ShieldState.DOWN
 
-        shield.down(shielded_container, shielded_container)
+        shield.down(shielded_container, shielded_container.id)
         assert shield.state(shielded_container) == ShieldState.DOWN
         assert_connectable(shielded_container, BLOCKED_TARGET_IP, BLOCKED_TARGET_DNS_PORT)
 
@@ -105,14 +105,14 @@ class TestBypassIdempotency:
         shield = _shield()
         assert shield.state(shielded_container) == ShieldState.UP
 
-        shield.up(shielded_container, shielded_container)
+        shield.up(shielded_container, shielded_container.id)
         assert shield.state(shielded_container) == ShieldState.UP
         assert_blocked(shielded_container, BLOCKED_TARGET_HTTP)
 
     def test_up_without_prior_down(self, shielded_container: str) -> None:
         """shield.up() on a freshly shielded container is a no-op."""
         shield = _shield()
-        shield.up(shielded_container, shielded_container)
+        shield.up(shielded_container, shielded_container.id)
         assert shield.state(shielded_container) == ShieldState.UP
         assert_blocked(shielded_container, BLOCKED_TARGET_HTTP)
 
@@ -129,10 +129,10 @@ class TestBypassModeSwitch:
     def test_down_to_disengaged(self, shielded_container: str) -> None:
         """Switch from protected bypass to full bypass."""
         shield = _shield()
-        shield.down(shielded_container, shielded_container)
+        shield.down(shielded_container, shielded_container.id)
         assert shield.state(shielded_container) == ShieldState.DOWN
 
-        shield.down(shielded_container, shielded_container, allow_all=True)
+        shield.down(shielded_container, shielded_container.id, allow_all=True)
         assert shield.state(shielded_container) == ShieldState.DISENGAGED
 
         # Private-range rules should be gone
@@ -142,10 +142,10 @@ class TestBypassModeSwitch:
     def test_disengaged_to_down(self, shielded_container: str) -> None:
         """Switch from full bypass back to protected bypass."""
         shield = _shield()
-        shield.down(shielded_container, shielded_container, allow_all=True)
+        shield.down(shielded_container, shielded_container.id, allow_all=True)
         assert shield.state(shielded_container) == ShieldState.DISENGAGED
 
-        shield.down(shielded_container, shielded_container)
+        shield.down(shielded_container, shielded_container.id)
         assert shield.state(shielded_container) == ShieldState.DOWN
 
         # Private-range rules should be restored
@@ -170,13 +170,13 @@ class TestBypassWithAllowDeny:
         transition even though the nft ruleset is atomically replaced.
         """
         shield = _shield()
-        shield.down(shielded_container, shielded_container)
+        shield.down(shielded_container, shielded_container.id)
 
         # Add IP to allow set during bypass — persists to live.allowed
         shield.allow(shielded_container, BLOCKED_TARGET_IP)
 
         # Restore shield — the IP is re-added from live.allowed
-        shield.up(shielded_container, shielded_container)
+        shield.up(shielded_container, shielded_container.id)
 
         # Verify the IP is still allowed
         assert_connectable(shielded_container, BLOCKED_TARGET_IP, BLOCKED_TARGET_DNS_PORT)
@@ -188,7 +188,7 @@ class TestBypassWithAllowDeny:
         operator-driven deny still drops matching traffic.  See PR #230.
         """
         shield = _shield()
-        shield.down(shielded_container, shielded_container)
+        shield.down(shielded_container, shielded_container.id)
 
         shield.deny(shielded_container, BLOCKED_TARGET_IP)
         assert_not_connectable(shielded_container, BLOCKED_TARGET_IP, BLOCKED_TARGET_DNS_PORT)
@@ -218,7 +218,7 @@ class TestBypassIPRestoration:
 
         try:
             extra_args = shield.pre_start(name)
-            start_shielded_container(name, extra_args, IMAGE)
+            cid = start_shielded_container(name, extra_args, IMAGE)
 
             # Allow Cloudflare IPs and verify reachability
             for ip in ALLOWED_TARGET_IPS:
@@ -229,11 +229,11 @@ class TestBypassIPRestoration:
             StateBundle(sd).profile_allowed.write_text("\n".join(ALLOWED_TARGET_IPS) + "\n")
 
             # Go down (all traffic allowed regardless)
-            shield.down(name, name)
+            shield.down(name, cid)
             assert_reachable(name, ALLOWED_TARGET_HTTP)
 
             # Come back up — cached IPs should be restored
-            shield.up(name, name)
+            shield.up(name, cid)
             assert shield.state(name) == ShieldState.UP
             assert_reachable(name, ALLOWED_TARGET_HTTP)
 
@@ -254,8 +254,8 @@ class TestBypassAuditTrail:
         """shield.down and shield.up produce audit log entries."""
         sd = shield_env / "containers" / shielded_container
         shield = Shield(ShieldConfig(state_dir=sd))
-        shield.down(shielded_container, shielded_container)
-        shield.up(shielded_container, shielded_container)
+        shield.down(shielded_container, shielded_container.id)
+        shield.up(shielded_container, shielded_container.id)
 
         events = list(shield.tail_log())
         actions = [e["action"] for e in events]
@@ -271,7 +271,7 @@ class TestBypassAuditTrail:
         """shield.down(allow_all=True) logs the allow_all detail."""
         sd = shield_env / "containers" / shielded_container
         shield = Shield(ShieldConfig(state_dir=sd))
-        shield.down(shielded_container, shielded_container, allow_all=True)
+        shield.down(shielded_container, shielded_container.id, allow_all=True)
 
         events = list(shield.tail_log())
         down_events = [e for e in events if e["action"] == "shield_down"]
@@ -311,7 +311,7 @@ class TestBypassFullE2E:
 
         try:
             extra_args = shield.pre_start(name)
-            start_shielded_container(name, extra_args, IMAGE)
+            cid = start_shielded_container(name, extra_args, IMAGE)
 
             # Step 1: Default deny is in effect
             assert shield.state(name) == ShieldState.UP
@@ -328,23 +328,23 @@ class TestBypassFullE2E:
             StateBundle(sd).profile_allowed.write_text("\n".join(ALLOWED_TARGET_IPS) + "\n")
 
             # Step 3: Down for discovery
-            shield.down(name, name)
+            shield.down(name, cid)
             assert shield.state(name) == ShieldState.DOWN
             assert_reachable(name, ALLOWED_TARGET_HTTP)
             assert_connectable(name, BLOCKED_TARGET_IP, BLOCKED_TARGET_DNS_PORT)
 
             # Step 4: Switch to full bypass to also check RFC1918 destinations
-            shield.down(name, name, allow_all=True)
+            shield.down(name, cid, allow_all=True)
             assert shield.state(name) == ShieldState.DISENGAGED
             assert_connectable(name, BLOCKED_TARGET_IP, BLOCKED_TARGET_DNS_PORT)
 
             # Step 5: Back to protected bypass
-            shield.down(name, name)
+            shield.down(name, cid)
             assert shield.state(name) == ShieldState.DOWN
             assert_connectable(name, BLOCKED_TARGET_IP, BLOCKED_TARGET_DNS_PORT)
 
             # Step 6: Restore the shield
-            shield.up(name, name)
+            shield.up(name, cid)
             assert shield.state(name) == ShieldState.UP
 
             # Cached IPs should be restored
@@ -377,12 +377,12 @@ class TestBypassFullE2E:
         """
         shield = _shield()
         # Rapid toggles
-        shield.down(shielded_container, shielded_container)
-        shield.up(shielded_container, shielded_container)
-        shield.down(shielded_container, shielded_container)
-        shield.down(shielded_container, shielded_container, allow_all=True)
-        shield.up(shielded_container, shielded_container)
-        shield.up(shielded_container, shielded_container)
+        shield.down(shielded_container, shielded_container.id)
+        shield.up(shielded_container, shielded_container.id)
+        shield.down(shielded_container, shielded_container.id)
+        shield.down(shielded_container, shielded_container.id, allow_all=True)
+        shield.up(shielded_container, shielded_container.id)
+        shield.up(shielded_container, shielded_container.id)
 
         # Final state must be UP and enforcing
         assert shield.state(shielded_container) == ShieldState.UP
@@ -407,8 +407,8 @@ class TestBypassFullE2E:
         assert_reachable(shielded_container, ALLOWED_TARGET_HTTP)
 
         # Bypass cycle
-        shield.down(shielded_container, shielded_container)
-        shield.up(shielded_container, shielded_container)
+        shield.down(shielded_container, shielded_container.id)
+        shield.up(shielded_container, shielded_container.id)
 
         # IPs survive because live.allowed is read back by shield_up()
         assert_reachable(shielded_container, ALLOWED_TARGET_HTTP)

--- a/tests/integration/bypass/test_state.py
+++ b/tests/integration/bypass/test_state.py
@@ -34,22 +34,22 @@ class TestShieldState:
     def test_state_down_after_shield_down(self, shielded_container: str) -> None:
         """State is DOWN after shield.down() (RFC1918 protection kept)."""
         shield = _shield()
-        shield.down(shielded_container, shielded_container)
+        shield.down(shielded_container, shielded_container.id)
         assert shield.state(shielded_container) == ShieldState.DOWN
 
     def test_state_disengaged_after_shield_disengaged(self, shielded_container: str) -> None:
         """State is DISENGAGED after shield.down(allow_all=True)."""
         shield = _shield()
-        shield.down(shielded_container, shielded_container, allow_all=True)
+        shield.down(shielded_container, shielded_container.id, allow_all=True)
         assert shield.state(shielded_container) == ShieldState.DISENGAGED
 
     def test_state_up_after_shield_up(self, shielded_container: str) -> None:
         """State returns to UP after shield.down() then shield.up()."""
         shield = _shield()
-        shield.down(shielded_container, shielded_container)
+        shield.down(shielded_container, shielded_container.id)
         assert shield.state(shielded_container) == ShieldState.DOWN
 
-        shield.up(shielded_container, shielded_container)
+        shield.up(shielded_container, shielded_container.id)
         assert shield.state(shielded_container) == ShieldState.UP
 
 

--- a/tests/integration/bypass/test_traffic.py
+++ b/tests/integration/bypass/test_traffic.py
@@ -43,16 +43,16 @@ class TestBypassTrafficDNS:
 
     def test_dns_connectable_in_bypass(self, shielded_container: str) -> None:
         """DNS port (53) on a non-allowed target is connectable during bypass."""
-        _shield().down(shielded_container, shielded_container)
+        _shield().down(shielded_container, shielded_container.id)
         assert_connectable(shielded_container, BLOCKED_TARGET_IP, BLOCKED_TARGET_DNS_PORT)
 
     def test_dns_blocked_again_after_up(self, shielded_container: str) -> None:
         """DNS connectivity is blocked again after restoring the shield."""
         shield = _shield()
-        shield.down(shielded_container, shielded_container)
+        shield.down(shielded_container, shielded_container.id)
         assert_connectable(shielded_container, BLOCKED_TARGET_IP, BLOCKED_TARGET_DNS_PORT)
 
-        shield.up(shielded_container, shielded_container)
+        shield.up(shielded_container, shielded_container.id)
         assert_not_connectable(shielded_container, BLOCKED_TARGET_IP, BLOCKED_TARGET_DNS_PORT)
 
 
@@ -67,16 +67,16 @@ class TestBypassTrafficHTTP:
 
     def test_http_reachable_in_bypass(self, shielded_container: str) -> None:
         """HTTP (port 80) to a non-allowed target is reachable during bypass."""
-        _shield().down(shielded_container, shielded_container)
+        _shield().down(shielded_container, shielded_container.id)
         assert_reachable(shielded_container, CONNCHECK_HTTP)
 
     def test_http_blocked_again_after_up(self, shielded_container: str) -> None:
         """HTTP traffic to non-allowed target is blocked after restoring shield."""
         shield = _shield()
-        shield.down(shielded_container, shielded_container)
+        shield.down(shielded_container, shielded_container.id)
         assert_reachable(shielded_container, CONNCHECK_HTTP)
 
-        shield.up(shielded_container, shielded_container)
+        shield.up(shielded_container, shielded_container.id)
         assert_blocked(shielded_container, CONNCHECK_HTTP)
 
 
@@ -91,16 +91,16 @@ class TestBypassTrafficHTTPS:
 
     def test_https_reachable_in_bypass(self, shielded_container: str) -> None:
         """HTTPS (port 443) to a non-allowed target is reachable during bypass."""
-        _shield().down(shielded_container, shielded_container)
+        _shield().down(shielded_container, shielded_container.id)
         assert_reachable(shielded_container, CONNCHECK_HTTPS)
 
     def test_https_blocked_again_after_up(self, shielded_container: str) -> None:
         """HTTPS traffic to non-allowed target is blocked after restoring shield."""
         shield = _shield()
-        shield.down(shielded_container, shielded_container)
+        shield.down(shielded_container, shielded_container.id)
         assert_reachable(shielded_container, CONNCHECK_HTTPS)
 
-        shield.up(shielded_container, shielded_container)
+        shield.up(shielded_container, shielded_container.id)
         assert_blocked(shielded_container, CONNCHECK_HTTPS)
 
 
@@ -115,7 +115,7 @@ class TestBypassTrafficAllowed:
 
     def test_allowed_target_reachable_in_bypass(self, shielded_container: str) -> None:
         """Already-allowed HTTP target stays reachable during bypass."""
-        _shield().down(shielded_container, shielded_container)
+        _shield().down(shielded_container, shielded_container.id)
         assert_reachable(shielded_container, ALLOWED_TARGET_HTTP)
 
 
@@ -131,14 +131,14 @@ class TestBypassRuleset:
     def test_bypass_ruleset_has_log_prefix(self, shielded_container: str) -> None:
         """The bypass ruleset contains the TEROK_SHIELD_BYPASS log prefix."""
         shield = _shield()
-        shield.down(shielded_container, shielded_container)
+        shield.down(shielded_container, shielded_container.id)
         rules = shield.rules(shielded_container)
         assert BYPASS_LOG_PREFIX in rules
 
     def test_bypass_ruleset_has_accept_policy(self, shielded_container: str) -> None:
         """The bypass ruleset output chain has policy accept."""
         shield = _shield()
-        shield.down(shielded_container, shielded_container)
+        shield.down(shielded_container, shielded_container.id)
         rules = shield.rules(shielded_container)
         assert "policy accept" in rules
 
@@ -155,7 +155,7 @@ class TestBypassRFC1918:
     def test_rfc1918_rules_present_in_default_bypass(self, shielded_container: str) -> None:
         """Default bypass (no --all) keeps RFC1918 reject rules."""
         shield = _shield()
-        shield.down(shielded_container, shielded_container)
+        shield.down(shielded_container, shielded_container.id)
         rules = shield.rules(shielded_container)
         for net in RFC1918:
             assert net in rules, f"RFC1918 reject rule for {net} missing in bypass"
@@ -163,7 +163,7 @@ class TestBypassRFC1918:
     def test_rfc1918_rules_absent_in_allow_all_bypass(self, shielded_container: str) -> None:
         """Bypass with allow_all=True removes RFC1918 reject rules."""
         shield = _shield()
-        shield.down(shielded_container, shielded_container, allow_all=True)
+        shield.down(shielded_container, shielded_container.id, allow_all=True)
         rules = shield.rules(shielded_container)
         for net in RFC1918:
             assert (
@@ -178,7 +178,7 @@ class TestBypassRFC1918:
         (which guarantees ICMP admin-prohibited responses).
         """
         shield = _shield()
-        shield.down(shielded_container, shielded_container)
+        shield.down(shielded_container, shielded_container.id)
         rules = shield.rules(shielded_container)
         assert "admin-prohibited" in rules
 
@@ -195,7 +195,7 @@ class TestBypassIPv6Private:
     def test_ipv6_private_rules_present_in_default_bypass(self, shielded_container: str) -> None:
         """Default bypass keeps IPv6 private reject rules."""
         shield = _shield()
-        shield.down(shielded_container, shielded_container)
+        shield.down(shielded_container, shielded_container.id)
         rules = shield.rules(shielded_container)
         for net in IPV6_PRIVATE:
             assert net in rules, f"IPv6 private reject rule for {net} missing in bypass"
@@ -203,7 +203,7 @@ class TestBypassIPv6Private:
     def test_ipv6_private_rules_absent_in_allow_all_bypass(self, shielded_container: str) -> None:
         """Bypass with allow_all=True removes IPv6 private reject rules."""
         shield = _shield()
-        shield.down(shielded_container, shielded_container, allow_all=True)
+        shield.down(shielded_container, shielded_container.id, allow_all=True)
         rules = shield.rules(shielded_container)
         for net in IPV6_PRIVATE:
             assert (

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -29,7 +29,7 @@ from pathlib import Path
 import pytest
 
 from terok_shield.podman_info import has_global_hooks, parse_podman_info
-from terok_shield.run import find_nft
+from terok_shield.run import find_nft, which_sbin_aware
 from tests.testnet import ALLOWED_TARGET_IPS
 
 from .helpers import start_shielded_container
@@ -174,6 +174,56 @@ def _hooks_available() -> bool:
         ).stdout
         return parse_podman_info(output).hooks_dir_persists
     return False
+
+
+# -- Matrix capability contract ------------------------------
+# On a dev machine a missing binary is a host limitation, and the skip
+# guards above are the right degradation.  Inside the matrix the harness
+# BUILT the image, so every capability it declares (TEROK_EXPECT,
+# exported by run-matrix.sh) is a contract: absence means the slot is
+# broken and must fail at session start — not dissolve into skips that
+# read as green (a collapsed slot once reported PASS on 95 skips).
+# Presence-level probes only: host-dependent dysfunction (dig_broken on
+# 64K-page kernels) stays a visible skip, because the image cannot
+# control it.
+
+_CAPABILITY_PROBES = {
+    "podman": lambda: _has("podman"),
+    "nft": lambda: bool(find_nft()),
+    "dnsmasq": lambda: bool(which_sbin_aware("dnsmasq")),
+    "dig": lambda: _has("dig"),
+    "getent": lambda: _has("getent"),
+    "hooks": _hooks_available,
+    "internet": lambda: _tcp_reachable(ALLOWED_TARGET_IPS[0], 53),
+}
+
+
+def _tcp_reachable(ip: str, port: int, timeout: float = 5.0) -> bool:
+    """Whether a TCP connection to ``ip:port`` succeeds within *timeout*."""
+    try:
+        with socket.create_connection((ip, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+def pytest_sessionstart(session: pytest.Session) -> None:
+    """Fail the whole session when the matrix capability contract is broken."""
+    expected = {c for c in os.environ.get("TEROK_EXPECT", "").split(",") if c}
+    if not expected:
+        return
+    unknown = expected - _CAPABILITY_PROBES.keys()
+    if unknown:
+        pytest.exit(
+            f"TEROK_EXPECT names unknown capabilities: {sorted(unknown)}", returncode=3
+        )
+    missing = sorted(cap for cap in expected if not _CAPABILITY_PROBES[cap]())
+    if missing:
+        pytest.exit(
+            "matrix capability contract broken — expected but missing: "
+            + ", ".join(missing),
+            returncode=3,
+        )
 
 
 _hooks_available_cached = _hooks_available()

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -128,9 +128,7 @@ def _dig_functional() -> bool:
         return False
     try:
         return (
-            subprocess.run(
-                ["dig", "+short", ".", "NS"], capture_output=True, timeout=10
-            ).returncode
+            subprocess.run(["dig", "+short", ".", "NS"], capture_output=True, timeout=10).returncode
             == 0
         )
     except (OSError, subprocess.TimeoutExpired):
@@ -214,14 +212,11 @@ def pytest_sessionstart(session: pytest.Session) -> None:
         return
     unknown = expected - _CAPABILITY_PROBES.keys()
     if unknown:
-        pytest.exit(
-            f"TEROK_EXPECT names unknown capabilities: {sorted(unknown)}", returncode=3
-        )
+        pytest.exit(f"TEROK_EXPECT names unknown capabilities: {sorted(unknown)}", returncode=3)
     missing = sorted(cap for cap in expected if not _CAPABILITY_PROBES[cap]())
     if missing:
         pytest.exit(
-            "matrix capability contract broken — expected but missing: "
-            + ", ".join(missing),
+            "matrix capability contract broken — expected but missing: " + ", ".join(missing),
             returncode=3,
         )
 
@@ -357,8 +352,7 @@ def container(_pull_image: None) -> Iterator[str]:
         # CalledProcessError hides stderr — surface the runtime's actual
         # complaint (this exact blindness cost a full matrix round).
         raise RuntimeError(
-            f"podman run failed for {name}: "
-            f"{(e.stderr or b'').decode(errors='replace').strip()}"
+            f"podman run failed for {name}: {(e.stderr or b'').decode(errors='replace').strip()}"
         ) from e
     yield name
     _podman_rm(name)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -117,6 +117,46 @@ nft_missing = pytest.mark.skipif(not find_nft(), reason="nft not installed")
 dig_missing = pytest.mark.skipif(not _has("dig"), reason="dig not installed")
 
 
+def _dig_functional() -> bool:
+    """Whether dig can execute at all — present-but-crashing builds exist.
+
+    Mageia's aarch64 bind (jemalloc built for 4K pages) SIGABRTs on
+    64K-page kernels before sending a single query; dig-tier tests must
+    skip there with the real reason, not fail on empty output.
+    """
+    if not _has("dig"):
+        return False
+    try:
+        return (
+            subprocess.run(
+                ["dig", "+short", ".", "NS"], capture_output=True, timeout=10
+            ).returncode
+            == 0
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+
+
+dig_broken = pytest.mark.skipif(
+    _has("dig") and not _dig_functional(),
+    reason="dig present but non-functional on this host",
+)
+
+
+def _infra_problem(message: str) -> None:
+    """Broken container infrastructure: skip locally, fail in the matrix.
+
+    The matrix images guarantee working nested podman, so a failed
+    pre-check there is a real finding that must turn the slot red —
+    skipping let a collapsed slot report green (95 skips in 5 seconds).
+    Outside the matrix (TEROK_MATRIX unset) a missing capability is a
+    legitimate host limitation and skipping stays correct.
+    """
+    if os.environ.get("TEROK_MATRIX"):
+        pytest.fail(message, pytrace=False)
+    pytest.skip(message)
+
+
 def _hooks_available() -> bool:
     """Return True if OCI hooks will fire on container start.
 
@@ -243,9 +283,10 @@ def nft_in_netns(_pull_image: None, _verify_connectivity: None) -> None:
             timeout=10,
         )
         if r.returncode != 0:
-            pytest.skip(f"nft not usable inside container netns: {r.stderr.strip()}")
+            _infra_problem(f"nft not usable inside container netns: {r.stderr.strip()}")
     except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
-        pytest.skip(f"nft pre-check failed: {e}")
+        stderr = getattr(e, "stderr", b"") or b""
+        _infra_problem(f"nft pre-check failed: {e}: {stderr.decode(errors='replace').strip()}")
     finally:
         _podman_rm(name)
 
@@ -255,12 +296,20 @@ def container(_pull_image: None) -> Iterator[str]:
     """Start a disposable Alpine container, yield its name, clean up after."""
     name = f"{CTR_PREFIX}-{os.getpid()}"
     _podman_rm(name)
-    subprocess.run(
-        ["podman", "run", "-d", "--name", name, IMAGE, "sleep", "120"],
-        check=True,
-        capture_output=True,
-        timeout=30,
-    )
+    try:
+        subprocess.run(
+            ["podman", "run", "-d", "--name", name, IMAGE, "sleep", "120"],
+            check=True,
+            capture_output=True,
+            timeout=30,
+        )
+    except subprocess.CalledProcessError as e:
+        # CalledProcessError hides stderr — surface the runtime's actual
+        # complaint (this exact blindness cost a full matrix round).
+        raise RuntimeError(
+            f"podman run failed for {name}: "
+            f"{(e.stderr or b'').decode(errors='replace').strip()}"
+        ) from e
     yield name
     _podman_rm(name)
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -39,6 +39,36 @@ CTR_PREFIX = "shield-itest"
 _PODMAN_RM_TIMEOUT = 60
 
 
+class ShieldedContainer(str):
+    """A container name (``str``) that also carries its real podman id.
+
+    Behaves as the operator-facing container name everywhere a plain name
+    string is expected (``.name`` mirrors the ``str`` value), while also
+    exposing the full 64-hex podman container id via ``.id`` — the
+    ``--container-id`` routing key now required by
+    [`Shield.down`][terok_shield.Shield.down] /
+    [`Shield.up`][terok_shield.Shield.up].
+    """
+
+    _cid: str
+
+    def __new__(cls, name: str, cid: str) -> "ShieldedContainer":
+        """Create the name-string carrying container id ``cid``."""
+        obj = super().__new__(cls, name)
+        obj._cid = cid
+        return obj
+
+    @property
+    def name(self) -> str:
+        """The operator-facing container name (the ``str`` value)."""
+        return str(self)
+
+    @property
+    def id(self) -> str:
+        """The full 64-hex podman container id."""
+        return self._cid
+
+
 def _podman_rm(name: str) -> None:
     """Best-effort container removal with bounded timeout.
 
@@ -301,7 +331,7 @@ def nsenter_nft(pid: str, *args: str, stdin: str | None = None) -> subprocess.Co
 def shielded_container(
     _pull_image: None,
     shield_env: Path,
-) -> Iterator[str]:
+) -> Iterator[ShieldedContainer]:
     """Start a container with firewall applied via OCI hooks.
 
     Requires OCI hooks to be available — either global hooks installed
@@ -310,11 +340,13 @@ def shielded_container(
 
     1. ``Shield.pre_start()`` installs hooks, resolves DNS, returns podman args.
     2. ``podman run`` starts the container (OCI hooks apply the ruleset).
-    3. Yields the container name.
+    3. Yields a `ShieldedContainer` — the container name, with the real
+       podman id available via ``.id`` for the ``--container-id`` /
+       ``container_id`` argument that ``Shield.down`` / ``Shield.up`` require.
     4. Cleanup: ``podman rm -f``.
 
     Yields:
-        Container name with shield firewall applied.
+        `ShieldedContainer` name (with ``.id``) with shield firewall applied.
     """
     if not _hooks_available_cached:
         pytest.skip(
@@ -334,7 +366,7 @@ def shielded_container(
 
     try:
         extra_args = shield.pre_start(name)
-        start_shielded_container(name, extra_args, IMAGE)
-        yield name
+        cid = start_shielded_container(name, extra_args, IMAGE)
+        yield ShieldedContainer(name, cid)
     finally:
         _podman_rm(name)

--- a/tests/integration/dns/test_dnsmasq_lifecycle.py
+++ b/tests/integration/dns/test_dnsmasq_lifecycle.py
@@ -507,9 +507,7 @@ class TestRestartWithReusedStateDir:
             subprocess.run(["podman", "stop", "--time=5", name], capture_output=True, timeout=30)
             subprocess.run(["podman", "rm", name], capture_output=True, timeout=15)
 
-            assert _wait_pid_gone(first_pid), (
-                "dnsmasq should be gone after container stop"
-            )
+            assert _wait_pid_gone(first_pid), "dnsmasq should be gone after container stop"
 
             # Second run with the same state dir — pre_start is idempotent
             extra_args2 = shield.pre_start(name)

--- a/tests/integration/dns/test_dnsmasq_lifecycle.py
+++ b/tests/integration/dns/test_dnsmasq_lifecycle.py
@@ -14,6 +14,7 @@ real containers and verify actual DNS/nft behavior — no mocking.
 import shutil as _shutil
 import subprocess
 import tempfile
+import time
 from pathlib import Path
 from unittest import mock
 
@@ -23,7 +24,9 @@ from terok_shield import Shield, ShieldConfig
 from terok_shield.config import DnsTier, detect_dns_tier
 from terok_shield.dns.dnsmasq import generate_config, nftset_entry, read_domains
 from terok_shield.nft.constants import DNSMASQ_BIND_DEFAULT, PASTA_DNS
+from terok_shield.run import which_sbin_aware
 from tests.testnet import (
+    ALLOWED_TARGET_DOMAIN,
     ALLOWED_TARGET_HTTP,
     BLOCKED_TARGET_HTTP,
     GOOGLE_DNS_DOMAIN,
@@ -46,12 +49,27 @@ from ..helpers import (
 )
 
 dnsmasq_missing = pytest.mark.skipif(
-    _shutil.which("dnsmasq") is None,
+    not which_sbin_aware("dnsmasq"),
     reason="dnsmasq not installed",
 )
 
 
 # ── Helpers ──────────────────────────────────────────────
+
+
+def _wait_pid_gone(pid: str, timeout: float = 10.0) -> bool:
+    """Wait for a PID to leave /proc — poststop hooks run asynchronously.
+
+    ``podman stop`` returns when the container is down; the runtime delete
+    that fires the poststop hook happens in podman's background cleanup,
+    so an immediate assertion races it.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if not Path(f"/proc/{pid}").exists():
+            return True
+        time.sleep(0.2)
+    return not Path(f"/proc/{pid}").exists()
 
 
 def _extract_annotation(args: list[str], key: str) -> str | None:
@@ -288,8 +306,16 @@ class TestDnsmasqInContainer:
         assert "timeout" in r.stdout
 
     def test_allowed_domain_resolves_and_is_reachable(self, dnsmasq_container) -> None:
-        """Traffic to allowed domains works through dnsmasq resolution."""
-        name, _sd, _shield = dnsmasq_container
+        """An allow()ed domain becomes reachable once dnsmasq resolves it.
+
+        allow() registers the domain's nftset line and the in-container
+        lookup drives dnsmasq, whose reply populates the allow sets — the
+        dnsmasq tier's whole point.  A raw-IP fetch with nothing allowed
+        would bypass DNS and assert an unpopulated set.
+        """
+        name, _sd, shield = dnsmasq_container
+        shield.allow(name, ALLOWED_TARGET_DOMAIN)
+        exec_in_container(name, "nslookup", ALLOWED_TARGET_DOMAIN)
         assert_reachable(name, ALLOWED_TARGET_HTTP)
 
     def test_blocked_target_is_denied(self, dnsmasq_container) -> None:
@@ -310,7 +336,7 @@ class TestDnsmasqInContainer:
             ["podman", "stop", "--time=5", name], capture_output=True, check=True, timeout=30
         )
 
-        assert not Path(f"/proc/{pid_str}").exists(), (
+        assert _wait_pid_gone(pid_str), (
             f"dnsmasq PID {pid_str} still in /proc after container stop — "
             "poststop hook may not have run"
         )
@@ -481,7 +507,7 @@ class TestRestartWithReusedStateDir:
             subprocess.run(["podman", "stop", "--time=5", name], capture_output=True, timeout=30)
             subprocess.run(["podman", "rm", name], capture_output=True, timeout=15)
 
-            assert not Path(f"/proc/{first_pid}").exists(), (
+            assert _wait_pid_gone(first_pid), (
                 "dnsmasq should be gone after container stop"
             )
 

--- a/tests/integration/dns/test_profiles_pipeline.py
+++ b/tests/integration/dns/test_profiles_pipeline.py
@@ -29,7 +29,7 @@ class TestProfileResolvePipeline:
             runner = SubprocessRunner()
             resolver = DnsResolver(runner=runner)
             entries = loader.load_profile("base")
-            cache_path = state.profile_allowed_path(Path(tmp))
+            cache_path = state.StateBundle(Path(tmp)).profile_allowed
             ips = resolver.resolve_and_cache(entries, cache_path)
             assert len(ips) > 0, "Base profile should resolve to at least one IP"
             assert cache_path.is_file(), "Cache file should be written"
@@ -41,7 +41,7 @@ class TestProfileResolvePipeline:
             runner = SubprocessRunner()
             resolver = DnsResolver(runner=runner)
             entries = loader.load_profile("dev-standard")
-            cache_path = state.profile_allowed_path(Path(tmp))
+            cache_path = state.StateBundle(Path(tmp)).profile_allowed
             ips = resolver.resolve_and_cache(entries, cache_path)
             # github.com should resolve to at least one IP
             assert len(ips) > 0
@@ -59,7 +59,7 @@ class TestProfileResolvePipeline:
             entries = loader.load_profile("custom")
             assert entries == [CLOUDFLARE_DOMAIN, TEST_IP99]
 
-            cache_path = state.profile_allowed_path(Path(tmp))
+            cache_path = state.StateBundle(Path(tmp)).profile_allowed
             ips = resolver.resolve_and_cache(entries, cache_path)
             assert TEST_IP99 in ips  # raw IP passes through
             assert len(ips) >= 2  # resolved + raw

--- a/tests/integration/dns/test_resolve_live.py
+++ b/tests/integration/dns/test_resolve_live.py
@@ -12,11 +12,12 @@ from terok_shield.dns.resolver import DnsResolver
 from terok_shield.run import SubprocessRunner
 from tests.testnet import CLOUDFLARE_DOMAIN, GOOGLE_DNS_DOMAIN, NONEXISTENT_DOMAIN, TEST_IP1
 
-from ..conftest import dig_missing
+from ..conftest import dig_broken, dig_missing
 
 
 @pytest.mark.needs_internet
 @dig_missing
+@dig_broken
 class TestResolveLive:
     """DNS resolution against real nameservers."""
 
@@ -43,6 +44,7 @@ class TestResolveLive:
 
 @pytest.mark.needs_internet
 @dig_missing
+@dig_broken
 class TestResolveAndCacheLive:
     """Full resolve-and-cache pipeline with real DNS."""
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -91,7 +91,7 @@ def _hook_diagnostics(extra_args: list[str]) -> str:
 
 def start_shielded_container(
     name: str, extra_args: list[str], image: str, timeout: int = 30
-) -> None:
+) -> str:
     """Start a container with shield args, providing detailed errors on failure.
 
     Unlike plain ``subprocess.run(..., check=True, capture_output=True)`` which
@@ -103,6 +103,11 @@ def start_shielded_container(
         extra_args: Extra arguments from ``Shield.pre_start()``.
         image: Container image to run.
         timeout: Podman timeout in seconds.
+
+    Returns:
+        The full 64-hex podman container id (``--container-id`` routing key
+        required by ``Shield.down`` / ``Shield.up``), read from ``podman
+        run -d`` stdout.
 
     Raises:
         RuntimeError: If podman run exits non-zero, with stderr/stdout details.
@@ -121,6 +126,7 @@ def start_shielded_container(
             f"  stdout: {result.stdout.strip()}\n"
             f"  extra_args: {extra_args}{diag}"
         )
+    return result.stdout.strip()
 
 
 def assert_connectable(container: str, ip: str, port: int = 53, timeout: int = 5) -> None:

--- a/tests/integration/launch/test_hook_entrypoint.py
+++ b/tests/integration/launch/test_hook_entrypoint.py
@@ -71,7 +71,7 @@ class TestHookEntrypointStory:
         assert_blocked(name, BLOCKED_TARGET_HTTP)
 
         # 4. shield_up re-applies the ruleset cleanly
-        shield.up(name, name)
+        shield.up(name, name.id)
         assert "terok_shield" in shield.rules(name)
         assert_blocked(name, BLOCKED_TARGET_HTTP)
 

--- a/tests/integration/observability/test_rules.py
+++ b/tests/integration/observability/test_rules.py
@@ -60,7 +60,7 @@ class TestRulesCLI:
         self, shielded_container: str, capsys: pytest.CaptureFixture
     ) -> None:
         """``main(["rules", container])`` shows State: down after bypass."""
-        _shield().down(shielded_container, shielded_container)
+        _shield().down(shielded_container, shielded_container.id)
         main(["rules", shielded_container])
         captured = capsys.readouterr()
         assert "State: down" in captured.out
@@ -81,7 +81,7 @@ class TestRulesBypassAPI:
     def test_rules_contain_bypass_prefix(self, shielded_container: str) -> None:
         """Bypass ruleset contains the TEROK_SHIELD_BYPASS log prefix."""
         shield = _shield()
-        shield.down(shielded_container, shielded_container)
+        shield.down(shielded_container, shielded_container.id)
         rules = shield.rules(shielded_container)
         assert BYPASS_LOG_PREFIX in rules
         assert "policy accept" in rules
@@ -89,10 +89,10 @@ class TestRulesBypassAPI:
     def test_rules_restored_after_up(self, shielded_container: str) -> None:
         """Rules revert to deny-all after shield.up()."""
         shield = _shield()
-        shield.down(shielded_container, shielded_container)
+        shield.down(shielded_container, shielded_container.id)
         assert "policy accept" in shield.rules(shielded_container)
 
-        shield.up(shielded_container, shielded_container)
+        shield.up(shielded_container, shielded_container.id)
         rules = shield.rules(shielded_container)
         assert "policy drop" in rules
         assert BYPASS_LOG_PREFIX not in rules

--- a/tests/unit/test_dns_resolver.py
+++ b/tests/unit/test_dns_resolver.py
@@ -114,9 +114,10 @@ def test_logs_warning_for_unresolvable(
     make_resolver: ResolverHarnessFactory,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """resolve_domains() logs a warning when a domain resolves to no IPs."""
+    """resolve_domains() warns when a domain yields no IPs from any tier."""
     harness = make_resolver()
     harness.runner.dig_all.side_effect = [[TEST_IP1], []]
+    harness.runner.getent_hosts.return_value = []
 
     with caplog.at_level("WARNING", logger="terok_shield.dns.resolver"):
         harness.resolver.resolve_domains([CLOUDFLARE_DOMAIN, NONEXISTENT_DOMAIN])
@@ -214,6 +215,31 @@ def test_resolve_domains_getent_fallback_deduplicates(
 
     result = harness.resolver.resolve_domains([CLOUDFLARE_DOMAIN, GOOGLE_DNS_DOMAIN])
     assert result == [TEST_IP1]
+
+
+def test_resolve_domains_empty_dig_retries_via_getent(
+    make_resolver: ResolverHarnessFactory,
+) -> None:
+    """A dig that runs but yields nothing retries the domain via getent."""
+    harness = make_resolver()
+    harness.runner.dig_all.return_value = []
+    harness.runner.getent_hosts.return_value = [TEST_IP1]
+
+    result = harness.resolver.resolve_domains([CLOUDFLARE_DOMAIN])
+    assert result == [TEST_IP1]
+
+
+def test_resolve_domains_empty_dig_fallback_is_per_domain(
+    make_resolver: ResolverHarnessFactory,
+) -> None:
+    """One empty dig answer does not demote later domains to getent."""
+    harness = make_resolver()
+    harness.runner.dig_all.side_effect = [[], [TEST_IP2]]
+    harness.runner.getent_hosts.return_value = [TEST_IP1]
+
+    result = harness.resolver.resolve_domains([CLOUDFLARE_DOMAIN, GOOGLE_DNS_DOMAIN])
+    assert result == [TEST_IP1, TEST_IP2]
+    harness.runner.getent_hosts.assert_called_once()
 
 
 from terok_shield.state import StateBundle

--- a/tests/unit/test_hook_mode_class.py
+++ b/tests/unit/test_hook_mode_class.py
@@ -1109,7 +1109,7 @@ class TestPreStartDnsTierBranches:
         _set_euid(monkeypatch, 0)
         harness = make_hook_mode()
         harness.runner.run.side_effect = lambda cmd, **_kw: (
-            _DNSMASQ_VERSION_NFTSET if cmd[0] == "dnsmasq" else _MODERN_PODMAN_INFO
+            _DNSMASQ_VERSION_NFTSET if Path(cmd[0]).name == "dnsmasq" else _MODERN_PODMAN_INFO
         )
         harness.runner.has.return_value = True  # dnsmasq available (nftset probed via run)
         harness.profiles.compose_profiles.return_value = [TEST_DOMAIN, TEST_IP1]
@@ -1158,7 +1158,7 @@ class TestPreStartDnsTierBranches:
         _set_euid(monkeypatch, 0)
         harness = make_hook_mode(config=make_config(runtime=ShieldRuntime.KRUN))
         harness.runner.run.side_effect = lambda cmd, **_kw: (
-            _DNSMASQ_VERSION_NFTSET if cmd[0] == "dnsmasq" else _MODERN_PODMAN_INFO
+            _DNSMASQ_VERSION_NFTSET if Path(cmd[0]).name == "dnsmasq" else _MODERN_PODMAN_INFO
         )
         harness.runner.has.return_value = True
         harness.profiles.compose_profiles.return_value = [TEST_DOMAIN]

--- a/tests/unit/test_nft_hook.py
+++ b/tests/unit/test_nft_hook.py
@@ -538,6 +538,26 @@ def test_poststop_escalates_to_sigkill(tmp_path: Path) -> None:
     assert any("SIGKILL" in str(c) for c in mock_log.call_args_list)
 
 
+def test_poststop_reports_failed_sigkill(tmp_path: Path) -> None:
+    """A SIGKILL that itself fails is reported, not swallowed."""
+    sd = tmp_path / "sd"
+    sd.mkdir()
+    (sd / "dnsmasq.pid").write_text("12345\n")
+
+    with (
+        mock.patch("terok_shield.resources.nft_hook._is_our_dnsmasq", return_value=True),
+        mock.patch("terok_shield.resources.nft_hook.time.sleep"),
+        mock.patch(
+            "terok_shield.resources._oci_state.os.kill",
+            side_effect=[None, OSError("EPERM")],
+        ),
+        mock.patch("terok_shield.resources._oci_state.log") as mock_log,
+    ):
+        nft_hook._poststop(sd)
+
+    assert any("SIGKILL" in str(c) and "failed" in str(c) for c in mock_log.call_args_list)
+
+
 def test_poststop_skips_stale_pid(tmp_path: Path) -> None:
     """_poststop() skips signalling and removes the stale PID file on identity mismatch."""
     sd = tmp_path / "sd"

--- a/tests/unit/test_nft_hook.py
+++ b/tests/unit/test_nft_hook.py
@@ -509,12 +509,33 @@ def test_poststop_sends_sigterm_to_dnsmasq(tmp_path: Path) -> None:
     (sd / "dnsmasq.pid").write_text("12345\n")
 
     with (
-        mock.patch("terok_shield.resources.nft_hook._is_our_dnsmasq", return_value=True),
+        mock.patch(
+            "terok_shield.resources.nft_hook._is_our_dnsmasq",
+            side_effect=[True, False],  # identity check passes; first poll sees it gone
+        ),
         mock.patch("terok_shield.resources._oci_state.os.kill") as mock_kill,
     ):
         nft_hook._poststop(sd)
 
     mock_kill.assert_called_once_with(12345, 15)
+
+
+def test_poststop_escalates_to_sigkill(tmp_path: Path) -> None:
+    """_poststop() SIGKILLs (and reports) a dnsmasq that survives SIGTERM."""
+    sd = tmp_path / "sd"
+    sd.mkdir()
+    (sd / "dnsmasq.pid").write_text("12345\n")
+
+    with (
+        mock.patch("terok_shield.resources.nft_hook._is_our_dnsmasq", return_value=True),
+        mock.patch("terok_shield.resources.nft_hook.time.sleep"),
+        mock.patch("terok_shield.resources._oci_state.os.kill") as mock_kill,
+        mock.patch("terok_shield.resources._oci_state.log") as mock_log,
+    ):
+        nft_hook._poststop(sd)
+
+    assert mock_kill.call_args_list == [mock.call(12345, 15), mock.call(12345, 9)]
+    assert any("SIGKILL" in str(c) for c in mock_log.call_args_list)
 
 
 def test_poststop_skips_stale_pid(tmp_path: Path) -> None:

--- a/tests/unit/test_prereqs.py
+++ b/tests/unit/test_prereqs.py
@@ -76,7 +76,7 @@ def test_which_sbin_aware_skips_non_executable_files(
     with a mode-0o644 ``/usr/sbin/nft`` (rpm gone wrong, chmod
     accident) must probe as missing, not as present-but-broken.
     """
-    monkeypatch.setattr("terok_shield.prereqs._SBIN_DIRS", (str(tmp_path),))
+    monkeypatch.setattr("terok_shield.run._SBIN_DIRS", (str(tmp_path),))
     # Isolated empty PATH so the real ``shutil.which`` can't find ``nft``
     # on the host — otherwise the assertion depends on /usr/bin being
     # clean, which CI runners often aren't.

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -6,7 +6,6 @@
 import shutil
 import subprocess
 from collections.abc import Iterator
-from pathlib import Path
 from unittest import mock
 
 import pytest
@@ -363,8 +362,7 @@ def test_find_nft_falls_back_to_sbin(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_find_nft_returns_empty_when_missing(monkeypatch: pytest.MonkeyPatch) -> None:
     """find_nft() returns empty string when nft is not found anywhere."""
     monkeypatch.setattr(shutil, "which", lambda _name, path=None: None)
-    with mock.patch("terok_shield.run.Path.is_file", return_value=False):
-        assert find_nft() == ""
+    assert find_nft() == ""
 
 
 def test_subprocess_runner_raises_when_nft_missing() -> None:

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -172,7 +172,7 @@ def test_has_uses_shutil_which(
 ) -> None:
     """has() reflects whether the executable can be found."""
     runner._has_cache.clear()
-    monkeypatch.setattr(shutil, "which", lambda _name: which_result)
+    monkeypatch.setattr(shutil, "which", lambda _name, path=None: which_result)
     assert runner.has("nft") is expected
 
 
@@ -324,7 +324,7 @@ def test_dig_all_raises_when_binary_missing(
 ) -> None:
     """dig_all() raises DigNotFoundError when dig is not on PATH."""
     runner._has_cache.clear()
-    monkeypatch.setattr(shutil, "which", lambda name: None)
+    monkeypatch.setattr(shutil, "which", lambda name, path=None: None)
     with pytest.raises(DigNotFoundError, match="dig binary not found"):
         runner.dig_all(TEST_DOMAIN)
 
@@ -346,24 +346,23 @@ def test_dig_all_uses_single_query(
 
 def test_find_nft_returns_path_from_which(monkeypatch: pytest.MonkeyPatch) -> None:
     """find_nft() returns the PATH result when shutil.which succeeds."""
-    monkeypatch.setattr(shutil, "which", lambda _name: NFT_BINARY)
+    monkeypatch.setattr(shutil, "which", lambda _name, path=None: NFT_BINARY)
     assert find_nft() == NFT_BINARY
 
 
 def test_find_nft_falls_back_to_sbin(monkeypatch: pytest.MonkeyPatch) -> None:
     """find_nft() checks /usr/sbin/nft when PATH lookup fails."""
-    monkeypatch.setattr(shutil, "which", lambda _name: None)
-
-    def _is_file(self: Path) -> bool:
-        return str(self) == NFT_SBIN
-
-    with mock.patch.object(Path, "is_file", _is_file):
-        assert find_nft() == NFT_SBIN
+    monkeypatch.setattr(
+        shutil,
+        "which",
+        lambda _name, path=None: NFT_SBIN if path and "/usr/sbin" in path else None,
+    )
+    assert find_nft() == NFT_SBIN
 
 
 def test_find_nft_returns_empty_when_missing(monkeypatch: pytest.MonkeyPatch) -> None:
     """find_nft() returns empty string when nft is not found anywhere."""
-    monkeypatch.setattr(shutil, "which", lambda _name: None)
+    monkeypatch.setattr(shutil, "which", lambda _name, path=None: None)
     with mock.patch("terok_shield.run.Path.is_file", return_value=False):
         assert find_nft() == ""
 

--- a/tests/unit/test_shield_facade.py
+++ b/tests/unit/test_shield_facade.py
@@ -446,7 +446,7 @@ def _run_side_effect(podman_version: str = "5.8.0"):
     """
 
     def _effect(cmd: list[str], **_kw: object) -> str:
-        if cmd[0] == "dnsmasq":
+        if Path(cmd[0]).name == "dnsmasq":
             return "Dnsmasq version 2.92\nCompile time options: nftset\n"
         return _podman_info_json(podman_version)
 


### PR DESCRIPTION
Part of the multi-repo **non-systemd matrix** work (refs terok-ai/terok#959, #1113).

Adds distro slots to `tests/containers/run-matrix.sh`: **Alpine** (musl/OpenRC, non-systemd; x86_64-only — skipped on aarch64 where tree-sitter has no musl wheels), **Void** (glibc/runit, non-systemd), and **Mageia** (glibc/systemd/rpm). Generalizes the non-systemd preflight assertion and makes per-slot image-build failures non-fatal. Also carries the dep-pinning-policy change.

Fixes: bypass integration tests pass the real 64-hex container id (not the name); `profile_allowed_path` -> `StateBundle.profile_allowed`; unpin broken virtualenv 21.4.2; drop stale `setup --user`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the test matrix to cover additional Linux distributions, including Alpine, Void, and Mageia.
  * Added support for non-systemd test environments.

* **Bug Fixes**
  * Improved executable detection so tools are found more reliably on systems where they live in admin paths.
  * DNS resolution now retries with an alternate lookup method when the primary lookup returns no results.
  * Container cleanup is more reliable, reducing stale processes and leftover test artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->