### PR TITLE
test(integration): shorten negative-probe timeouts to the proof minimum

### DIFF
--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -151,10 +151,17 @@ def assert_connectable(container: str, ip: str, port: int = 53, timeout: int = 5
     )
 
 
-def assert_not_connectable(container: str, ip: str, port: int = 53, timeout: int = 5) -> None:
+def assert_not_connectable(container: str, ip: str, port: int = 53, timeout: int = 1) -> None:
     """Assert that a TCP connection to ip:port is blocked from inside a container.
 
     Inverse of `assert_connectable`.  Uses ``nc -z`` and expects failure.
+
+    Shield's policy is *drop*, so a blocked probe gets no response and
+    ``nc`` waits out the full window — the timeout is a guaranteed burn
+    on every call, not a margin.  1s still carries the proof in the
+    controlled test environment: permitted paths there answer in
+    milliseconds, so a probe silent for a full second is blocked, not
+    slow.
 
     Args:
         container: Container name or ID.
@@ -228,11 +235,16 @@ def _assert_container_running(container: str) -> None:
     )
 
 
-def assert_blocked(container: str, url: str, timeout: int = 10) -> None:
+def assert_blocked(container: str, url: str, timeout: int = 2) -> None:
     """Assert that a URL is blocked (wget fails) from inside a container.
 
     Verifies the container is running first to avoid false positives from
     a dead container or failed ``podman exec``.
+
+    Like `assert_not_connectable`, the timeout is a guaranteed burn: a
+    dropped connection never answers, so wget always waits the full
+    window.  2s (not 1s) because the URL path also covers an in-container
+    DNS resolution before the blocked connect.
 
     Args:
         container: Container name or ID.


### PR DESCRIPTION
Follow-up from the matrix runtime analysis on #377 (independent of the uv pilot — based on master).

Negative connectivity checks are guaranteed timeout burns by construction: shield's policy is *drop*, so a blocked probe gets no RST and `nc`/`wget` always wait out their full window. The window is therefore pure cost, not margin — and in the controlled matrix environment, where permitted paths answer in milliseconds, 1s of silence carries the same proof as 5s.

- `assert_not_connectable`: 5s → **1s**
- `assert_blocked` (wget): 10s → **2s** (the URL path includes an in-container DNS resolution before the blocked connect)
- positive probes (`assert_connectable`, `assert_reachable`) keep their windows — they return immediately on success and only wait on genuine failure.

No call site overrides the defaults, so the two signature changes cover all 23 negative-probe sites. Back-of-envelope saving: ~1.5–2.5 min per matrix slot; the `--durations=25` reporting added on the pilot branch will give exact per-test numbers to verify against.

Trade-off stated plainly: on a heavily loaded DGX a *permitted* path slower than 1s would false-pass a negative probe. If that ever flakes, the fix is bumping the specific call site, not the default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)