### PR TITLE
ci: consume the fleet's reusable workflows by tag (extraction pilot)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 # Pin third-party actions to full commit SHAs for supply-chain security.
 # GitHub-owned actions (actions/*) may use version tags.
+#
+# The static-check battery lives in terok-util's fleet-checks.yml
+# (reusable across the package family); only the repo-specific
+# host-integration job stays local.
 name: CI
 
 on:
@@ -12,149 +16,9 @@ permissions:
   contents: read
 
 jobs:
-  reuse:
-    if: github.repository == 'terok-ai/terok-shield'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - name: REUSE compliance check
-        uses: fsfe/reuse-action@676e2d560c9a403aa252096d99fcab3e1132b0f5 # v6
+  checks:
+    uses: terok-ai/terok-util/.github/workflows/fleet-checks.yml@v0.3.0a2
 
-  lint:
-    if: github.repository == 'terok-ai/terok-shield'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Ruff lint
-        uses: astral-sh/ruff-action@278981a28ce3188b1e39527901f38254bf3aac89 # v4.1.0
-        with:
-          args: check
-
-      - name: Ruff format check
-        uses: astral-sh/ruff-action@278981a28ce3188b1e39527901f38254bf3aac89 # v4.1.0
-        with:
-          args: format --check
-
-      - name: ASCII-only pyproject
-        run: |
-          ! LC_ALL=C grep -nP '[^\x00-\x7F]' pyproject.toml
-
-  docstring-coverage:
-    if: github.repository == 'terok-ai/terok-shield'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
-        with:
-          enable-cache: true
-
-      - name: Install tools
-        run: uv sync --locked --only-group dev
-
-      - name: Check docstring coverage
-        run: uv run --no-sync docstr-coverage src/terok_shield/ --fail-under=95
-
-  dead-code:
-    if: github.repository == 'terok-ai/terok-shield'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
-        with:
-          enable-cache: true
-
-      - name: Install tools
-        run: uv sync --locked --only-group dev
-
-      - name: Check for dead code
-        run: uv run --no-sync vulture src/terok_shield/ --min-confidence 80
-
-  tach:
-    if: github.repository == 'terok-ai/terok-shield'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
-        with:
-          enable-cache: true
-
-      - name: Install tools
-        run: uv sync --locked --only-group dev
-
-      - name: Check module boundaries
-        run: uv run --no-sync tach check
-
-  security:
-    if: github.repository == 'terok-ai/terok-shield'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
-        with:
-          enable-cache: true
-
-      - name: Install tools
-        run: uv sync --locked --only-group dev
-
-      - name: Run SAST scan
-        run: uv run --no-sync bandit -r src/terok_shield/ -ll
-
-  # Static type checking via mypy.  Installs the package + main deps so
-  # mypy can read real signatures for third-party types instead of
-  # falling back to ``Any`` (via ``ignore_missing_imports = true``).
-  typecheck:
-    if: github.repository == 'terok-ai/terok-shield'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
-        with:
-          enable-cache: true
-
-      - name: Install project + tools
-        run: uv sync --locked
-
-      - name: Run mypy
-        run: uv run --no-sync mypy src/terok_shield/
-
-  # Keep host-only integration tests in CI, but outside the Sonar-producing workflow.
-  # That keeps the Sonar path fast while still exercising Linux host features on PRs.
   integration-tests-host:
     name: Integration tests (host)
     if: github.repository == 'terok-ai/terok-shield'
@@ -186,19 +50,3 @@ jobs:
           files: ./reports/integration-host.junit.xml
           token: ${{ secrets.CODECOV_TOKEN }}
 
-  readme-check:
-    if: github.repository == 'terok-ai/terok-shield'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-      - name: Install uv
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
-        with:
-          enable-cache: true
-
-      - name: Verify README renders for PyPI
-        run: uv run --no-project --with 'readme-renderer[md]' python -m readme_renderer README.md --format md

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -49,117 +49,17 @@ permissions:
   actions: read
 
 jobs:
+  # The build lives in mkdocs-terok's docs-build.yml (reusable across
+  # the package family): uv sync, scc, the coverage-artifact handoff,
+  # strict properdocs build, docs-site upload.
   build:
     if: github.repository == 'terok-ai/terok-shield'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Set up Python
