### PR TITLE
test(integration): stop burning podman's 10s stop timeout per container

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -33,7 +33,7 @@ from terok_shield.podman_info import has_global_hooks, parse_podman_info
 from terok_shield.run import find_nft, which_sbin_aware
 from tests.testnet import ALLOWED_TARGET_IPS
 
-from .helpers import start_shielded_container
+from .helpers import keepalive, start_shielded_container
 
 IMAGE = "docker.io/library/alpine:latest"
 CTR_PREFIX = "shield-itest"
@@ -78,7 +78,7 @@ def _podman_rm(name: str) -> None:
     """
     try:
         subprocess.run(
-            ["podman", "rm", "-f", name], capture_output=True, timeout=_PODMAN_RM_TIMEOUT
+            ["podman", "rm", "-f", "-t", "0", name], capture_output=True, timeout=_PODMAN_RM_TIMEOUT
         )
     except subprocess.TimeoutExpired:
         warnings.warn(
@@ -291,7 +291,7 @@ def nft_in_netns(_pull_image: None, _verify_connectivity: None) -> None:
     _podman_rm(name)
     try:
         subprocess.run(
-            ["podman", "run", "-d", "--name", name, IMAGE, "sleep", "30"],
+            ["podman", "run", "-d", "--name", name, IMAGE, *keepalive(30)],
             check=True,
             capture_output=True,
             timeout=30,
@@ -325,7 +325,7 @@ def container(_pull_image: None) -> Iterator[str]:
     _podman_rm(name)
     try:
         subprocess.run(
-            ["podman", "run", "-d", "--name", name, IMAGE, "sleep", "120"],
+            ["podman", "run", "-d", "--name", name, IMAGE, *keepalive(120)],
             check=True,
             capture_output=True,
             timeout=30,
@@ -355,7 +355,7 @@ def probe_container(_pull_image: None) -> Iterator[str]:
     _podman_rm(name)
     try:
         subprocess.run(
-            ["podman", "run", "-d", "--name", name, IMAGE, "sleep", "120"],
+            ["podman", "run", "-d", "--name", name, IMAGE, *keepalive(120)],
             check=True,
             capture_output=True,
             timeout=30,

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -89,6 +89,21 @@ def _hook_diagnostics(extra_args: list[str]) -> str:
     return f"{diag}\n  [diag] no hook JSON found in any hooks directory"
 
 
+def keepalive(seconds: int) -> list[str]:
+    """A TERM-responsive keep-the-container-alive command.
+
+    Bare ``sleep`` as PID 1 installs no SIGTERM handler and PID 1 ignores
+    unhandled signals, so every ``podman stop``/``restart``/``rm -f`` of
+    such a container burns the full stop timeout (10s by default) before
+    the SIGKILL.  Trapping TERM makes teardown and the restart-path tests
+    complete in milliseconds — and is the more realistic workload shape.
+
+    Args:
+        seconds: Upper bound on the container's lifetime.
+    """
+    return ["sh", "-c", f"trap 'exit 0' TERM; sleep {seconds} & wait"]
+
+
 def start_shielded_container(
     name: str, extra_args: list[str], image: str, timeout: int = 30
 ) -> str:
@@ -113,7 +128,7 @@ def start_shielded_container(
         RuntimeError: If podman run exits non-zero, with stderr/stdout details.
     """
     result = subprocess.run(
-        ["podman", "run", "-d", "--name", name, *extra_args, image, "sleep", "120"],
+        ["podman", "run", "-d", "--name", name, *extra_args, image, *keepalive(120)],
         capture_output=True,
         text=True,
         timeout=timeout,


### PR DESCRIPTION
The `--durations=25` data from the latest matrix run (added for exactly this purpose) found the integration suite's dominant cost, and it isn't the tests at all: **~12.1s of teardown on nearly every container-backed test** — 114 occurrences in one matrix log.

Root cause: the test containers run bare `sleep` as PID 1. PID 1 ignores unhandled signals and `sleep` installs no SIGTERM handler, so every `podman rm -f` waits out podman's full default 10s stop timeout before the SIGKILL. The in-call heavies (`test_shield_lifecycle_with_restart` 18s, `test_dnsmasq_restarts_cleanly_on_reuse` 20s) pay the same tax through their `podman stop`/`restart` calls.

Two changes:
- `_podman_rm` passes `-t 0` — teardown is pure disposal, no reason to offer grace.
- A shared `keepalive()` helper replaces bare `sleep` at all four launch sites: `sh -c "trap 'exit 0' TERM; sleep N & wait"`. Graceful-stop paths (`stop --time=5`, `restart`) now complete in milliseconds, and a TERM-responsive PID 1 is the more realistic workload shape besides. (Verified locally: TERM → exit 0 in 1ms.)

Expected impact per the durations data: the ~1200s integration phase should drop by roughly 10s × (number of container-backed tests) — order of **10+ minutes per slot**, turning the ~20-minute slots into ~5–8 minutes. The next matrix run's `--durations` output will verify.

The explicit `podman stop --time=N` call sites in the dnsmasq/restart tests keep their timeouts — with a TERM-responsive PID 1 they no longer burn them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved integration test container startup and shutdown behavior.
  * Containers now terminate more reliably and respond faster during cleanup and restart operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->