### PR TITLE
chore(deps): pin terok-util to the pull-always PR branch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dynamic = ["version"]
 dependencies = [
     "PyYAML~=6.0",
     "pydantic~=2.13",
-    "terok-util @ https://github.com/terok-ai/terok-util/releases/download/v0.3.1a2/terok_util-0.3.1a2-py3-none-any.whl",
+    "terok-util @ git+https://github.com/sliwowitz/terok-util@feat/pull-always-podman3",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dynamic = ["version"]
 dependencies = [
     "PyYAML~=6.0",
     "pydantic~=2.13",
-    "terok-util @ git+https://github.com/sliwowitz/terok-util@feat/pull-always-podman3",
+    "terok-util @ https://github.com/terok-ai/terok-util/releases/download/v0.3.1a3/terok_util-0.3.1a3-py3-none-any.whl",
 ]
 
 [project.urls]
@@ -87,7 +87,7 @@ allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
-fallback-version = "0.8.0a5"
+fallback-version = "0.8.0a6"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/terok_shield"]

--- a/uv.lock
+++ b/uv.lock
@@ -1439,7 +1439,7 @@ test = [
 requires-dist = [
     { name = "pydantic", specifier = "~=2.13" },
     { name = "pyyaml", specifier = "~=6.0" },
-    { name = "terok-util", git = "https://github.com/sliwowitz/terok-util?rev=feat%2Fpull-always-podman3" },
+    { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a3/terok_util-0.3.1a3-py3-none-any.whl" },
 ]
 
 [package.metadata.requires-dev]
@@ -1470,12 +1470,22 @@ test = [
 
 [[package]]
 name = "terok-util"
-version = "0.3.1a3.dev69+ge29c9c537"
-source = { git = "https://github.com/sliwowitz/terok-util?rev=feat%2Fpull-always-podman3#e29c9c5372e523da154378beb92631e33bfe9bf1" }
+version = "0.3.1a3"
+source = { url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a3/terok_util-0.3.1a3-py3-none-any.whl" }
 dependencies = [
     { name = "jinja2" },
     { name = "platformdirs" },
     { name = "ruamel-yaml" },
+]
+wheels = [
+    { url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a3/terok_util-0.3.1a3-py3-none-any.whl", hash = "sha256:dc579905a4c9d815ccadb8370834002a9f2f0c0f2fd35d42e58140e7563799c1" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "jinja2", specifier = "~=3.1" },
+    { name = "platformdirs", specifier = "~=4.10" },
+    { name = "ruamel-yaml", specifier = "==0.19.1" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1439,7 +1439,7 @@ test = [
 requires-dist = [
     { name = "pydantic", specifier = "~=2.13" },
     { name = "pyyaml", specifier = "~=6.0" },
-    { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a2/terok_util-0.3.1a2-py3-none-any.whl" },
+    { name = "terok-util", git = "https://github.com/sliwowitz/terok-util?rev=feat%2Fpull-always-podman3" },
 ]
 
 [package.metadata.requires-dev]
@@ -1470,22 +1470,12 @@ test = [
 
 [[package]]
 name = "terok-util"
-version = "0.3.1a2"
-source = { url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a2/terok_util-0.3.1a2-py3-none-any.whl" }
+version = "0.3.1a3.dev69+ge29c9c537"
+source = { git = "https://github.com/sliwowitz/terok-util?rev=feat%2Fpull-always-podman3#e29c9c5372e523da154378beb92631e33bfe9bf1" }
 dependencies = [
     { name = "jinja2" },
     { name = "platformdirs" },
     { name = "ruamel-yaml" },
-]
-wheels = [
-    { url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a2/terok_util-0.3.1a2-py3-none-any.whl", hash = "sha256:f0172db426bb5a0dd18e45d044453c231bd02e5cea82355ca370813aa6edee1f" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "jinja2", specifier = "~=3.1" },
-    { name = "platformdirs", specifier = "~=4.10" },
-    { name = "ruamel-yaml", specifier = "==0.19.1" },
 ]
 
 [[package]]


### PR DESCRIPTION
Chain link for terok-ai/terok-util#75 (version-aware `--pull=always` / `--pull-always` spelling for podman 3.x hosts). Repin only — no shield code changes; keeps the util URL pin consistent across the resolver chain. Repin to the released util wheel at merge time via the release chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)