-        id: setup-python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
-        with:
-          enable-cache: true
-
-      - name: Install dependencies
-        run: uv sync --locked --all-groups
-
-      - name: Install scc (lines of code counter)
-        run: |
-          cd "$(mktemp -d)"
-          curl -sLO https://github.com/boyter/scc/releases/download/v3.5.0/scc_Linux_x86_64.tar.gz
-          echo "6c31f4d0cf3b7a8c5ca910fa4e451949434798f6541ec5dea4b83f4973e13772  scc_Linux_x86_64.tar.gz" | sha256sum -c
-          sudo tar xzf scc_Linux_x86_64.tar.gz -C /usr/local/bin scc
-
-      # On master we strictly require the Tests & Analysis run for *this* commit
-      # to have finished successfully — published docs must agree with published
-      # code. Tests & Analysis only contains the fast in-repo jobs (unit-tests,
-      # ruff, bandit); the third-party SonarQube scan lives in sonar.yml, so
-      # waiting on workflow completion here no longer drags in Sonar wait time.
-      # Polling rather than `workflow_run` keeps this build visible as its own
-      # PR check.
-      - name: Wait for Tests & Analysis on this commit (master)
-        if: github.ref == 'refs/heads/master'
-        uses: actions/github-script@v9
-        with:
-          script: |
-            const deadline = Date.now() + 20 * 60 * 1000;
-            const sleep = ms => new Promise(r => setTimeout(r, ms));
-            while (Date.now() < deadline) {
-              const { data } = await github.rest.actions.listWorkflowRuns({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                workflow_id: 'analysis.yml',
-                head_sha: context.sha,
-                per_page: 5,
-              });
-              const run = data.workflow_runs[0];
-              if (run?.status === 'completed') {
-                if (run.conclusion === 'success') {
-                  core.info(`Tests & Analysis succeeded for ${context.sha}`);
-                  return;
-                }
-                core.setFailed(
-                  `Tests & Analysis ${run.conclusion} for ${context.sha} — refusing to publish docs with a mismatched treemap`
-                );
-                return;
-              }
-              core.info(`Tests & Analysis for ${context.sha}: ${run?.status ?? 'not yet started'} — waiting`);
-              await sleep(20_000);
-            }
-            core.setFailed('Timed out after 20m waiting for Tests & Analysis')
-
-      - name: Coverage artifact (master — same SHA, required)
-        if: github.ref == 'refs/heads/master'
-        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
-        with:
-          workflow: analysis.yml
-          workflow_conclusion: success
-          commit: ${{ github.sha }}
-          name: coverage
-          path: reports
-          if_no_artifact_found: fail
-
-      # First push of a PR: Tests & Analysis and this workflow start together,
-      # so this step usually misses and we fall through to latest-master below.
-      # Re-running this workflow after Tests & Analysis goes green picks up the
-      # same-SHA artifact here instead.
-      - name: Coverage artifact (non-master — same SHA, best effort)
-        if: github.ref != 'refs/heads/master'
-        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
-        with:
-          workflow: analysis.yml
-          workflow_conclusion: completed
-          commit: ${{ github.event.pull_request.head.sha || github.sha }}
-          name: coverage
-          path: reports
-          if_no_artifact_found: warn
-
-      - name: Coverage artifact (non-master — fall back to latest master)
-        if: github.ref != 'refs/heads/master' && !hashFiles('reports/coverage.json')
-        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
-        with:
-          workflow: analysis.yml
-          workflow_conclusion: success
-          branch: master
-          name: coverage
-          path: reports
-          if_no_artifact_found: fail
-
-      - name: Build documentation
-        run: uv run properdocs build --strict
-
-      - name: Upload site for versioned publish
-        if: github.ref == 'refs/heads/master' || inputs.release
-        uses: actions/upload-artifact@v7
-        with:
-          name: docs-site
-          path: site/
+    permissions:
+      contents: read
+      actions: read
+    uses: terok-ai/mkdocs-terok/.github/workflows/docs-build.yml@v0.8.0a2
+    with:
+      release: ${{ inputs.release == true }}
 
   publish:
     if: github.repository == 'terok-ai/terok-shield' && (github.ref == 'refs/heads/master' || inputs.release)
@@ -168,6 +68,6 @@ jobs:
       contents: write
       pages: write
       id-token: write
