### PR TITLE
ci: release build + test matrix ride the fleet reusables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   checks:
-    uses: terok-ai/terok-util/.github/workflows/fleet-checks.yml@v0.3.0a4
+    uses: terok-ai/terok-util/.github/workflows/fleet-checks.yml@v0.3.0a5
 
   integration-tests-host:
     name: Integration tests (host)

--- a/.github/workflows/no-git-deps.yml
+++ b/.github/workflows/no-git-deps.yml
@@ -13,4 +13,4 @@ jobs:
   # the package family); this caller keeps the local triggers and the
   # release.yml gate wiring.
   scan:
-    uses: terok-ai/terok-util/.github/workflows/no-git-deps.yml@v0.3.0a4
+    uses: terok-ai/terok-util/.github/workflows/no-git-deps.yml@v0.3.0a5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,30 +27,13 @@ jobs:
     permissions:
       contents: read
 
+  # The build job is the fleet-wide reusable hosted in terok-util
+  # (fleet-release-build.yml), pinned by that repo's release tag.
   build:
     needs: no-git-deps
-    runs-on: ubuntu-latest
     permissions:
       contents: read
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0    # hatch-vcs needs full history
-
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-
-      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
-
-      - name: Build distributions
-        run: uv build
-
-      - uses: actions/upload-artifact@v7
-        with:
-          name: dist
-          path: dist/
-          retention-days: 90    # cover any realistic re-run window
+    uses: terok-ai/terok-util/.github/workflows/fleet-release-build.yml@v0.3.0a5
 
   github-release:
     needs: build

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -18,6 +18,6 @@ permissions:
 
 jobs:
   sonar:
-    uses: terok-ai/terok-util/.github/workflows/fleet-sonar.yml@v0.3.0a4
+    uses: terok-ai/terok-util/.github/workflows/fleet-sonar.yml@v0.3.0a5
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sonar_pr.yml
+++ b/.github/workflows/sonar_pr.yml
@@ -17,6 +17,6 @@ permissions:
 
 jobs:
   sonar:
-    uses: terok-ai/terok-util/.github/workflows/fleet-sonar-pr.yml@v0.3.0a4
+    uses: terok-ai/terok-util/.github/workflows/fleet-sonar-pr.yml@v0.3.0a5
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -1,12 +1,10 @@
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 #
-# Multi-distro integration test matrix.
-# Requires a self-hosted runner with podman, --privileged support, and
-# uv.  Will NOT work on GitHub-hosted runners (no nested containers).
-#
-# The slot list is derived from tests/containers/matrix.yml (the single
-# source of truth the local runs use) via `terok-matrix --slots-json`.
+# Multi-distro integration test matrix on the self-hosted runner.
+# Thin caller: the jobs live in terok-util's reusable
+# fleet-test-matrix.yml; the slot list is derived from this repo's
+# tests/containers/matrix.yml via `terok-matrix --slots-json`.
 name: Test Matrix
 
 on:
@@ -21,30 +19,7 @@ permissions:
   contents: read
 
 jobs:
-  slots:
-    if: github.repository == 'terok-ai/terok-shield'
-    runs-on: self-hosted
-    outputs:
-      matrix: ${{ steps.gen.outputs.matrix }}
-    steps:
-      - uses: actions/checkout@v7
-      - name: Install the matrix engine (terok-util via uv)
-        run: uv sync --locked --no-default-groups --no-install-project
-      - id: gen
-        run: echo "matrix=$(uv run --no-sync terok-matrix --slots-json ${{ inputs.slots }})" >> "$GITHUB_OUTPUT"
-
   matrix:
-    needs: slots
-    runs-on: self-hosted
-    strategy:
-      fail-fast: false
-      matrix:
-        slot: ${{ fromJSON(needs.slots.outputs.matrix) }}
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-      - name: Install the matrix engine (terok-util via uv)
-        run: uv sync --locked --no-default-groups --no-install-project
-      - name: Run test matrix (${{ matrix.slot }})
-        run: uv run --no-sync terok-matrix ${{ matrix.slot }}
+    uses: terok-ai/terok-util/.github/workflows/fleet-test-matrix.yml@v0.3.0a5
+    with:
+      slots: ${{ inputs.slots }}


### PR DESCRIPTION
Final consumer sweep for terok-ai/terok-util#51: the inline release build job becomes a thin caller of the reusable `fleet-release-build.yml`, and every terok-util workflow ref is bumped to `v0.3.0a5`. The existing DGX test-matrix workflow is converted (not added) to the thin `fleet-test-matrix.yml` shell, keeping its workflow_dispatch trigger and slot-subset input; terok, terok-sandbox, and terok-clearance gain the same dispatchable matrix in this wave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)