### PR TITLE
perf(dns): parallel resolution, 2s per-lookup budget, shared host-level cache

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -109,10 +109,17 @@ runtime, before the reply reaches the workload. There is no pre-resolution at
 launch (`cache-size=0`) — dynamic resolution handles IP rotation automatically,
 so no cache expiry is needed.
 
-**dig / getent tiers** (fallback): resolved IPs are stored in `resolved.ips`,
-one IP per line. The cache uses file modification time (`st_mtime`) for
-freshness checking — entries older than 1 hour (or older than the authored
-policy) are automatically re-resolved.
+**dig / getent tiers** (fallback): the allowlist is resolved at pre-start into
+the per-container `resolved.ips` cache, one IP per line. Domains resolve
+concurrently with a 2s per-lookup budget, so a batch costs about one lookup.
+The cache uses file modification time (`st_mtime`) for freshness — entries
+older than 1 hour, or older than the authored policy, are re-resolved.
+
+**Shared host cache** (opt-in, off by default): set `ShieldConfig.dns_cache_dir`
+(the CLI points it at `<state root>/dns-cache/`) to share one resolution across
+every container with the same allowlist. Keyed by the allowlist's content hash,
+so an edit re-resolves; a resolve where every domain failed is never shared.
+Only the dig/getent tiers use it — the dnsmasq tier resolves on-demand.
 
 Force a cache refresh (all tiers):
 

--- a/src/terok_shield/__init__.py
+++ b/src/terok_shield/__init__.py
@@ -226,7 +226,7 @@ class Shield:
             audit_path=StateBundle(config.state_dir).audit,
             enabled=config.audit_enabled,
         )
-        self.dns = dns or DnsResolver(runner=self.runner)
+        self.dns = dns or DnsResolver(runner=self.runner, host_cache_dir=config.dns_cache_dir)
         self.profiles = profiles or ProfileLoader(
             user_dir=config.profiles_dir or Path("/nonexistent"),
         )

