### PR TITLE
chore(deps): wire terok-util for the supervisor-process-split chain

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dynamic = ["version"]
 dependencies = [
     "PyYAML~=6.0",
     "pydantic~=2.13",
-    "terok-util @ git+https://github.com/sliwowitz/terok-util.git@feat/supervisor-process-split",
+    "terok-util @ https://github.com/terok-ai/terok-util/releases/download/v0.3.1a1/terok_util-0.3.1a1-py3-none-any.whl",
 ]
 
 [project.urls]
@@ -87,7 +87,7 @@ allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
-fallback-version = "0.8.0a3"
+fallback-version = "0.8.0a4"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/terok_shield"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dynamic = ["version"]
 dependencies = [
     "PyYAML~=6.0",
     "pydantic~=2.13",
-    "terok-util @ https://github.com/terok-ai/terok-util/releases/download/v0.3.0/terok_util-0.3.0-py3-none-any.whl",
+    "terok-util @ git+https://github.com/sliwowitz/terok-util.git@feat/supervisor-process-split",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -1439,7 +1439,7 @@ test = [
 requires-dist = [
     { name = "pydantic", specifier = "~=2.13" },
     { name = "pyyaml", specifier = "~=6.0" },
-    { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.0/terok_util-0.3.0-py3-none-any.whl" },
+    { name = "terok-util", git = "https://github.com/sliwowitz/terok-util.git?rev=feat%2Fsupervisor-process-split" },
 ]
 
 [package.metadata.requires-dev]
@@ -1470,22 +1470,12 @@ test = [
 
 [[package]]
 name = "terok-util"
-version = "0.3.0"
-source = { url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.0/terok_util-0.3.0-py3-none-any.whl" }
+version = "0.3.1.dev65+gad67354db"
+source = { git = "https://github.com/sliwowitz/terok-util.git?rev=feat%2Fsupervisor-process-split#ad67354dbcace2c4fa96a7bcffa63464e0ad019d" }
 dependencies = [
     { name = "jinja2" },
     { name = "platformdirs" },
     { name = "ruamel-yaml" },
-]
-wheels = [
-    { url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.0/terok_util-0.3.0-py3-none-any.whl", hash = "sha256:966c66ed4de17c18247c65ccb8dba45060e1bced804a305ec1794b30bd9a9f4e" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "jinja2", specifier = "~=3.1" },
-    { name = "platformdirs", specifier = "~=4.10" },
-    { name = "ruamel-yaml", specifier = "==0.19.1" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1439,7 +1439,7 @@ test = [
 requires-dist = [
     { name = "pydantic", specifier = "~=2.13" },
     { name = "pyyaml", specifier = "~=6.0" },
-    { name = "terok-util", git = "https://github.com/sliwowitz/terok-util.git?rev=feat%2Fsupervisor-process-split" },
+    { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a1/terok_util-0.3.1a1-py3-none-any.whl" },
 ]
 
 [package.metadata.requires-dev]
@@ -1470,12 +1470,22 @@ test = [
 
 [[package]]
 name = "terok-util"
-version = "0.3.1.dev65+gad67354db"
-source = { git = "https://github.com/sliwowitz/terok-util.git?rev=feat%2Fsupervisor-process-split#ad67354dbcace2c4fa96a7bcffa63464e0ad019d" }
+version = "0.3.1a1"
+source = { url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a1/terok_util-0.3.1a1-py3-none-any.whl" }
 dependencies = [
     { name = "jinja2" },
     { name = "platformdirs" },
     { name = "ruamel-yaml" },
+]
+wheels = [
+    { url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a1/terok_util-0.3.1a1-py3-none-any.whl", hash = "sha256:f75d4ef6db5587b5297ffe9c166103b5d6ede63a5014d8dfb6667211fd505bbd" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "jinja2", specifier = "~=3.1" },
+    { name = "platformdirs", specifier = "~=4.10" },
+    { name = "ruamel-yaml", specifier = "==0.19.1" },
 ]
 
 [[package]]


### PR DESCRIPTION
Deps-only member of the **feat/supervisor-process-split** PR chain (terok-util#70 → clearance → shield → terok-sandbox#450).

shield's code is unchanged; it only re-pins `terok-util` to the chain branch so the whole chain resolves to one consistent `terok-util` under uv (its released alpha wheel otherwise pins the v0.3.0 wheel URL, conflicting with sandbox's branch pin). The release script rewrites this back to a wheel at release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)