### PR TITLE
fix(dns): NSS fallback resolves both address families

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dynamic = ["version"]
 dependencies = [
     "PyYAML~=6.0",
     "pydantic~=2.13",
-    "terok-util @ https://github.com/terok-ai/terok-util/releases/download/v0.3.0a1/terok_util-0.3.0a1-py3-none-any.whl",
+    "terok-util @ https://github.com/terok-ai/terok-util/releases/download/v0.3.0a7/terok_util-0.3.0a7-py3-none-any.whl",
 ]
 
 [project.urls]
@@ -87,7 +87,7 @@ allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
-fallback-version = "0.8.0a1"
+fallback-version = "0.8.0a2"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/terok_shield"]

--- a/src/terok_shield/dns/resolver.py
+++ b/src/terok_shield/dns/resolver.py
@@ -95,6 +95,17 @@ class DnsResolver:
                 # not batch-wide: one genuinely dead domain must not demote
                 # the resolver for the rest.
                 ips = self._resolve_one(domain, use_getent=True)
+                if ips:
+                    # NSS resolving what dig could not is the proof that dig
+                    # itself is broken here (crashed, EDNS-hostile forwarder)
+                    # -- worth a warning, since dig's own stderr is not
+                    # surfaced (the mageia/64K jemalloc SIGABRT hid behind
+                    # this exact silence, terok#1119).
+                    logger.warning(
+                        "dig returned nothing for %r but NSS resolved it — "
+                        "dig is broken in this environment",
+                        domain,
+                    )
             if not ips:
                 logger.warning("Domain %r resolved to no IPs (typo or DNS failure?)", domain)
             for ip in ips:

--- a/src/terok_shield/run.py
+++ b/src/terok_shield/run.py
@@ -201,22 +201,27 @@ class SubprocessRunner:
         return result
 
     def getent_hosts(self, domain: str) -> list[str]:
-        """Resolve domain via ``getent hosts`` (fallback when dig is missing).
+        """Resolve domain via NSS (fallback when dig is missing or broken).
 
