### PR TITLE
fix(ci): stop PR docs builds from evicting queued master deploys

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,9 +35,14 @@ on:
         type: boolean
         default: false
 
+# Concurrency is per ref: GitHub keeps only the newest *pending* run
+# per group, so a shared group let PR builds silently evict queued
+# master deploys. Superseded PR builds are cancelled outright; pushes
+# never are. Actual Pages deployments are serialized by the job-level
+# group inside publish-versioned-docs.yml.
 concurrency:
-  group: "pages"
-  cancel-in-progress: false
+  group: docs-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read


### PR DESCRIPTION
## Problem

`docs.yml` shares one workflow-level concurrency group (`"pages"`) across every ref. GitHub keeps only the newest **pending** run per group, so a docs run on any other ref while a master deploy is queued silently cancels that deploy. This bit terok after terok-ai/terok#1123 merged: a PR build evicted three queued master deploys and the site never picked up the fix until a manual `workflow_dispatch`.

## Fix

- `group: docs-${{ github.ref }}` — builds on different refs queue independently; two quick master pushes still coalesce to the newest (desired: each deploy publishes the full tree).
- `cancel-in-progress: ${{ github.event_name == 'pull_request' }}` — superseded PR builds are cancelled outright (feedback-only); master/tag runs never are.

Deploy serialization does not regress: the actual Pages deployment is already guarded by the job-level `versioned-docs-${{ github.repository }}` group inside `publish-versioned-docs.yml` (workflow-level concurrency is ignored under `workflow_call` anyway).

Same fix as terok-ai/terok#1126; fanned out family-wide since every repo copied the identical stanza.

🤖 Generated with [Claude Code](https://claude.com/claude-code)