### PR TITLE
test: distinct operands in the find_nft stability check

### DIFF
--- a/tests/integration/setup/test_find_nft.py
+++ b/tests/integration/setup/test_find_nft.py
@@ -31,4 +31,5 @@ class TestFindNft:
 
     def test_result_is_stable(self) -> None:
         """Repeated calls return the same path."""
-        assert find_nft() == find_nft()
+        first, second = find_nft(), find_nft()
+        assert first == second


### PR DESCRIPTION
Shield's one open Sonar bug (S5863). Not a tautology — `find_nft() == find_nft()` makes two separate lookups, which is exactly what "repeated calls return the same path" means. Binding the operands states that and dissolves the finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)