--- a/src/terok_shield/cli/main.py
+++ b/src/terok_shield/cli/main.py
@@ -377,12 +377,17 @@ def _build_config(
     # Profiles dir
     profiles_dir = _resolve_config_root() / "profiles"
 
+    # Shared DNS cache lives beside the per-container state dirs, so every
+    # container on this host that resolves the same allowlist shares one pass.
+    dns_cache_dir = (state_dir_override or _resolve_state_root()).resolve() / "dns-cache"
+
     return ShieldConfig(
         state_dir=state_dir,
         mode=mode,
         default_profiles=tuple(file_cfg.default_profiles),
         audit_enabled=file_cfg.audit.enabled,
         profiles_dir=profiles_dir,
+        dns_cache_dir=dns_cache_dir,
     )
 
 

--- a/src/terok_shield/config.py
+++ b/src/terok_shield/config.py
@@ -161,6 +161,14 @@ class ShieldConfig:
     audit_enabled: bool = True
     profiles_dir: Path | None = None
     runtime: ShieldRuntime = ShieldRuntime.DEFAULT
+    dns_cache_dir: Path | None = None
+    """Opt-in shared DNS-resolution cache, shared across containers.
+
+    The one deliberate exception to the state_dir-only rule: ``None`` (the
+    default) keeps resolution per-container; a path enables a host-level cache
+    that lets many tasks with the same allowlist share one resolve. Only the
+    dig/getent tiers use it — the dnsmasq tier resolves on-demand at runtime.
+    """
 
 
 # ── ShieldModeBackend protocol ──────────────────────────

--- a/src/terok_shield/dns/resolver.py
+++ b/src/terok_shield/dns/resolver.py
@@ -23,9 +23,11 @@ handles raw IPs only.
 """
 # WAYPOINT: Shield (__init__), HookMode (hooks.mode)
 
+import contextlib
 import hashlib
 import logging
 import os
+import tempfile
 import time
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
@@ -221,12 +223,20 @@ class DnsResolver:
 
     @staticmethod
     def _write_cache(path: Path, ips: list[str]) -> None:
-        """Write resolved IPs atomically (write + rename).
+        """Write resolved IPs atomically (unique temp file + rename).
 
-        The host-level file is read by concurrently starting tasks, and a torn
-        read there would seed a container with a truncated allowlist.
+        The host-level file is shared across concurrently starting tasks — a
+        torn read would seed a container with a truncated allowlist — and two
+        threads of one process can write the same (content-hash-keyed) file at
+        once, so each write goes to its own ``mkstemp`` temp before the rename.
         """
         path.parent.mkdir(parents=True, exist_ok=True)
-        tmp = path.with_name(f".{path.name}.{os.getpid()}.tmp")
-        tmp.write_text("\n".join(ips) + "\n" if ips else "")
-        tmp.replace(path)
+        fd, tmp = tempfile.mkstemp(dir=path.parent, prefix=f".{path.name}.", suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w") as f:
+                f.write("\n".join(ips) + "\n" if ips else "")
+            os.replace(tmp, path)
+        except OSError:
+            with contextlib.suppress(OSError):
+                os.unlink(tmp)
+            raise

--- a/src/terok_shield/dns/resolver.py
+++ b/src/terok_shield/dns/resolver.py
@@ -3,40 +3,71 @@
 
 """DNS resolution with timestamp-based caching.
 
-Resolves domain names from allowlist profiles via ``dig`` and caches
-the results so containers do not block on DNS at every start.  Profiles
-prefer domain names over raw IPs because CDN addresses rotate.
+Resolves allowlist domains via ``dig`` (``getent`` fallback) and caches
+the IPs so containers do not block on DNS at every start.
 
-Falls back to ``getent hosts`` when ``dig`` is not installed, and
-per-domain when ``dig`` runs but yields nothing (some environments break
-``dig`` while glibc resolution still works) — fewer IPs are captured
-(no parallel A + AAAA query), but resolution still works.  The dnsmasq tier does not use this module at launch at all —
-domain resolution happens at runtime via ``--nftset``; static resolution
-is the fallback tiers' (dig/getent) enforcement mechanism and the
-``shield resolve`` warm-up path.
+Two cache layers:
+
+- **per-container file** (``cache_path``): the view the nft ruleset reads.
+  Scoped to one container, so a fresh container never reuses another's.
+- **host cache** (``host_cache_dir``, opt-in, off by default): shared across
+  containers, keyed by the allowlist's content hash. The first task resolves;
+  the rest read.
+
+Domains resolve concurrently with a per-lookup timeout, so a batch costs
+about one lookup and one dead domain cannot stall startup.
+
+Only the dig/getent tiers use this module at launch. On the dnsmasq tier
+domains resolve on-demand at runtime via ``--nftset``; this module then
+handles raw IPs only.
 """
 # WAYPOINT: Shield (__init__), HookMode (hooks.mode)
 
+import hashlib
 import logging
+import os
 import time
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
-from ..run import CommandRunner, DigNotFoundError
+from ..run import CommandRunner
+from ..state import STATE_DIR_MODE
 from ..util import is_ip as _is_ip
 
 logger = logging.getLogger(__name__)
 
+RESOLVE_TIMEOUT = 2
+"""Per-subprocess DNS budget in seconds.
+
+Best-effort: an answer slower than this counts as no answer. The old 10s
+budget let one dead domain (times the getent retry) stall a start by ~20s.
+"""
+
+MAX_RESOLVE_WORKERS = 16
+"""Upper bound on concurrent resolver subprocesses per batch."""
+
+_HOST_CACHE_KEY_LEN = 16
+"""Hex digits of the entry-list hash used as the host-cache filename."""
+
 
 class DnsResolver:
-    """Stateless DNS resolver — all persistence lives in the cache file.
+    """Stateless DNS resolver — all persistence lives in the cache files.
 
-    The only dependency is a [`CommandRunner`][terok_shield.dns.resolver.CommandRunner] for ``dig`` / ``getent``
-    subprocess calls.
+    Depends on a [`CommandRunner`][terok_shield.dns.resolver.CommandRunner]
+    for ``dig`` / ``getent`` subprocess calls and, optionally, a host-level
+    cache directory shared across containers.
     """
 
-    def __init__(self, *, runner: CommandRunner) -> None:
-        """Inject the command runner used for all DNS subprocess calls."""
+    def __init__(self, *, runner: CommandRunner, host_cache_dir: Path | None = None) -> None:
+        """Inject the command runner and the optional shared cache location.
+
+        Args:
+            runner: Command runner used for all DNS subprocess calls.
+            host_cache_dir: Cross-container cache directory. ``None`` (the
+                default) disables the shared layer.
+        """
         self._runner = runner
+        self._host_cache_dir = host_cache_dir
 
     # ── Public API ──────────────────────────────────────────
 
@@ -50,17 +81,19 @@ class DnsResolver:
     ) -> list[str]:
         """Resolve profile entries and cache the result.
 
-        Profiles mix domain names with literal IPs/CIDRs — domains go
-        through DNS resolution, literals pass through unchanged.
+        Reads the per-container file first, then the shared host cache
+        (materializing a hit into the per-container file), and only resolves
+        when both miss.
 
         Args:
             entries: Domain names and/or raw IPs from composed profiles.
-            cache_path: File to store resolved IPs in, per-container scoped.
+            cache_path: Per-container file the nft ruleset reads.
             max_age: Cache freshness threshold in seconds (default: 1 hour).
-            source_mtime: mtime of the authored policy the entries came from;
-                a cache older than this is re-resolved even when still within
-                ``max_age``, so an edited allowlist takes effect on the next
-                task start instead of waiting out the timer.
+            source_mtime: mtime of the authored policy; a per-container cache
+                older than it is re-resolved even within ``max_age``, so an
+                edited allowlist takes effect on the next task start. The host
+                cache ignores this — its content-hash key already makes it
+                edit-aware.
 
         Returns:
             Resolved IPv4/IPv6 addresses combined with raw IPs/CIDRs.
@@ -68,67 +101,90 @@ class DnsResolver:
         if self._cache_fresh(cache_path, max_age, source_mtime):
             return self._read_cache(cache_path)
 
+        host_path = self._host_cache_path(entries)
+        if host_path is not None and self._cache_fresh(host_path, max_age):
+            ips = self._read_cache(host_path)
+            self._write_cache(cache_path, ips)
+            return ips
+
         domains, raw_ips = self._split_entries(entries)
         resolved = self.resolve_domains(domains)
         all_ips = raw_ips + resolved
 
         self._write_cache(cache_path, all_ips)
+        # An all-domains-failed resolve (DNS outage, broken resolver) is fine
+        # for one container but must not poison every task on the host for
+        # max_age: share only when at least one domain resolved (or there were
+        # none to resolve).
+        if host_path is not None and (resolved or not domains):
+            self._write_cache(host_path, all_ips)
         return all_ips
 
     def resolve_domains(self, domains: list[str]) -> list[str]:
-        """Resolve domain names to IP addresses (A + AAAA), best-effort.
+        """Resolve domain names to IPs (A + AAAA), best-effort and concurrent.
 
-        Unresolvable domains are skipped with a warning.  Results are
-        deduplicated in first-seen order.
+        Probes for ``dig`` once, then resolves every domain on a small thread
+        pool — a batch costs about its slowest single lookup. Unresolvable
+        domains are skipped with a warning; results are deduplicated in
+        first-seen (input) order.
         """
-        seen: set[str] = set()
-        result: list[str] = []
-        use_getent = False
-        for domain in domains:
-            try:
-                ips = self._resolve_one(domain, use_getent=use_getent)
-            except DigNotFoundError:
-                # dig missing — degrade gracefully for the rest of this batch
-                logger.warning("dig not found — falling back to getent for DNS resolution")
-                use_getent = True
-                ips = self._resolve_one(domain, use_getent=True)
-            if not ips and not use_getent:
-                # dig ran but produced nothing.  That is usually not a dead
-                # domain: some environments break dig specifically (a DNS
-                # forwarder rejecting its EDNS options, a hardened container
-                # path) while glibc resolution still works — so retry this
-                # one domain through getent before giving up.  Per-domain,
-                # not batch-wide: one genuinely dead domain must not demote
-                # the resolver for the rest.
-                ips = self._resolve_one(domain, use_getent=True)
-                if ips:
-                    # NSS resolving what dig could not is the proof that dig
-                    # itself is broken here (crashed, EDNS-hostile forwarder)
-                    # -- worth a warning, since dig's own stderr is not
-                    # surfaced (the mageia/64K jemalloc SIGABRT hid behind
-                    # this exact silence, terok#1119).
-                    logger.warning(
-                        "dig returned nothing for %r but NSS resolved it — "
-                        "dig is broken in this environment",
-                        domain,
-                    )
-            if not ips:
-                logger.warning("Domain %r resolved to no IPs (typo or DNS failure?)", domain)
-            for ip in ips:
-                if ip not in seen:
-                    seen.add(ip)
-                    result.append(ip)
-        return result
+        if not domains:
+            return []
+        if self._runner.has("dig"):
+            resolve = self._resolve_via_dig
+        else:
+            logger.warning("dig not found — using getent for DNS resolution")
+            resolve = self._resolve_via_getent
+        with ThreadPoolExecutor(max_workers=min(len(domains), MAX_RESOLVE_WORKERS)) as pool:
+            per_domain = pool.map(resolve, domains)
+        return list(dict.fromkeys(ip for ips in per_domain for ip in ips))
 
     # ── Resolution detail ───────────────────────────────────
 
-    def _resolve_one(self, domain: str, *, use_getent: bool = False) -> list[str]:
-        """Resolve a single domain using dig or getent."""
-        if use_getent:
-            return self._runner.getent_hosts(domain)
-        return self._runner.dig_all(domain)
+    def _resolve_via_dig(self, domain: str) -> list[str]:
+        """Resolve via ``dig``, retrying one domain through NSS when dig answers empty.
+
+        An empty ``dig`` answer is usually not a dead domain: some environments
+        break ``dig`` specifically (an EDNS-hostile forwarder, a hardened path)
+        while glibc resolution still works, so we retry that one domain through
+        ``getent`` before giving up (terok#1119).
+        """
+        ips = self._runner.dig_all(domain, timeout=RESOLVE_TIMEOUT)
+        if not ips:
+            ips = self._runner.getent_hosts(domain, timeout=RESOLVE_TIMEOUT)
+            if ips:
+                logger.warning(
+                    "dig returned nothing for %r but NSS resolved it — dig is broken here", domain
+                )
+        return self._warn_if_empty(domain, ips)
+
+    def _resolve_via_getent(self, domain: str) -> list[str]:
+        """Resolve via NSS (``getent``) — the path taken when ``dig`` is absent."""
+        ips = self._runner.getent_hosts(domain, timeout=RESOLVE_TIMEOUT)
+        return self._warn_if_empty(domain, ips)
+
+    @staticmethod
+    def _warn_if_empty(domain: str, ips: list[str]) -> list[str]:
+        """Warn on an empty resolution (typo or DNS failure); pass the IPs through."""
+        if not ips:
+            logger.warning("Domain %r resolved to no IPs (typo or DNS failure?)", domain)
+        return ips
 
     # ── Cache mechanics ─────────────────────────────────────
+
+    def _host_cache_path(self, entries: list[str]) -> Path | None:
+        """Shared cache file for this exact entry list, or ``None`` when off.
+
+        Keyed by the content hash of the entry list: any allowlist edit lands
+        on a fresh key and re-resolves. Creates the directory ``0700`` on first
+        use.
+        """
+        if self._host_cache_dir is None:
+            return None
+        self._host_cache_dir.mkdir(parents=True, exist_ok=True)
+        self._host_cache_dir.chmod(STATE_DIR_MODE)
+        digest = hashlib.sha256("\n".join(entries).encode()).hexdigest()
+        return self._host_cache_dir / f"{digest[:_HOST_CACHE_KEY_LEN]}.resolved"
 
     @staticmethod
     def _split_entries(entries: list[str]) -> tuple[list[str], list[str]]:
@@ -136,12 +192,12 @@ class DnsResolver:
         domains: list[str] = []
         ips: list[str] = []
         for entry in entries:
-            (_ips := ips if _is_ip(entry) else domains).append(entry)
+            (ips if _is_ip(entry) else domains).append(entry)
         return domains, ips
 
     @staticmethod
     def _cache_fresh(path: Path, max_age: int, source_mtime: float = 0.0) -> bool:
-        """Check whether the cache exists, is younger than *max_age*, and post-dates its source.
+        """True when *path* exists, is younger than *max_age*, and post-dates *source_mtime*.
 
         A cache older than *source_mtime* (the authored policy's mtime) is
         stale even within *max_age* — the allowlist changed since we resolved.
@@ -165,6 +221,12 @@ class DnsResolver:
 
     @staticmethod
     def _write_cache(path: Path, ips: list[str]) -> None:
-        """Write resolved IPs to a cache file."""
+        """Write resolved IPs atomically (write + rename).
+
+        The host-level file is read by concurrently starting tasks, and a torn
+        read there would seed a container with a truncated allowlist.
+        """
         path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text("\n".join(ips) + "\n" if ips else "")
+        tmp = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+        tmp.write_text("\n".join(ips) + "\n" if ips else "")
+        tmp.replace(path)

--- a/src/terok_shield/run.py
+++ b/src/terok_shield/run.py
@@ -67,7 +67,7 @@ class CommandRunner(Protocol):
         """Resolve domain to both IPv4 and IPv6 addresses."""
         ...
 
-    def getent_hosts(self, domain: str) -> list[str]:
+    def getent_hosts(self, domain: str, *, timeout: int = 10) -> list[str]:
         """Resolve domain via ``getent hosts`` (fallback when dig is missing)."""
         ...
 
@@ -219,7 +219,7 @@ class SubprocessRunner:
                 continue
         return result
 
-    def getent_hosts(self, domain: str) -> list[str]:
+    def getent_hosts(self, domain: str, *, timeout: int = 10) -> list[str]:
         """Resolve domain via NSS (fallback when dig is missing or broken).
 
         Queries both address families explicitly: plain ``getent hosts``
@@ -227,10 +227,13 @@ class SubprocessRunner:
         names), which left ``allow_v4`` empty on the one host whose dig
         crashes -- an allowed literal-IPv4 target then hit the terminal
         reject as "Host is unreachable" (terok#1119).
+
+        *timeout* bounds each family query; on expiry that family yields
+        nothing (best-effort, matching ``dig_all``).
         """
         result: list[str] = []
         for database in ("ahostsv4", "ahostsv6"):
-            out = self.run(["getent", database, domain], check=False, timeout=10)
+            out = self.run(["getent", database, domain], check=False, timeout=timeout)
             for line in out.splitlines():
                 parts = line.strip().split()
                 if len(parts) < 2 or parts[1] != "STREAM":

--- a/tests/unit/test_api_surface.py
+++ b/tests/unit/test_api_surface.py
@@ -104,6 +104,7 @@ class TestAPISurface:
             "audit_enabled",
             "profiles_dir",
             "runtime",
+            "dns_cache_dir",
         ]
 
         cfg = make_config()
@@ -113,6 +114,7 @@ class TestAPISurface:
         assert cfg.audit_enabled is True
         assert cfg.profiles_dir is None
         assert cfg.runtime == ShieldRuntime.DEFAULT
+        assert cfg.dns_cache_dir is None
 
     def test_shield_config_frozen(self, make_config):
         """ShieldConfig is frozen — assignment raises FrozenInstanceError."""

--- a/tests/unit/test_dns_resolver.py
+++ b/tests/unit/test_dns_resolver.py
@@ -12,7 +12,7 @@ from unittest import mock
 import pytest
 
 from terok_shield.dns.resolver import DnsResolver
-from terok_shield.run import DigNotFoundError
+from terok_shield.state import StateBundle
 
 from ..testfs import NONEXISTENT_DIR, TEST_CACHE_FILENAME, TEST_SUBDIR_NAME
 from ..testnet import (
@@ -40,13 +40,29 @@ ResolverHarnessFactory = Callable[..., ResolverHarness]
 
 @pytest.fixture
 def make_resolver() -> ResolverHarnessFactory:
-    """Build a resolver plus its injected runner mock."""
+    """Build a resolver plus its injected runner mock (``dig`` present by default)."""
 
-    def _make_resolver(**runner_kwargs: object) -> ResolverHarness:
+    def _make_resolver(
+        *, host_cache_dir: Path | None = None, **runner_kwargs: object
+    ) -> ResolverHarness:
         runner = mock.MagicMock(**runner_kwargs)
-        return ResolverHarness(resolver=DnsResolver(runner=runner), runner=runner)
+        runner.has.return_value = True  # dig present unless a test says otherwise
+        return ResolverHarness(
+            resolver=DnsResolver(runner=runner, host_cache_dir=host_cache_dir),
+            runner=runner,
+        )
 
     return _make_resolver
+
+
+def _dig_returns(runner: mock.MagicMock, mapping: dict[str, list[str]]) -> None:
+    """Answer ``dig_all`` per domain — thread-order-independent (the pool is concurrent)."""
+    runner.dig_all.side_effect = lambda domain, **_kw: list(mapping.get(domain, []))
+
+
+def _getent_returns(runner: mock.MagicMock, mapping: dict[str, list[str]]) -> None:
+    """Answer ``getent_hosts`` per domain."""
+    runner.getent_hosts.side_effect = lambda domain, **_kw: list(mapping.get(domain, []))
 
 
 def test_direct_init() -> None:
@@ -67,6 +83,14 @@ def test_read_write_roundtrip(tmp_path: Path) -> None:
     assert DnsResolver._read_cache(cache_path) == [TEST_IP1, TEST_IP2]
 
 
+def test_write_cache_is_atomic_and_leaves_no_temp(tmp_path: Path) -> None:
+    """_write_cache() writes via a temp file + rename, leaving only the target."""
+    cache_path = tmp_path / TEST_CACHE_FILENAME
+    DnsResolver._write_cache(cache_path, [TEST_IP1])
+    assert cache_path.is_file()
+    assert list(tmp_path.iterdir()) == [cache_path]  # no .tmp sibling left behind
+
+
 def test_write_cache_creates_parent_dirs(tmp_path: Path) -> None:
     """_write_cache() creates missing parent directories."""
     cache_path = tmp_path / TEST_SUBDIR_NAME / TEST_CACHE_FILENAME
@@ -81,49 +105,41 @@ def test_write_cache_empty_list(tmp_path: Path) -> None:
     assert cache_path.read_text() == ""
 
 
+# ── resolve_domains: concurrency, dedup, probe-once ─────
+
+
 @pytest.mark.parametrize(
-    ("side_effect", "domains", "expected"),
+    ("mapping", "domains", "expected"),
     [
         pytest.param(
-            [[TEST_IP1, IPV6_CLOUDFLARE], [TEST_IP2]],
+            {CLOUDFLARE_DOMAIN: [TEST_IP1, IPV6_CLOUDFLARE], GOOGLE_DNS_DOMAIN: [TEST_IP2]},
             [CLOUDFLARE_DOMAIN, GOOGLE_DNS_DOMAIN],
             [TEST_IP1, IPV6_CLOUDFLARE, TEST_IP2],
             id="multiple-domains",
         ),
         pytest.param(
-            [[TEST_IP1], [TEST_IP1, TEST_IP2]],
+            {TEST_DOMAIN: [TEST_IP1], TEST_DOMAIN2: [TEST_IP1, TEST_IP2]},
             [TEST_DOMAIN, TEST_DOMAIN2],
             [TEST_IP1, TEST_IP2],
             id="deduplicates",
         ),
     ],
 )
-def test_resolve_domains(
+def test_resolve_domains_merges_in_input_order(
     make_resolver: ResolverHarnessFactory,
-    side_effect: list[list[str]],
+    mapping: dict[str, list[str]],
     domains: list[str],
     expected: list[str],
 ) -> None:
-    """resolve_domains() merges results while preserving first-seen order."""
+    """resolve_domains() merges concurrent results in first-seen (input) order.
+
+    The per-domain mapping is answered regardless of thread completion order,
+    so a pass proves the result order tracks the input, not whichever lookup
+    finished first.
+    """
     harness = make_resolver()
-    harness.runner.dig_all.side_effect = side_effect
+    _dig_returns(harness.runner, mapping)
     assert harness.resolver.resolve_domains(domains) == expected
-
-
-def test_logs_warning_for_unresolvable(
-    make_resolver: ResolverHarnessFactory,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """resolve_domains() warns when a domain yields no IPs from any tier."""
-    harness = make_resolver()
-    harness.runner.dig_all.side_effect = [[TEST_IP1], []]
-    harness.runner.getent_hosts.return_value = []
-
-    with caplog.at_level("WARNING", logger="terok_shield.dns.resolver"):
-        harness.resolver.resolve_domains([CLOUDFLARE_DOMAIN, NONEXISTENT_DOMAIN])
-
-    assert len(caplog.messages) == 1
-    assert NONEXISTENT_DOMAIN in caplog.messages[0]
 
 
 def test_resolve_domains_empty_input(make_resolver: ResolverHarnessFactory) -> None:
@@ -131,6 +147,96 @@ def test_resolve_domains_empty_input(make_resolver: ResolverHarnessFactory) -> N
     harness = make_resolver()
     assert harness.resolver.resolve_domains([]) == []
     harness.runner.dig_all.assert_not_called()
+    harness.runner.has.assert_not_called()  # no probe when there is nothing to resolve
+
+
+def test_resolve_domains_probes_dig_once_no_getent_when_dig_answers(
+    make_resolver: ResolverHarnessFactory,
+) -> None:
+    """When dig answers, getent is never touched (probe once, no per-domain retry)."""
+    harness = make_resolver()
+    _dig_returns(harness.runner, {TEST_DOMAIN: [TEST_IP1], TEST_DOMAIN2: [TEST_IP2]})
+    harness.resolver.resolve_domains([TEST_DOMAIN, TEST_DOMAIN2])
+    harness.runner.getent_hosts.assert_not_called()
+
+
+def test_logs_warning_for_unresolvable(
+    make_resolver: ResolverHarnessFactory,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """resolve_domains() warns once when a domain yields no IPs from any tier."""
+    harness = make_resolver()
+    _dig_returns(harness.runner, {CLOUDFLARE_DOMAIN: [TEST_IP1]})  # NONEXISTENT → []
+    _getent_returns(harness.runner, {})  # getent retry also empty
+
+    with caplog.at_level("WARNING", logger="terok_shield.dns.resolver"):
+        harness.resolver.resolve_domains([CLOUDFLARE_DOMAIN, NONEXISTENT_DOMAIN])
+
+    unresolvable = [m for m in caplog.messages if NONEXISTENT_DOMAIN in m]
+    assert len(unresolvable) == 1
+
+
+# ── dig-missing and broken-dig fallbacks ────────────────
+
+
+def test_resolve_domains_uses_getent_when_dig_absent(
+    make_resolver: ResolverHarnessFactory,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """No dig on the host → resolve via getent, warning once for the whole batch."""
+    harness = make_resolver()
+    harness.runner.has.return_value = False
+    _getent_returns(harness.runner, {CLOUDFLARE_DOMAIN: [TEST_IP1], GOOGLE_DNS_DOMAIN: [TEST_IP2]})
+
+    with caplog.at_level("WARNING", logger="terok_shield.dns.resolver"):
+        result = harness.resolver.resolve_domains([CLOUDFLARE_DOMAIN, GOOGLE_DNS_DOMAIN])
+
+    assert result == [TEST_IP1, TEST_IP2]
+    harness.runner.dig_all.assert_not_called()
+    assert sum("dig not found" in m for m in caplog.messages) == 1
+
+
+def test_resolve_domains_getent_fallback_deduplicates(
+    make_resolver: ResolverHarnessFactory,
+) -> None:
+    """getent-only path still deduplicates IPs across domains."""
+    harness = make_resolver()
+    harness.runner.has.return_value = False
+    _getent_returns(harness.runner, {CLOUDFLARE_DOMAIN: [TEST_IP1], GOOGLE_DNS_DOMAIN: [TEST_IP1]})
+
+    assert harness.resolver.resolve_domains([CLOUDFLARE_DOMAIN, GOOGLE_DNS_DOMAIN]) == [TEST_IP1]
+
+
+def test_resolve_domains_empty_dig_retries_via_getent(
+    make_resolver: ResolverHarnessFactory,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A dig that runs but yields nothing retries that domain via getent (broken-dig env)."""
+    harness = make_resolver()
+    _dig_returns(harness.runner, {CLOUDFLARE_DOMAIN: []})
+    _getent_returns(harness.runner, {CLOUDFLARE_DOMAIN: [TEST_IP1]})
+
+    with caplog.at_level("WARNING", logger="terok_shield.dns.resolver"):
+        result = harness.resolver.resolve_domains([CLOUDFLARE_DOMAIN])
+
+    assert result == [TEST_IP1]
+    assert any("dig is broken" in m for m in caplog.messages)
+
+
+def test_resolve_domains_empty_dig_retry_is_per_domain(
+    make_resolver: ResolverHarnessFactory,
+) -> None:
+    """One empty dig answer retries only that domain — others keep their dig results."""
+    harness = make_resolver()
+    _dig_returns(harness.runner, {CLOUDFLARE_DOMAIN: [], GOOGLE_DNS_DOMAIN: [TEST_IP2]})
+    _getent_returns(harness.runner, {CLOUDFLARE_DOMAIN: [TEST_IP1]})
+
+    result = harness.resolver.resolve_domains([CLOUDFLARE_DOMAIN, GOOGLE_DNS_DOMAIN])
+    assert result == [TEST_IP1, TEST_IP2]
+    harness.runner.getent_hosts.assert_called_once()  # only the empty domain retried
+
+
+# ── resolve_and_cache: per-container layer ──────────────
 
 
 def test_resolve_and_cache_writes_cache(
@@ -139,7 +245,7 @@ def test_resolve_and_cache_writes_cache(
 ) -> None:
     """resolve_and_cache() resolves entries and writes the cache file."""
     harness = make_resolver()
-    harness.runner.dig_all.return_value = [TEST_IP1]
+    _dig_returns(harness.runner, {TEST_DOMAIN: [TEST_IP1]})
 
     cache_path = StateBundle(tmp_path).resolved_cache
     assert harness.resolver.resolve_and_cache([TEST_DOMAIN], cache_path) == [TEST_IP1]
@@ -168,7 +274,7 @@ def test_resolve_and_cache_re_resolves_stale_cache(
 ) -> None:
     """resolve_and_cache() refreshes stale cache files."""
     harness = make_resolver()
-    harness.runner.dig_all.return_value = [TEST_IP2]
+    _dig_returns(harness.runner, {TEST_DOMAIN: [TEST_IP2]})
 
     cache_path = StateBundle(tmp_path).resolved_cache
     cache_path.write_text(f"{TEST_IP1}\n")
@@ -184,7 +290,7 @@ def test_resolve_and_cache_re_resolves_when_source_is_newer(
 ) -> None:
     """A cache older than ``source_mtime`` is re-resolved even within ``max_age``."""
     harness = make_resolver()
-    harness.runner.dig_all.return_value = [TEST_IP2]
+    _dig_returns(harness.runner, {TEST_DOMAIN: [TEST_IP2]})
 
     cache_path = StateBundle(tmp_path).resolved_cache
     cache_path.write_text(f"{TEST_IP1}\n")
@@ -221,7 +327,7 @@ def test_resolve_and_cache_mixed_entries(
 ) -> None:
     """resolve_and_cache() preserves raw IPs while resolving domain entries."""
     harness = make_resolver()
-    harness.runner.dig_all.return_value = [TEST_IP2]
+    _dig_returns(harness.runner, {TEST_DOMAIN: [TEST_IP2]})
 
     cache_path = StateBundle(tmp_path).resolved_cache
     result = harness.resolver.resolve_and_cache([TEST_IP1, TEST_DOMAIN], cache_path)
@@ -229,54 +335,104 @@ def test_resolve_and_cache_mixed_entries(
     assert TEST_IP2 in result
 
 
-def test_resolve_domains_falls_back_to_getent(
+# ── resolve_and_cache: shared host-level cache (opt-in) ──
+
+
+def _host_files(host_dir: Path) -> list[Path]:
+    """The materialized host-cache files (ignoring any in-flight temp file)."""
+    return [p for p in host_dir.iterdir() if not p.name.startswith(".")]
+
+
+def test_host_cache_off_by_default(
+    tmp_path: Path,
     make_resolver: ResolverHarnessFactory,
 ) -> None:
-    """resolve_domains() falls back to getent when dig is not found."""
-    harness = make_resolver()
-    harness.runner.dig_all.side_effect = DigNotFoundError("dig not found")
-    harness.runner.getent_hosts.side_effect = [[TEST_IP1], [TEST_IP2]]
+    """With no host_cache_dir, nothing is written outside the per-container file."""
+    harness = make_resolver()  # host_cache_dir=None
+    _dig_returns(harness.runner, {TEST_DOMAIN: [TEST_IP1]})
+    cache_path = StateBundle(tmp_path / "ctr").resolved_cache
 
-    result = harness.resolver.resolve_domains([CLOUDFLARE_DOMAIN, GOOGLE_DNS_DOMAIN])
-    assert result == [TEST_IP1, TEST_IP2]
-    harness.runner.getent_hosts.assert_called()
+    harness.resolver.resolve_and_cache([TEST_DOMAIN], cache_path)
+    # Only the per-container file exists; no shared artifacts anywhere.
+    assert cache_path.is_file()
 
 
-def test_resolve_domains_getent_fallback_deduplicates(
+def test_host_cache_miss_writes_both_layers(
+    tmp_path: Path,
     make_resolver: ResolverHarnessFactory,
 ) -> None:
-    """getent fallback still deduplicates IPs."""
-    harness = make_resolver()
-    harness.runner.dig_all.side_effect = DigNotFoundError("dig not found")
-    harness.runner.getent_hosts.side_effect = [[TEST_IP1], [TEST_IP1]]
+    """A cold resolve writes the per-container file AND the shared host file."""
+    host_dir = tmp_path / "dns-cache"
+    harness = make_resolver(host_cache_dir=host_dir)
+    _dig_returns(harness.runner, {TEST_DOMAIN: [TEST_IP1]})
+    cache_path = StateBundle(tmp_path / "ctr").resolved_cache
 
-    result = harness.resolver.resolve_domains([CLOUDFLARE_DOMAIN, GOOGLE_DNS_DOMAIN])
+    harness.resolver.resolve_and_cache([TEST_DOMAIN], cache_path)
+    assert cache_path.read_text().split() == [TEST_IP1]
+    assert len(_host_files(host_dir)) == 1
+
+
+def test_host_cache_hit_skips_resolution(
+    tmp_path: Path,
+    make_resolver: ResolverHarnessFactory,
+) -> None:
+    """A second container with the same allowlist reads the host file, never resolving."""
+    host_dir = tmp_path / "dns-cache"
+    first = make_resolver(host_cache_dir=host_dir)
+    _dig_returns(first.runner, {TEST_DOMAIN: [TEST_IP1]})
+    first.resolver.resolve_and_cache([TEST_DOMAIN], StateBundle(tmp_path / "a").resolved_cache)
+
+    second = make_resolver(host_cache_dir=host_dir)
+    cache_b = StateBundle(tmp_path / "b").resolved_cache
+    result = second.resolver.resolve_and_cache([TEST_DOMAIN], cache_b)
+
     assert result == [TEST_IP1]
+    second.runner.dig_all.assert_not_called()  # served from the shared layer
+    assert cache_b.read_text().split() == [TEST_IP1]  # materialized per-container
 
 
-def test_resolve_domains_empty_dig_retries_via_getent(
+def test_host_cache_is_content_keyed(
+    tmp_path: Path,
     make_resolver: ResolverHarnessFactory,
 ) -> None:
-    """A dig that runs but yields nothing retries the domain via getent."""
-    harness = make_resolver()
-    harness.runner.dig_all.return_value = []
-    harness.runner.getent_hosts.return_value = [TEST_IP1]
+    """A changed allowlist lands on a fresh key — the edit re-resolves, no stale hit."""
+    host_dir = tmp_path / "dns-cache"
+    harness = make_resolver(host_cache_dir=host_dir)
+    _dig_returns(harness.runner, {TEST_DOMAIN: [TEST_IP1], TEST_DOMAIN2: [TEST_IP2]})
 
-    result = harness.resolver.resolve_domains([CLOUDFLARE_DOMAIN])
+    harness.resolver.resolve_and_cache([TEST_DOMAIN], StateBundle(tmp_path / "a").resolved_cache)
+    harness.resolver.resolve_and_cache(
+        [TEST_DOMAIN, TEST_DOMAIN2], StateBundle(tmp_path / "b").resolved_cache
+    )
+    assert len(_host_files(host_dir)) == 2  # distinct entry lists → distinct files
+
+
+def test_host_cache_not_poisoned_by_total_failure(
+    tmp_path: Path,
+    make_resolver: ResolverHarnessFactory,
+) -> None:
+    """An all-domains-failed resolve is kept per-container but never shared."""
+    host_dir = tmp_path / "dns-cache"
+    harness = make_resolver(host_cache_dir=host_dir)
+    _dig_returns(harness.runner, {})  # every domain fails
+    _getent_returns(harness.runner, {})
+    cache_path = StateBundle(tmp_path / "ctr").resolved_cache
+
+    result = harness.resolver.resolve_and_cache([TEST_DOMAIN], cache_path)
+    assert result == []
+    assert cache_path.is_file()  # per-container view written (existing semantics)
+    assert _host_files(host_dir) == []  # but the host layer is NOT poisoned
+
+
+def test_host_cache_shares_when_raw_ips_only(
+    tmp_path: Path,
+    make_resolver: ResolverHarnessFactory,
+) -> None:
+    """A literal-IP-only list has nothing to fail, so it populates the shared layer."""
+    host_dir = tmp_path / "dns-cache"
+    harness = make_resolver(host_cache_dir=host_dir)
+    cache_path = StateBundle(tmp_path / "ctr").resolved_cache
+
+    result = harness.resolver.resolve_and_cache([TEST_IP1], cache_path)
     assert result == [TEST_IP1]
-
-
-def test_resolve_domains_empty_dig_fallback_is_per_domain(
-    make_resolver: ResolverHarnessFactory,
-) -> None:
-    """One empty dig answer does not demote later domains to getent."""
-    harness = make_resolver()
-    harness.runner.dig_all.side_effect = [[], [TEST_IP2]]
-    harness.runner.getent_hosts.return_value = [TEST_IP1]
-
-    result = harness.resolver.resolve_domains([CLOUDFLARE_DOMAIN, GOOGLE_DNS_DOMAIN])
-    assert result == [TEST_IP1, TEST_IP2]
-    harness.runner.getent_hosts.assert_called_once()
-
-
-from terok_shield.state import StateBundle
+    assert len(_host_files(host_dir)) == 1

--- a/tests/unit/test_dns_resolver.py
+++ b/tests/unit/test_dns_resolver.py
@@ -91,6 +91,36 @@ def test_write_cache_is_atomic_and_leaves_no_temp(tmp_path: Path) -> None:
     assert list(tmp_path.iterdir()) == [cache_path]  # no .tmp sibling left behind
 
 
+def test_write_cache_concurrent_same_path_no_collision(tmp_path: Path) -> None:
+    """Concurrent writes to one shared host-cache path each use a distinct temp.
+
+    The host cache is content-hash keyed, so two same-process threads launching
+    containers with the same allowlist target one file at once — a pid-only
+    temp name would collide; ``mkstemp`` gives each write its own.
+    """
+    from concurrent.futures import ThreadPoolExecutor
+
+    cache_path = tmp_path / "shared.resolved"
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        list(
+            pool.map(
+                lambda _n: DnsResolver._write_cache(cache_path, [TEST_IP1, TEST_IP2]), range(32)
+            )
+        )
+
+    assert DnsResolver._read_cache(cache_path) == [TEST_IP1, TEST_IP2]  # a full write won
+    assert [p for p in tmp_path.iterdir() if p.name.startswith(".")] == []  # no temp leftovers
+
+
+def test_write_cache_cleans_up_temp_on_rename_failure(tmp_path: Path) -> None:
+    """A failed rename removes the temp file and re-raises — no partial artifact."""
+    cache_path = tmp_path / TEST_CACHE_FILENAME
+    with mock.patch("terok_shield.dns.resolver.os.replace", side_effect=OSError("boom")):
+        with pytest.raises(OSError, match="boom"):
+            DnsResolver._write_cache(cache_path, [TEST_IP1])
+    assert list(tmp_path.iterdir()) == []  # temp cleaned up, target never created
+
+
 def test_write_cache_creates_parent_dirs(tmp_path: Path) -> None:
     """_write_cache() creates missing parent directories."""
     cache_path = tmp_path / TEST_SUBDIR_NAME / TEST_CACHE_FILENAME


### PR DESCRIPTION
Now that **#352 is merged**, this is a standalone PR off master. It makes the fallback-tier DNS path fast and robust.

Makes the **static DNS resolution path** fast and robust: the path #352 leaves in place for the **dig/getent tiers** (and the `shield resolve` warm-up). The dnsmasq tier resolves on-demand and pays none of this — but dnsmasq-less hosts are common enough that this path is worth optimizing.

## Parallel resolution

`resolve_domains` probes for `dig` once, then resolves the whole batch on a thread pool (≤16 workers) via `pool.map`. A batch costs about its slowest single lookup instead of the sum.

- `dig`/`getent` are subprocess I/O (the GIL is released), so threads are the right tool; `pool.map` preserves input order, so first-seen dedup falls out for free.
- Probing `dig` up front means no per-domain `DigNotFoundError` handling and no lock: `dig` can't appear or vanish mid-batch. (Simpler than a warn-once lock.)
- The empty-`dig` → per-domain `getent` retry — the fix for `dig`-broken/EDNS-hostile environments (terok#1119) — is kept.

## 2s per-lookup budget

`RESOLVE_TIMEOUT = 2` (was 10), on `dig` and `getent` alike. Resolution is best-effort: a slower answer counts as no answer, so a dead domain costs seconds, not ~20s. Timeouts degrade to an empty result (`check=False`), never raising through the pool. `getent_hosts` gains the `timeout` parameter `dig_all` already had.

## Shared host cache (opt-in)

`resolve_and_cache` reads the per-container file first, then a host-level cache keyed by the **content hash of the entry list**, resolving only when both miss. A host hit is materialized into the per-container view nft reads.

- **Off by default**: `ShieldConfig.dns_cache_dir = None` (prior behaviour byte-for-byte). The CLI points it at `<state root>/dns-cache/`; terok/sandbox opt in by setting it.
- Content keying makes it **edit-aware**: a changed allowlist lands on a fresh key and re-resolves.
- **No host-wide poisoning**: a resolve where every domain failed is written per-container but never shared.
- **Atomic writes** (temp + rename): a concurrently starting task never reads a torn file.
- Ignores `source_mtime` (the content hash already gives edit-awareness); the per-container file keeps the `source_mtime` freshness check from #352.

## Verification

`make check` green: ruff · full unit suite (1308, `dns/resolver.py` + `config.py` 100%) · tach (`dns → state` allowed for `STATE_DIR_MODE`) · mypy · bandit · docstrings · vulture · reuse.

Closes the startup-latency half of #69 for the fallback tiers. The dnsmasq-tier half is handled in #352 (no pre-resolution at all).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an opt-in shared DNS resolution cache (shared across containers with matching allowlists) for the `dig/getent` tiers; `dnsmasq` still resolves on demand.
  * DNS resolution now runs concurrently, with `getent` support honoring a configurable timeout.
  * Cache automatically refreshes when stale or when the authored policy changes.

* **Bug Fixes**
  * Improved cache reliability with atomic cache writes to prevent partially written results.
  * Prevented the shared cache from being populated when all domain resolutions fail.

* **Documentation**
  * Updated DNS resolution and cache freshness behavior, including shared-cache configuration and tier limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->