-        Returns validated IP addresses from NSS resolution.  Typically
-        returns fewer results than ``dig`` (often a single address).
+        Queries both address families explicitly: plain ``getent hosts``
+        stops at the first family glibc resolves (AAAA for dual-stack
+        names), which left ``allow_v4`` empty on the one host whose dig
+        crashes -- an allowed literal-IPv4 target then hit the terminal
+        reject as "Host is unreachable" (terok#1119).
         """
-        out = self.run(["getent", "hosts", domain], check=False, timeout=10)
         result: list[str] = []
-        for line in out.splitlines():
-            parts = line.strip().split()
-            if not parts:
-                continue
-            try:
-                _ipaddress.ip_address(parts[0])
-                result.append(parts[0])
-            except ValueError:
-                continue
+        for database in ("ahostsv4", "ahostsv6"):
+            out = self.run(["getent", database, domain], check=False, timeout=10)
+            for line in out.splitlines():
+                parts = line.strip().split()
+                if len(parts) < 2 or parts[1] != "STREAM":
+                    continue
+                try:
+                    _ipaddress.ip_address(parts[0])
+                except ValueError:
+                    continue
+                if parts[0] not in result:
+                    result.append(parts[0])
         return result
 
 

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -382,26 +382,34 @@ def test_subprocess_runner_stores_nft_path() -> None:
 # ── getent_hosts tests ───────────────────────────────────
 
 
-@pytest.mark.parametrize(
-    ("stdout", "expected"),
-    [
-        pytest.param(f"{TEST_IP1}       {TEST_DOMAIN}\n", [TEST_IP1], id="single-ip"),
-        pytest.param(
-            f"{TEST_IP1}       host1\n{TEST_IP2}       host2\n",
-            [TEST_IP1, TEST_IP2],
-            id="multiple-lines",
-        ),
-        pytest.param("", [], id="empty-output"),
-        pytest.param("not-an-ip    host\n", [], id="invalid-ip-skipped"),
-        pytest.param(f"\n{TEST_IP1}       {TEST_DOMAIN}\n\n", [TEST_IP1], id="blank-lines-skipped"),
-    ],
-)
-def test_getent_hosts(
+def test_getent_hosts_queries_both_families(
     runner: SubprocessRunner,
     subprocess_run: mock.Mock,
-    stdout: str,
-    expected: list[str],
 ) -> None:
-    """getent_hosts() parses IP addresses from getent output."""
-    subprocess_run.return_value = _completed(stdout=stdout)
-    assert runner.getent_hosts(TEST_DOMAIN) == expected
+    """Both address families are queried explicitly and results merge.
+
+    Plain ``getent hosts`` stops at the first family glibc resolves
+    (AAAA for dual-stack names), which left allow_v4 empty when dig was
+    broken (terok#1119) -- the fallback must ask v4 and v6 separately.
+    """
+    subprocess_run.side_effect = [
+        _completed(stdout=f"{TEST_IP1}   STREAM {TEST_DOMAIN}\n{TEST_IP1}   DGRAM  \n"),
+        _completed(stdout=f"2606:4700:4700::1111 STREAM {TEST_DOMAIN}\n"),
+    ]
+    assert runner.getent_hosts(TEST_DOMAIN) == [TEST_IP1, "2606:4700:4700::1111"]
+    databases = [call.args[0][1] for call in subprocess_run.call_args_list]
+    assert databases == ["ahostsv4", "ahostsv6"]
+
+
+def test_getent_hosts_skips_non_stream_and_junk_lines(
+    runner: SubprocessRunner,
+    subprocess_run: mock.Mock,
+) -> None:
+    """Only STREAM rows with valid addresses count; duplicates collapse."""
+    subprocess_run.side_effect = [
+        _completed(
+            stdout=f"{TEST_IP1} STREAM a\n{TEST_IP1} STREAM b\nnot-an-ip STREAM c\nbare-line\n"
+        ),
+        _completed(stdout=""),
+    ]
+    assert runner.getent_hosts(TEST_DOMAIN) == [TEST_IP1]

--- a/uv.lock
+++ b/uv.lock
@@ -1445,7 +1445,7 @@ test = [
 requires-dist = [
     { name = "pydantic", specifier = "~=2.13" },
     { name = "pyyaml", specifier = "~=6.0" },
-    { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.0a1/terok_util-0.3.0a1-py3-none-any.whl" },
+    { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.0a7/terok_util-0.3.0a7-py3-none-any.whl" },
 ]
 
 [package.metadata.requires-dev]
@@ -1476,15 +1476,15 @@ test = [
 
 [[package]]
 name = "terok-util"
-version = "0.3.0a1"
-source = { url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.0a1/terok_util-0.3.0a1-py3-none-any.whl" }
+version = "0.3.0a7"
+source = { url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.0a7/terok_util-0.3.0a7-py3-none-any.whl" }
 dependencies = [
     { name = "jinja2" },
     { name = "platformdirs" },
     { name = "ruamel-yaml" },
 ]
 wheels = [
-    { url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.0a1/terok_util-0.3.0a1-py3-none-any.whl", hash = "sha256:b5b1e2132a6d4a1b50bcc35d566e0d462f3e7a8317ae2be162652a54885ed233" },
+    { url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.0a7/terok_util-0.3.0a7-py3-none-any.whl", hash = "sha256:5591d5eeac101b7b42b7a896a601d628799b7d1fc1c5beeaa59bf7da43ac77b5" },
 ]
 
 [package.metadata]


### PR DESCRIPTION
Fixes the mageia half of terok-ai/terok#1119. The chain: dig SIGABRTs on mageia/aarch64/64K (4K-built jemalloc, stderr discarded) → the getent fallback used plain `getent hosts`, which returns **AAAA-only** for dual-stack names (glibc stops at the first family) → `allow_v6` populated, `allow_v4` empty → the allowed `http://1.1.1.1/` hit the terminal `reject with icmpx admin-prohibited` → `Host is unreachable`. Every neighboring test discriminates in favor: literal-IP allows pass (nft fine), blocked-by-default passes (ruleset fine), unshielded wget to 1.1.1.1 passes (datapath fine).

Fallback now queries `getent ahostsv4` + `ahostsv6` and merges STREAM rows; and when NSS resolves what dig could not, the resolver logs that dig is broken instead of the crash staying invisible. Validation: mageia slot on the DGX after the next shield alpha repins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)