-    uses: terok-ai/mkdocs-terok/.github/workflows/publish-versioned-docs.yml@v0.8.0a1
+    uses: terok-ai/mkdocs-terok/.github/workflows/publish-versioned-docs.yml@v0.8.0a2
     with:
       release: ${{ inputs.release == true }}

--- a/.github/workflows/inventory.yml
+++ b/.github/workflows/inventory.yml
@@ -24,6 +24,6 @@ permissions:
 jobs:
   publish:
     if: github.repository == 'terok-ai/terok-shield' && github.ref == 'refs/heads/master'
-    uses: terok-ai/mkdocs-terok/.github/workflows/publish-inventory.yml@v0.8.0a1
+    uses: terok-ai/mkdocs-terok/.github/workflows/publish-inventory.yml@v0.8.0a2
     secrets:
       INVENTORY_WRITE_TOKEN: ${{ secrets.INVENTORY_WRITE_TOKEN }}

--- a/.github/workflows/no-git-deps.yml
+++ b/.github/workflows/no-git-deps.yml
@@ -9,50 +9,8 @@ permissions:
   contents: read
 
 jobs:
+  # The scanner lives in terok-util's no-git-deps.yml (reusable across
+  # the package family); this caller keeps the local triggers and the
+  # release.yml gate wiring.
   scan:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v7
-      - name: Scan pyproject.toml for git sources
-        run: |
-          python3 <<'PY'
-          import sys, tomllib, pathlib
-
-          data = tomllib.loads(pathlib.Path("pyproject.toml").read_text())
-          offenders = []
-
-          def scan(label, deps):
-              for name, spec in deps.items():
-                  if not isinstance(spec, dict):
-                      continue
-                  if "git" in spec:
-                      ref = spec.get("branch") or spec.get("rev") or spec.get("tag") or "?"
-                      offenders.append(f"{label}.{name} -> {spec['git']}@{ref}")
-                  elif "url" in spec and str(spec["url"]).startswith("git+"):
-                      offenders.append(f"{label}.{name} -> {spec['url']}")
-
-          sources = data.get("tool", {}).get("uv", {}).get("sources", {})
-          scan("tool.uv.sources", sources)
-
-          project = data.get("project", {})
-          for dep in project.get("dependencies", []):
-              if "git+" in dep:
-                  offenders.append(dep)
-          for gname, deps in project.get("optional-dependencies", {}).items():
-              for dep in deps:
-                  if "git+" in dep:
-                      offenders.append(f"{gname}: {dep}")
-          for gname, deps in data.get("dependency-groups", {}).items():
-              for dep in deps:
-                  if isinstance(dep, str) and "git+" in dep:
-                      offenders.append(f"{gname}: {dep}")
-
-          if offenders:
-              print("Git sources found in pyproject.toml:")
-              for o in offenders:
-                  print(f"  - {o}")
-              sys.exit(1)
-          print("No git sources - OK.")
-          PY
+    uses: terok-ai/terok-util/.github/workflows/no-git-deps.yml@v0.3.0a2


### PR DESCRIPTION
Pilot consumer for terok-ai/terok-util#47 wave 1 (terok-ai/terok-util#48 + terok-ai/mkdocs-terok#108, tags `v0.3.0a2` / `v0.8.0a2`).

- **ci.yml**: the eight-job static-check battery → one `fleet-checks.yml@v0.3.0a2` call (all defaults — shield needs no toggles); only the repo-specific host-integration job stays local.
- **no-git-deps.yml**: thin nested caller of terok-util's scanner; the local `push` trigger and `release.yml`'s `workflow_call` gate keep working unchanged (nested reusables are fine, ≤4 levels).
- **docs.yml**: the ~110-line build job → one `docs-build.yml@v0.8.0a2` call (defaults match shield exactly: `--locked --all-groups`, `analysis.yml` coverage source); publish + inventory refs ride the same tag.

Net **−260 lines** of duplicated YAML in this repo alone. This PR's CI is the end-to-end validation of cross-repo tag-pinned consumption; after it soaks, the same conversion sweeps the remaining five repos.

**Heads-up**: check names change to `checks / lint` style — anything keyed on the old names (branch protection / required checks) needs the new spelling. The release chain's check-waiting is bucket-based and unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)