### PR TITLE
chore(dev): add make test-fast and steer agents to it during development

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,10 +21,22 @@
 
 ## Build, Lint, and Test Commands
 
+**During development — ALWAYS use the fast loop:**
+```bash
+make test-fast # Only the tests affected by your branch diff (tach impact analysis)
+```
+Rerunning the full suite after every edit is the single biggest time sink in
+agent dev loops — don't do it. Iterate with `make test-fast`; run the full
+`make test` exactly once, right before committing. One exception: impact
+analysis follows the Python import graph only, so after changing non-Python
+inputs (resource YAML, templates, shell scripts) `make test-fast` skips tests
+that are actually affected — run the full `make test` for those changes.
+
 **Before committing:**
 ```bash
 make lint      # Run linter (required before every commit)
 make format    # Auto-fix lint issues if lint fails
+make test      # Full unit suite — once, after iterating with test-fast
 ```
 
 **Before pushing:**

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all lint format test test-unit ruff-report bandit-report sonar-inputs test-integration-host test-integration-network test-integration-podman test-integration test-integration-map test-matrix ci-map tach security docstrings complexity deadcode reuse typecheck check install install-dev docs docs-build clean spdx
+.PHONY: all lint format test test-unit test-fast ruff-report bandit-report sonar-inputs test-integration-host test-integration-network test-integration-podman test-integration test-integration-map test-matrix ci-map tach security docstrings complexity deadcode reuse typecheck check install install-dev docs docs-build clean spdx
 
 REPORTS_DIR ?= reports
 COVERAGE_XML ?= $(REPORTS_DIR)/coverage.xml
@@ -27,6 +27,13 @@ lint:
 format:
 	poetry run ruff check --fix .
 	poetry run ruff format .
+
+# Fast dev loop: run only the tests affected by the branch diff (tach
+# impact analysis), no coverage.  Impact analysis follows the Python
+# import graph only — after touching non-Python inputs (resources/,
+# YAML, templates, scripts) run the full `make test` instead.
+test-fast:
+	poetry run pytest tests/unit/ --tach
 
 # Run tests with coverage (excludes podman-dependent integration tests)
 test-unit:


### PR DESCRIPTION
Adds a `make test-fast` target that runs only the tests affected by the branch diff (tach impact analysis, `pytest --tach`, no coverage/junit reports), and updates AGENTS.md to explicitly instruct agents to iterate with it — reserving the full `make test` for the single pre-commit run.

Rationale: agents rerunning the full coverage suite after every edit is the biggest recurring inefficiency in our dev loops. On a branch with no Python changes, `test-fast` deselects all 1236 tests in ~1.1s.

Caveat documented in both the Makefile comment and AGENTS.md: tach impact analysis follows the Python import graph only, so changes to non-Python inputs must still run the full suite. CI keeps running everything unmasked.

Part of the test-fast rollout: terok#1139, executor#439, sandbox#429.

🤖 Generated with [Claude Code](https://claude.com/claude-code)