### PR TITLE
feat(shield): accept generated t20/t30 tiers at pre_start

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,7 @@ allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
-fallback-version = "0.8.0a6"
+fallback-version = "0.8.0a7"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/terok_shield"]

--- a/src/terok_shield/__init__.py
+++ b/src/terok_shield/__init__.py
@@ -19,7 +19,7 @@ helpers.  Heavy imports are deferred until ``Shield`` is instantiated.
 
 import importlib as _importlib
 import logging
-from collections.abc import Iterator
+from collections.abc import Iterator, Sequence
 from dataclasses import dataclass, field
 from importlib.metadata import PackageNotFoundError, version as _meta_version
 from pathlib import Path
@@ -346,11 +346,25 @@ class Shield:
             "audit_enabled": self.config.audit_enabled,
         }
 
-    def pre_start(self, container: str, profiles: list[str] | None = None) -> list[str]:
-        """Prepare shield for container start.  Returns extra podman args."""
+    def pre_start(
+        self,
+        container: str,
+        profiles: list[str] | None = None,
+        *,
+        security_deny: Sequence[str] = (),
+        provider_allow: Sequence[str] = (),
+    ) -> list[str]:
+        """Prepare shield for container start.  Returns extra podman args.
+
+        *security_deny* / *provider_allow* are the generated t20 / t30 tiers
+        (executor's roster projection, carried by sandbox); shield writes them
+        into the bundle so callers pass data, never touch the layout.
+        """
         if profiles is None:
             profiles = list(self.config.default_profiles)
-        result = self._mode.pre_start(container, profiles)
+        result = self._mode.pre_start(
+            container, profiles, security_deny=security_deny, provider_allow=provider_allow
+        )
         self.audit.log_event(container, "setup", detail=f"profiles={','.join(profiles)}")
         return result
 

--- a/src/terok_shield/__init__.py
+++ b/src/terok_shield/__init__.py
@@ -353,17 +353,27 @@ class Shield:
         *,
         security_deny: Sequence[str] = (),
         provider_allow: Sequence[str] = (),
+        project_allow: Sequence[str] = (),
+        override: Sequence[str] = (),
     ) -> list[str]:
         """Prepare shield for container start.  Returns extra podman args.
 
-        *security_deny* / *provider_allow* are the generated t20 / t30 tiers
-        (executor's roster projection, carried by sandbox); shield writes them
-        into the bundle so callers pass data, never touch the layout.
+        The four tier arguments are the orchestrator-generated policy tiers,
+        which shield writes into the bundle so callers pass data and never touch
+        the layout: *security_deny* → t20 (vault hosts denied direct),
+        *provider_allow* → t30 (provider egress), *project_allow* → t40 (git
+        remote + custom, merged with the composed profiles), *override* → t10
+        (break-glass allow above the deny; single host/IP only).
         """
         if profiles is None:
             profiles = list(self.config.default_profiles)
         result = self._mode.pre_start(
-            container, profiles, security_deny=security_deny, provider_allow=provider_allow
+            container,
+            profiles,
+            security_deny=security_deny,
+            provider_allow=provider_allow,
+            project_allow=project_allow,
+            override=override,
         )
         self.audit.log_event(container, "setup", detail=f"profiles={','.join(profiles)}")
         return result

--- a/src/terok_shield/__init__.py
+++ b/src/terok_shield/__init__.py
@@ -378,6 +378,36 @@ class Shield:
         self.audit.log_event(container, "setup", detail=f"profiles={','.join(profiles)}")
         return result
 
+    def refresh(
+        self,
+        container: str,
+        profiles: list[str] | None = None,
+        *,
+        security_deny: Sequence[str] = (),
+        provider_allow: Sequence[str] = (),
+        project_allow: Sequence[str] = (),
+        override: Sequence[str] = (),
+    ) -> None:
+        """Recompute an existing container's policy bundle before a plain restart.
+
+        Same tier arguments as [`pre_start`][terok_shield.Shield.pre_start],
+        but for a container that already exists: rewrites the tiers and
+        static-resolution caches and regenerates the pre-applied artifacts
+        (``ruleset.nft``, dnsmasq config), so the next ``podman start``
+        enforces *current* policy instead of the bundle frozen at creation.
+        Returns nothing — the container keeps its launch-time podman args.
+        """
+        if profiles is None:
+            profiles = list(self.config.default_profiles)
+        self._mode.refresh(
+            profiles,
+            security_deny=security_deny,
+            provider_allow=provider_allow,
+            project_allow=project_allow,
+            override=override,
+        )
+        self.audit.log_event(container, "refresh", detail=f"profiles={','.join(profiles)}")
+
     def allow(self, container: str, target: str) -> list[str]:
         """Live-allow a domain or IP for a running container."""
         from .run import ExecError

--- a/src/terok_shield/config.py
+++ b/src/terok_shield/config.py
@@ -11,7 +11,7 @@ a mode backend must satisfy.
 from __future__ import annotations
 
 import enum
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Protocol, runtime_checkable
@@ -183,8 +183,19 @@ class ShieldModeBackend(Protocol):
     and preview.
     """
 
-    def pre_start(self, container: str, profiles: list[str]) -> list[str]:
-        """Prepare for container start; return extra podman args."""
+    def pre_start(
+        self,
+        container: str,
+        profiles: list[str],
+        *,
+        security_deny: Sequence[str] = (),
+        provider_allow: Sequence[str] = (),
+    ) -> list[str]:
+        """Prepare for container start; return extra podman args.
+
+        *security_deny* / *provider_allow* are the caller-generated t20 / t30
+        tiers (see [`Shield.pre_start`][terok_shield.Shield.pre_start]).
+        """
         ...
 
     def allow_ip(self, container: str, ip: str) -> None:

--- a/src/terok_shield/config.py
+++ b/src/terok_shield/config.py
@@ -190,11 +190,14 @@ class ShieldModeBackend(Protocol):
         *,
         security_deny: Sequence[str] = (),
         provider_allow: Sequence[str] = (),
+        project_allow: Sequence[str] = (),
+        override: Sequence[str] = (),
     ) -> list[str]:
         """Prepare for container start; return extra podman args.
 
-        *security_deny* / *provider_allow* are the caller-generated t20 / t30
-        tiers (see [`Shield.pre_start`][terok_shield.Shield.pre_start]).
+        *security_deny* / *provider_allow* / *project_allow* / *override* are the
+        caller-generated t20 / t30 / t40 / t10 tiers
+        (see [`Shield.pre_start`][terok_shield.Shield.pre_start]).
         """
         ...
 

--- a/src/terok_shield/config.py
+++ b/src/terok_shield/config.py
@@ -201,6 +201,23 @@ class ShieldModeBackend(Protocol):
         """
         ...
 
+    def refresh(
+        self,
+        profiles: list[str],
+        *,
+        security_deny: Sequence[str] = (),
+        provider_allow: Sequence[str] = (),
+        project_allow: Sequence[str] = (),
+        override: Sequence[str] = (),
+    ) -> None:
+        """Recompute an existing container's policy bundle before a plain restart.
+
+        Same tier data as
+        [`pre_start`][terok_shield.config.ShieldModeBackend.pre_start], no
+        launch half — rewrites tiers, caches, and pre-applied artifacts only.
+        """
+        ...
+
     def allow_ip(self, container: str, ip: str) -> None:
         """Live-allow an IP for a running container."""
         ...

--- a/src/terok_shield/container.py
+++ b/src/terok_shield/container.py
@@ -33,38 +33,27 @@ import shutil
 import subprocess  # nosec B404 — podman is a trusted host binary
 from pathlib import Path
 
-from .config import ANNOTATION_STATE_DIR_KEY
+from .config import ANNOTATION_STATE_DIR_KEY, ANNOTATION_VERSION_KEY
 
 _log = logging.getLogger(__name__)
 
 _INSPECT_TIMEOUT_S = 10
 
 
-def resolve_state_dir(container: str) -> Path | None:
-    """Return the per-container ``state_dir`` from podman annotations, or ``None``.
+def _inspect_records(container: str) -> object | None:
+    """Run ``podman inspect --format=json`` for *container*; return parsed records or ``None``.
 
-    Calls ``podman inspect --format=json`` and pulls the
-    ``terok.shield.state_dir`` annotation out of the container's config.
-    Any failure — podman missing, container absent, annotation not set,
-    JSON malformed — collapses to ``None`` so callers can fall through.
-
-    Args:
-        container: Container name or ID (short or full) as podman knows it.
-
-    Returns:
-        The resolved ``Path`` if the annotation is present and absolute,
-        otherwise ``None``.
+    Any failure — podman missing, container absent, non-zero exit, malformed
+    JSON — collapses to ``None`` so callers fall through.  ``--`` bars podman
+    from reading a hostile *container* value as one of its own flags
+    (``--all``, ``--latest``, …) — the public contract accepts identifiers from
+    external callers that may not have validated them.
     """
     podman = shutil.which("podman")
     if not podman:
-        _log.warning("podman not on PATH — cannot resolve state_dir for %s", container)
+        _log.warning("podman not on PATH — cannot inspect %s", container)
         return None
     try:
-        # ``--`` bars podman from interpreting a hostile *container* value as
-        # one of its own flags (``--all``, ``--latest``, ``--format=bad`` …).
-        # The module's public contract accepts container identifiers from
-        # external callers that may not have validated them; ``--`` makes
-        # the positional boundary explicit regardless of what the caller did.
         result = subprocess.run(  # nosec B603
             [podman, "inspect", "--format=json", "--", container],
             check=False,
@@ -76,28 +65,21 @@ def resolve_state_dir(container: str) -> Path | None:
         _log.warning("podman inspect failed for %s: %s", container, exc)
         return None
     if result.returncode != 0:
-        # Warn — every failure here translates into a verdict that silently
-        # fails downstream.  Operators hitting this need to know *why*
-        # podman couldn't speak to its own state (sandbox / hardening
-        # interaction, stale pause process, missing socket, etc.) rather
-        # than just "no annotation".
+        # Warn — every failure here translates into a downstream miss.
+        # Operators need *why* podman couldn't speak to its own state.
         _log.warning(
-            "podman inspect %s returned %d: %s",
-            container,
-            result.returncode,
-            result.stderr.strip(),
+            "podman inspect %s returned %d: %s", container, result.returncode, result.stderr.strip()
         )
         return None
     try:
-        records = json.loads(result.stdout)
+        return json.loads(result.stdout)
     except json.JSONDecodeError as exc:
         _log.warning("podman inspect %s returned malformed JSON: %s", container, exc)
         return None
-    return _extract_state_dir(records)
 
 
-def _extract_state_dir(records: object) -> Path | None:
-    """Pull ``terok.shield.state_dir`` out of one ``podman inspect`` record set."""
+def _annotations(records: object) -> dict | None:
+    """Pull the OCI annotations dict out of one ``podman inspect`` record set."""
     if not isinstance(records, list) or not records:
         return None
     head = records[0]
@@ -107,21 +89,59 @@ def _extract_state_dir(records: object) -> Path | None:
     if not isinstance(config, dict):
         return None
     annotations = config.get("Annotations")
-    if not isinstance(annotations, dict):
+    return annotations if isinstance(annotations, dict) else None
+
+
+def resolve_state_dir(container: str) -> Path | None:
+    """Return the per-container ``state_dir`` from podman annotations, or ``None``.
+
+    Reads the ``terok.shield.state_dir`` annotation out of the container's
+    config.  Any failure — podman missing, container absent, annotation not
+    set, non-absolute, JSON malformed — collapses to ``None`` so callers can
+    fall through.
+
+    Args:
+        container: Container name or ID (short or full) as podman knows it.
+
+    Returns:
+        The resolved ``Path`` if the annotation is present and absolute,
+        otherwise ``None``.
+    """
+    annotations = _annotations(_inspect_records(container))
+    if annotations is None:
         return None
     raw = annotations.get(ANNOTATION_STATE_DIR_KEY)
     if not isinstance(raw, str) or not raw:
         return None
     path = Path(raw)
     if not path.is_absolute():
-        _log.warning(
-            "container %r carries a non-absolute state_dir annotation: %r",
-            head.get("Name") or head.get("Id") or "?",
-            raw,
-        )
+        _log.warning("container carries a non-absolute state_dir annotation: %r", raw)
         return None
     try:
         return path.resolve()
     except OSError as exc:
         _log.warning("failed to resolve state_dir annotation %r: %s", raw, exc)
+        return None
+
+
+def resolve_shield_version(container: str) -> int | None:
+    """Return the bundle version a container was prepared with, or ``None``.
+
+    Reads the ``terok.shield.version`` OCI annotation stamped by
+    [`Shield.pre_start`][terok_shield.Shield.pre_start].  ``None`` when the
+    container is absent, unshielded, or the annotation is missing / non-integer
+    — callers treat that as "cannot determine" and fall through rather than
+    block.  An orchestrator compares this against
+    [`BUNDLE_VERSION`][terok_shield.state.BUNDLE_VERSION] to refuse restarting a
+    container whose bundle predates the installed shield (fail-fast, re-create).
+    """
+    annotations = _annotations(_inspect_records(container))
+    if annotations is None:
+        return None
+    raw = annotations.get(ANNOTATION_VERSION_KEY)
+    if not isinstance(raw, str):
+        return None
+    try:
+        return int(raw)
+    except ValueError:
         return None

--- a/src/terok_shield/dns/dnsmasq.py
+++ b/src/terok_shield/dns/dnsmasq.py
@@ -45,6 +45,7 @@ def reload(
     upstream_dns: str,
     domains: list[str],
     deny_domains: Sequence[str] = (),
+    override_domains: Sequence[str] = (),
     *,
     container: str,
     runner: CommandRunner,
@@ -68,6 +69,8 @@ def reload(
         upstream_dns: Upstream DNS forwarder address.
         domains: Updated domain names for nftset auto-population.
         deny_domains: Denied domain names for DNS-plane NXDOMAIN sinkholes.
+        override_domains: t10 override domains — sinkhole punch-throughs
+            (see [`generate_config`][terok_shield.dns.dnsmasq.generate_config]).
         container: Container name — used to enter its netns for the relaunch.
         runner: Command runner that performs the in-netns relaunch.
 
@@ -102,6 +105,7 @@ def reload(
             listen_address=listen_address,
             log_path=log_path,
             deny_domains=deny_domains,
+            override_domains=override_domains,
         )
     )
 
@@ -165,6 +169,17 @@ def read_denied_domains(state_dir: Path) -> list[str]:
     return StateBundle(state_dir).read_effective().deny_domains()
 
 
+def read_override_domains(state_dir: Path) -> list[str]:
+    """Break-glass (t10) override domains from the composed policy bundle.
+
+    Fed to [`generate_config`][terok_shield.dns.dnsmasq.generate_config] as
+    sinkhole punch-throughs: an override host is usually *also* denied by
+    t20, and without the punch-through it would NXDOMAIN before its
+    statically seeded t10 set ever saw a packet.
+    """
+    return StateBundle(state_dir).read_effective().override_domains()
+
+
 # ── Container DNS setup ────────────────────────────────
 
 
@@ -179,6 +194,7 @@ def generate_config(
     listen_address: str,
     log_path: Path | None = None,
     deny_domains: Sequence[str] = (),
+    override_domains: Sequence[str] = (),
 ) -> str:
     """Generate a complete dnsmasq configuration.
 
@@ -201,6 +217,12 @@ def generate_config(
         deny_domains: Denied domains, sinkholed in the DNS plane (NXDOMAIN)
             so they fail fast and observably instead of resolving and then
             timing out against the packet filter.
+        override_domains: t10 break-glass override domains — treated as
+            allowed by the sinkhole generator (exact-name denies emit no
+            sinkhole, subdomain-of-denied-ancestor gets a punch-through)
+            without joining the ``--nftset`` population: the override's
+            addresses are statically seeded into the t10 set, the DNS plane
+            only has to keep the name resolvable.
 
     Raises:
         ValueError: If *upstream_dns* or *listen_address* is not a valid IP address.
@@ -226,7 +248,7 @@ def generate_config(
         except ValueError:
             logger.warning("generate_config: skipping invalid domain entry")
             continue
-    lines += deny_config_lines(domains, deny_domains, upstream_dns)
+    lines += deny_config_lines([*domains, *override_domains], deny_domains, upstream_dns)
     return "\n".join(lines) + "\n"
 
 

--- a/src/terok_shield/dns/dnsmasq.py
+++ b/src/terok_shield/dns/dnsmasq.py
@@ -44,9 +44,9 @@ def reload(
     state_dir: Path,
     upstream_dns: str,
     domains: list[str],
+    *,
     deny_domains: Sequence[str] = (),
     override_domains: Sequence[str] = (),
-    *,
     container: str,
     runner: CommandRunner,
 ) -> None:

--- a/src/terok_shield/hooks/mode.py
+++ b/src/terok_shield/hooks/mode.py
@@ -57,6 +57,7 @@ from ..nft.constants import (
 from ..nft.rules import (
     RulesetBuilder,
     add_deny_elements_dual,
+    add_override_elements_dual,
     delete_deny_elements_dual,
     parse_set_elements,
     restore_elements,
@@ -126,6 +127,8 @@ class HookMode:
         *,
         security_deny: Sequence[str] = (),
         provider_allow: Sequence[str] = (),
+        project_allow: Sequence[str] = (),
+        override: Sequence[str] = (),
     ) -> list[str]:
         """Prepare for container start in hook mode.
 
@@ -138,12 +141,21 @@ class HookMode:
                 projection, carried by sandbox) generates for the t20
                 security-deny tier — vault hosts denied direct egress.
             provider_allow: Hosts/IPs generated for the t30 provider-allow
-                tier — agent/provider egress endpoints.  Shield owns writing
-                these tiers so callers pass data, never touch the bundle.
+                tier — agent/provider egress endpoints.
+            project_allow: Hosts/IPs authored by the orchestrator for the t40
+                project-allow tier (git remote, custom domains) — merged with
+                the composed profiles.
+            override: Hosts/IPs authored for the t10 break-glass override tier,
+                which sits *above* the security-deny.  Single host/IP only (no
+                CIDR); statically resolved and seeded into a separate nft set.
+                Shield owns writing every tier, so callers pass data, never
+                touch the bundle.
 
         Raises:
             ShieldNeedsSetup: When global hooks are not installed
                 (see ``WORKAROUND(hooks-dir-persist)``).
+            ValueError: When an *override* entry is a CIDR/range (a break-glass
+                override must name one host, never widen access to a subnet).
         """
         sd = self._config.state_dir.resolve()
         info = self._get_podman_info()
@@ -165,9 +177,10 @@ class HookMode:
         # ``loopback.ports`` is persisted before ``_write_ruleset`` runs so
         # the builder reads ports from the bundle (SSOT): later up/down
         # rebuilds use the same source.
-        entries = self._profiles.compose_profiles(profiles)
-        self._write_generated_tiers(sd, security_deny, provider_allow)
+        entries = self._profiles.compose_profiles(profiles) + list(project_allow)
+        self._write_generated_tiers(sd, security_deny, provider_allow, override)
         self._write_policy_and_resolve(sd, entries, tier)
+        self._resolve_override(sd)
         StateBundle(sd).upstream_dns.write_text(f"{upstream_dns}\n")
         StateBundle(sd).dns_tier.write_text(f"{tier.value}\n")
         StateBundle(sd).loopback_ports.write_text(
@@ -231,22 +244,44 @@ class HookMode:
         return args
 
     def _write_generated_tiers(
-        self, sd: Path, security_deny: Sequence[str], provider_allow: Sequence[str]
+        self,
+        sd: Path,
+        security_deny: Sequence[str],
+        provider_allow: Sequence[str],
+        override: Sequence[str],
     ) -> None:
-        """Persist the caller-generated t20/t30 tiers into the policy bundle.
+        """Persist the caller-generated t20/t30/t10 tiers into the policy bundle.
 
-        These are the upstream-owned tiers Phase 1 left empty: t20 vault-host
-        denies and t30 provider-allow endpoints, projected by the executor
-        roster and handed in by sandbox.  Shield owns the on-disk layout, so
-        it renders the ``-``/``+`` policy lines and writes them here rather
-        than exposing the bundle;
-        [`EffectivePolicy`][terok_shield.state.EffectivePolicy] already
-        composes both tiers into resolution, dnsmasq domains, and the ruleset.
+        These are the orchestrator-owned tiers Phase 1 left empty: t20 vault-host
+        denies, t30 provider-allow endpoints, and t10 break-glass overrides.
+        Shield owns the on-disk layout, so it renders the ``-``/``+`` policy lines
+        and writes them here rather than exposing the bundle;
+        [`EffectivePolicy`][terok_shield.state.EffectivePolicy] already composes
+        every tier into resolution, dnsmasq domains, and the ruleset.
         Content-stable (empty input clears the tier).
         """
         bundle = StateBundle(sd)
         bundle.write_tier("security_deny", "".join(f"-{h}\n" for h in security_deny))
         bundle.write_tier("provider_allow", "".join(f"+{h}\n" for h in provider_allow))
+        bundle.write_tier("override", "".join(f"+{h}\n" for h in _validate_override(override)))
+
+    def _resolve_override(self, sd: Path) -> None:
+        """Statically resolve the t10 break-glass targets into the override seed cache.
+
+        The override tier is a *separate* above-deny nft set, resolved
+        independently of the allow tiers and statically on every DNS tier —
+        break-glass entries are rare and specific, and dnsmasq interception
+        would populate t40 (below the deny), defeating the override.  An empty
+        override clears the cache.
+        """
+        bundle = StateBundle(sd)
+        targets = bundle.read_effective().override_targets()
+        if not targets:
+            bundle.override_resolved.unlink(missing_ok=True)
+            return
+        self._dns.resolve_and_cache(
+            targets, bundle.override_resolved, source_mtime=bundle.policy_mtime()
+        )
 
     def _write_policy_and_resolve(self, sd: Path, entries: list[str], tier: DnsTier) -> None:
         """Write the composed profiles as the project-allow tier; statically resolve only where needed.
@@ -291,9 +326,12 @@ class HookMode:
             set_timeout=set_timeout,
         )
         ips = StateBundle(sd).read_effective_ips()
+        override_ips = list(StateBundle(sd).read_override_ips())
         denied_ips = list(StateBundle(sd).read_denied_ips())
         ruleset = ruleset_builder.build_hook()
         ruleset += ruleset_builder.add_elements_dual(ips)
+        if override_ips:
+            ruleset += add_override_elements_dual(override_ips)
         if denied_ips:
             ruleset += add_deny_elements_dual(denied_ips)
         StateBundle(sd).ruleset.write_text(ruleset)
@@ -796,6 +834,19 @@ class HookMode:
 
 
 # ── Module-level helpers ────────────────────────────────
+
+
+def _validate_override(override: Sequence[str]) -> list[str]:
+    """Return the override hosts, rejecting CIDR/range entries.
+
+    A t10 break-glass override sits above the security-deny tier, so widening
+    it to a subnet would punch a whole range straight through the firewall.
+    Each entry must name a single host or IP; a ``/`` (CIDR) is a caller
+    contract violation and fails the launch closed.
+    """
+    if bad := [h for h in override if "/" in h]:
+        raise ValueError(f"t10 override entries must be single hosts/IPs, not CIDR: {bad}")
+    return list(override)
 
 
 def _dnsmasq_bind(runtime: ShieldRuntime) -> str:

--- a/src/terok_shield/hooks/mode.py
+++ b/src/terok_shield/hooks/mode.py
@@ -22,7 +22,7 @@ Orchestrates collaborators per lifecycle phase:
 import ipaddress
 import logging
 import os
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -119,12 +119,27 @@ class HookMode:
 
     # ── Setup (pre_start) ───────────────────────────────
 
-    def pre_start(self, container: str, profiles: list[str]) -> list[str]:
+    def pre_start(
+        self,
+        container: str,
+        profiles: list[str],
+        *,
+        security_deny: Sequence[str] = (),
+        provider_allow: Sequence[str] = (),
+    ) -> list[str]:
         """Prepare for container start in hook mode.
 
         Installs hooks, composes profiles, resolves DNS, writes
         allowlist, detects DNS tier, sets annotations, and returns
         the podman CLI arguments needed for shield protection.
+
+        Args:
+            security_deny: Hosts/IPs an upstream layer (executor's roster
+                projection, carried by sandbox) generates for the t20
+                security-deny tier — vault hosts denied direct egress.
+            provider_allow: Hosts/IPs generated for the t30 provider-allow
+                tier — agent/provider egress endpoints.  Shield owns writing
+                these tiers so callers pass data, never touch the bundle.
 
         Raises:
             ShieldNeedsSetup: When global hooks are not installed
@@ -151,6 +166,7 @@ class HookMode:
         # the builder reads ports from the bundle (SSOT): later up/down
         # rebuilds use the same source.
         entries = self._profiles.compose_profiles(profiles)
+        self._write_generated_tiers(sd, security_deny, provider_allow)
         self._write_policy_and_resolve(sd, entries, tier)
         StateBundle(sd).upstream_dns.write_text(f"{upstream_dns}\n")
         StateBundle(sd).dns_tier.write_text(f"{tier.value}\n")
@@ -213,6 +229,24 @@ class HookMode:
             "NET_RAW",
         ]
         return args
+
+    def _write_generated_tiers(
+        self, sd: Path, security_deny: Sequence[str], provider_allow: Sequence[str]
+    ) -> None:
+        """Persist the caller-generated t20/t30 tiers into the policy bundle.
+
+        These are the upstream-owned tiers Phase 1 left empty: t20 vault-host
+        denies and t30 provider-allow endpoints, projected by the executor
+        roster and handed in by sandbox.  Shield owns the on-disk layout, so
+        it renders the ``-``/``+`` policy lines and writes them here rather
+        than exposing the bundle;
+        [`EffectivePolicy`][terok_shield.state.EffectivePolicy] already
+        composes both tiers into resolution, dnsmasq domains, and the ruleset.
+        Content-stable (empty input clears the tier).
+        """
+        bundle = StateBundle(sd)
+        bundle.write_tier("security_deny", "".join(f"-{h}\n" for h in security_deny))
+        bundle.write_tier("provider_allow", "".join(f"+{h}\n" for h in provider_allow))
 
     def _write_policy_and_resolve(self, sd: Path, entries: list[str], tier: DnsTier) -> None:
         """Write the composed profiles as the project-allow tier; statically resolve only where needed.

--- a/src/terok_shield/hooks/mode.py
+++ b/src/terok_shield/hooks/mode.py
@@ -173,22 +173,26 @@ class HookMode:
         upstream_dns = _upstream_dns_for_mode(mode)
         gw_v4, gw_v6 = self._gateways = _gateways_for_mode(mode)
 
-        # Resolve DNS, write allowlists, generate ruleset + dnsmasq config.
-        # ``loopback.ports`` is persisted before ``_write_ruleset`` runs so
-        # the builder reads ports from the bundle (SSOT): later up/down
-        # rebuilds use the same source.
-        entries = self._profiles.compose_profiles(profiles) + list(project_allow)
-        self._write_generated_tiers(sd, security_deny, provider_allow, override)
-        self._write_policy_and_resolve(sd, entries, tier)
-        self._resolve_override(sd)
-        self._resolve_security_deny(sd)
-        StateBundle(sd).upstream_dns.write_text(f"{upstream_dns}\n")
-        StateBundle(sd).dns_tier.write_text(f"{tier.value}\n")
-        StateBundle(sd).loopback_ports.write_text(
-            "".join(f"{p}\n" for p in self._config.loopback_ports)
+        # Persist the launch-detected facts first: they are what ``refresh``
+        # reuses instead of re-detecting, and ``_write_ruleset`` reads the
+        # ports back out of the bundle (SSOT) rather than off the config, so
+        # later up/down rebuilds share one source.
+        bundle = StateBundle(sd)
+        bundle.upstream_dns.write_text(f"{upstream_dns}\n")
+        bundle.dns_tier.write_text(f"{tier.value}\n")
+        bundle.network_mode.write_text(f"{mode}\n")
+        bundle.loopback_ports.write_text("".join(f"{p}\n" for p in self._config.loopback_ports))
+        self._author_policy(
+            sd,
+            profiles,
+            tier,
+            upstream_dns,
+            (gw_v4, gw_v6),
+            security_deny=security_deny,
+            provider_allow=provider_allow,
+            project_allow=project_allow,
+            override=override,
         )
-        self._write_ruleset(sd, tier, upstream_dns, gw_v4, gw_v6)
-        self._write_dnsmasq_config_or_scrub(sd, tier, upstream_dns)
 
         # Build podman args
         args = self._build_network_args(mode)
@@ -261,38 +265,69 @@ class HookMode:
         refreshes the static-resolution caches, and regenerates
         ``ruleset.nft`` + the dnsmasq config — so the OCI hook applies
         *current* policy at the next ``podman start`` instead of replaying
-        the bundle frozen at creation.  Deliberately reuses the persisted
-        DNS tier, upstream DNS, and loopback ports: the container's mounts
-        and annotations were built for those, and a fresh detection could
-        disagree with them.
+        the bundle frozen at creation.  Reuses every launch-detected fact the
+        bundle persisted — DNS tier, upstream DNS, network mode, loopback
+        ports — rather than re-detecting: the container's mounts and
+        annotations were built for those, a fresh detection could disagree
+        with them, and a restart stays free of ``podman info``.
 
         Raises:
             RuntimeError: When the bundle carries no persisted DNS tier /
-                upstream DNS (``pre_start`` never ran for this state dir).
+                upstream DNS / network mode (``pre_start`` never ran for this
+                state dir).
             ValueError: When an *override* entry is a CIDR/range (same
                 validation as ``pre_start``).
         """
         sd = self._config.state_dir.resolve()
-        tier_str = (
-            StateBundle(sd).dns_tier.read_text().strip()
-            if StateBundle(sd).dns_tier.is_file()
-            else ""
-        )
+        bundle = StateBundle(sd)
+        tier_str = bundle.dns_tier.read_text().strip() if bundle.dns_tier.is_file() else ""
+        mode = bundle.network_mode.read_text().strip() if bundle.network_mode.is_file() else ""
         upstream_dns = self._read_upstream_dns()
-        if not tier_str or not upstream_dns:
+        if not tier_str or not upstream_dns or not mode:
             raise RuntimeError(
-                "shield bundle has no persisted DNS tier / upstream DNS — "
+                "shield bundle has no persisted DNS tier / upstream DNS / network mode — "
                 "pre_start never completed for this container; re-create the task"
             )
-        tier = DnsTier(tier_str)
+        self._gateways = _gateways_for_mode(mode)
+        self._author_policy(
+            sd,
+            profiles,
+            DnsTier(tier_str),
+            upstream_dns,
+            self._gateways,
+            security_deny=security_deny,
+            provider_allow=provider_allow,
+            project_allow=project_allow,
+            override=override,
+        )
+
+    def _author_policy(
+        self,
+        sd: Path,
+        profiles: list[str],
+        tier: DnsTier,
+        upstream_dns: str,
+        gateways: tuple[str, str],
+        *,
+        security_deny: Sequence[str],
+        provider_allow: Sequence[str],
+        project_allow: Sequence[str],
+        override: Sequence[str],
+    ) -> None:
+        """Write every tier, refresh the seed caches, regenerate the artifacts.
+
+        The half of [`pre_start`][terok_shield.hooks.mode.HookMode.pre_start]
+        that [`refresh`][terok_shield.hooks.mode.HookMode.refresh] repeats.  A
+        launch and a plain restart must derive the *same* bundle from the same
+        tier data, so a new tier or a new resolution step belongs here — where
+        neither path can miss it.
+        """
         entries = self._profiles.compose_profiles(profiles) + list(project_allow)
         self._write_generated_tiers(sd, security_deny, provider_allow, override)
         self._write_policy_and_resolve(sd, entries, tier)
         self._resolve_override(sd)
         self._resolve_security_deny(sd)
-        mode = self._get_podman_info().network_mode or "pasta"
-        gw_v4, gw_v6 = self._gateways = _gateways_for_mode(mode)
-        self._write_ruleset(sd, tier, upstream_dns, gw_v4, gw_v6)
+        self._write_ruleset(sd, tier, upstream_dns, *gateways)
         self._write_dnsmasq_config_or_scrub(sd, tier, upstream_dns)
 
     def _write_generated_tiers(
@@ -323,16 +358,11 @@ class HookMode:
         The override tier is a *separate* above-deny nft set, resolved
         independently of the allow tiers and statically on every DNS tier —
         break-glass entries are rare and specific, and dnsmasq interception
-        would populate t40 (below the deny), defeating the override.  An empty
-        override clears the cache.
+        would populate t40 (below the deny), defeating the override.
         """
         bundle = StateBundle(sd)
-        targets = bundle.read_effective().override_targets()
-        if not targets:
-            bundle.override_resolved.unlink(missing_ok=True)
-            return
-        self._dns.resolve_and_cache(
-            targets, bundle.override_resolved, source_mtime=bundle.policy_mtime()
+        self._resolve_tier(
+            bundle, bundle.read_effective().override_targets(), bundle.override_resolved
         )
 
     def _resolve_security_deny(self, sd: Path) -> None:
@@ -344,16 +374,17 @@ class HookMode:
         and an address-level deny also catches direct-IP access that never
         consults the DNS plane.  Resolved statically on every DNS tier —
         dnsmasq interception only ever *adds* to allow sets, so it can play
-        no part in populating a deny.  An empty deny tier clears the cache.
+        no part in populating a deny.
         """
         bundle = StateBundle(sd)
-        targets = bundle.read_effective().deny_targets()
+        self._resolve_tier(bundle, bundle.read_effective().deny_targets(), bundle.deny_resolved)
+
+    def _resolve_tier(self, bundle: StateBundle, targets: list[str], cache: Path) -> None:
+        """Refresh one tier's static-resolution cache; an empty tier clears it."""
         if not targets:
-            bundle.deny_resolved.unlink(missing_ok=True)
+            cache.unlink(missing_ok=True)
             return
-        self._dns.resolve_and_cache(
-            targets, bundle.deny_resolved, source_mtime=bundle.policy_mtime()
-        )
+        self._dns.resolve_and_cache(targets, cache, source_mtime=bundle.policy_mtime())
 
     def _write_policy_and_resolve(self, sd: Path, entries: list[str], tier: DnsTier) -> None:
         """Write the composed profiles as the project-allow tier; statically resolve only where needed.
@@ -526,8 +557,8 @@ class HookMode:
             state_dir,
             upstream,
             domains,
-            dnsmasq.read_denied_domains(state_dir),
-            dnsmasq.read_override_domains(state_dir),
+            deny_domains=dnsmasq.read_denied_domains(state_dir),
+            override_domains=dnsmasq.read_override_domains(state_dir),
             container=container,
             runner=self._runner,
         )

--- a/src/terok_shield/hooks/mode.py
+++ b/src/terok_shield/hooks/mode.py
@@ -181,6 +181,7 @@ class HookMode:
         self._write_generated_tiers(sd, security_deny, provider_allow, override)
         self._write_policy_and_resolve(sd, entries, tier)
         self._resolve_override(sd)
+        self._resolve_security_deny(sd)
         StateBundle(sd).upstream_dns.write_text(f"{upstream_dns}\n")
         StateBundle(sd).dns_tier.write_text(f"{tier.value}\n")
         StateBundle(sd).loopback_ports.write_text(
@@ -243,6 +244,57 @@ class HookMode:
         ]
         return args
 
+    def refresh(
+        self,
+        profiles: list[str],
+        *,
+        security_deny: Sequence[str] = (),
+        provider_allow: Sequence[str] = (),
+        project_allow: Sequence[str] = (),
+        override: Sequence[str] = (),
+    ) -> None:
+        """Recompute an existing container's policy bundle before a plain restart.
+
+        The policy-authoring half of
+        [`pre_start`][terok_shield.hooks.mode.HookMode.pre_start] without the
+        launch half: rewrites every tier from the caller's current data,
+        refreshes the static-resolution caches, and regenerates
+        ``ruleset.nft`` + the dnsmasq config — so the OCI hook applies
+        *current* policy at the next ``podman start`` instead of replaying
+        the bundle frozen at creation.  Deliberately reuses the persisted
+        DNS tier, upstream DNS, and loopback ports: the container's mounts
+        and annotations were built for those, and a fresh detection could
+        disagree with them.
+
+        Raises:
+            RuntimeError: When the bundle carries no persisted DNS tier /
+                upstream DNS (``pre_start`` never ran for this state dir).
+            ValueError: When an *override* entry is a CIDR/range (same
+                validation as ``pre_start``).
+        """
+        sd = self._config.state_dir.resolve()
+        tier_str = (
+            StateBundle(sd).dns_tier.read_text().strip()
+            if StateBundle(sd).dns_tier.is_file()
+            else ""
+        )
+        upstream_dns = self._read_upstream_dns()
+        if not tier_str or not upstream_dns:
+            raise RuntimeError(
+                "shield bundle has no persisted DNS tier / upstream DNS — "
+                "pre_start never completed for this container; re-create the task"
+            )
+        tier = DnsTier(tier_str)
+        entries = self._profiles.compose_profiles(profiles) + list(project_allow)
+        self._write_generated_tiers(sd, security_deny, provider_allow, override)
+        self._write_policy_and_resolve(sd, entries, tier)
+        self._resolve_override(sd)
+        self._resolve_security_deny(sd)
+        mode = self._get_podman_info().network_mode or "pasta"
+        gw_v4, gw_v6 = self._gateways = _gateways_for_mode(mode)
+        self._write_ruleset(sd, tier, upstream_dns, gw_v4, gw_v6)
+        self._write_dnsmasq_config_or_scrub(sd, tier, upstream_dns)
+
     def _write_generated_tiers(
         self,
         sd: Path,
@@ -281,6 +333,26 @@ class HookMode:
             return
         self._dns.resolve_and_cache(
             targets, bundle.override_resolved, source_mtime=bundle.policy_mtime()
+        )
+
+    def _resolve_security_deny(self, sd: Path) -> None:
+        """Statically resolve the t20 security-deny targets into the deny seed cache.
+
+        Denied domains must deny by *address*: the deny set is enforced even
+        in the shield-down posture (bypass repopulates it from
+        [`read_denied_ips`][terok_shield.state.StateBundle.read_denied_ips]),
+        and an address-level deny also catches direct-IP access that never
+        consults the DNS plane.  Resolved statically on every DNS tier —
+        dnsmasq interception only ever *adds* to allow sets, so it can play
+        no part in populating a deny.  An empty deny tier clears the cache.
+        """
+        bundle = StateBundle(sd)
+        targets = bundle.read_effective().deny_targets()
+        if not targets:
+            bundle.deny_resolved.unlink(missing_ok=True)
+            return
+        self._dns.resolve_and_cache(
+            targets, bundle.deny_resolved, source_mtime=bundle.policy_mtime()
         )
 
     def _write_policy_and_resolve(self, sd: Path, entries: list[str], tier: DnsTier) -> None:
@@ -348,6 +420,7 @@ class HookMode:
                 listen_address=bind,
                 log_path=StateBundle(sd).dnsmasq_log,
                 deny_domains=dnsmasq.read_denied_domains(sd),
+                override_domains=dnsmasq.read_override_domains(sd),
             )
             StateBundle(sd).dnsmasq_conf.write_text(conf)
             StateBundle(sd).resolv_conf.write_text(f"nameserver {bind}\noptions ndots:0\n")
@@ -454,6 +527,7 @@ class HookMode:
             upstream,
             domains,
             dnsmasq.read_denied_domains(state_dir),
+            dnsmasq.read_override_domains(state_dir),
             container=container,
             runner=self._runner,
         )
@@ -564,12 +638,9 @@ class HookMode:
         # forget every learned IP after one down/up round trip.
         self._restore_allow_sets(container, snapshot, skip=())
 
-        # Repopulate deny sets so deny.list is enforced even when shield is down.
-        denied_ips = list(StateBundle(sd).read_denied_ips())
-        if denied_ips:
-            deny_cmd = add_deny_elements_dual(denied_ips)
-            if deny_cmd:
-                self._runner.nft_via_nsenter(container, stdin=deny_cmd)
+        # Repopulate deny sets so the deny policy is enforced even when shield
+        # is down, and the t10 override set so break-glass hosts stay above it.
+        self._reseed_deny_and_override(container, sd)
 
         output = self._runner.nft_via_nsenter(
             container,
@@ -634,12 +705,8 @@ class HookMode:
             if elements_cmd:
                 self._runner.nft_via_nsenter(container, stdin=elements_cmd)
 
-        # Repopulate deny sets from deny.list
-        denied_ips = list(StateBundle(sd).read_denied_ips())
-        if denied_ips:
-            deny_cmd = add_deny_elements_dual(denied_ips)
-            if deny_cmd:
-                self._runner.nft_via_nsenter(container, stdin=deny_cmd)
+        # Repopulate the deny sets and the t10 override set from the bundle
+        denied_ips = self._reseed_deny_and_override(container, sd)
 
         # Restore the snapshot, minus everything the rebuild already re-added
         # (a duplicate/overlapping element would abort the nft transaction)
@@ -678,6 +745,24 @@ class HookMode:
         stdin += ruleset.add_elements_dual(StateBundle(sd).read_effective_ips())
         self._runner.nft_via_nsenter(container, stdin=stdin)
 
+    def _reseed_deny_and_override(self, container: str, sd: Path) -> list[str]:
+        """Repopulate the t20 deny and t10 override sets after a table rebuild.
+
+        Both sets seed purely from the bundle (literals + static-resolution
+        caches), so unlike the dnsmasq-learned t40 they need no snapshot —
+        every ``shield down``/``up`` rebuild re-derives them.  The override
+        is re-seeded in *both* postures: it sits above the deny, and the
+        deny is enforced even when the shield is down.  Returns the denied
+        IPs so ``shield_up`` can exclude them from the snapshot restore.
+        """
+        denied_ips = list(StateBundle(sd).read_denied_ips())
+        if denied_ips and (deny_cmd := add_deny_elements_dual(denied_ips)):
+            self._runner.nft_via_nsenter(container, stdin=deny_cmd)
+        override_ips = list(StateBundle(sd).read_override_ips())
+        if override_ips and (override_cmd := add_override_elements_dual(override_ips)):
+            self._runner.nft_via_nsenter(container, stdin=override_cmd)
+        return denied_ips
+
     # ── Allow-set snapshot/restore (down/up round trips) ─
 
     def _snapshot_allow_sets(self, container: str) -> list[tuple[str, str, str]]:
@@ -685,8 +770,10 @@ class HookMode:
 
         Captures seeds and dnsmasq-learned elements right before a table
         rebuild.  A missing table or set yields no rows — there was nothing
-        to keep.  (Tiers 10/30 have no runtime population yet; extend this
-        snapshot when they gain one.)
+        to keep.  (Tiers 10/20 are re-seeded from the bundle by
+        ``_reseed_deny_and_override`` instead — they have no *learned*
+        state to preserve.  Tier 30 has no runtime population yet; extend
+        this snapshot when it gains one.)
         """
         rows: list[tuple[str, str, str]] = []
         for fam in ("v4", "v6"):

--- a/src/terok_shield/nft/constants.py
+++ b/src/terok_shield/nft/constants.py
@@ -38,6 +38,13 @@ PASTA_HOST_LOOPBACK_MAP = "169.254.1.2"
 HARD_DENY_RANGES: tuple[str, ...] = (
     "169.254.0.0/16",  # RFC 3927 IPv4 link-local — includes cloud-metadata IMDS  # NOSONAR
     "fe80::/10",  # RFC 4291 IPv6 link-local
+    # AWS IMDS IPv6 endpoint.  Pinned here even though it falls inside ULA
+    # fc00::/7: the ULA reject lives in PRIVATE_RANGES, *below* the override
+    # tier, so without this entry an operator override carving out ULA space
+    # could reach the v6 metadata service — the absolute-IMDS guarantee
+    # would be v4-only.  Bare address (no /128): nft strips a /128 prefix
+    # when listing, so the verifier's literal round-trip needs the bare form.
+    "fd00:ec2::254",
 )
 
 # PRIVATE_RANGES — RFC 1918 + RFC 4193 (ULA): the private LAN.  Denied by

--- a/src/terok_shield/nft/constants.py
+++ b/src/terok_shield/nft/constants.py
@@ -44,7 +44,7 @@ HARD_DENY_RANGES: tuple[str, ...] = (
     # could reach the v6 metadata service — the absolute-IMDS guarantee
     # would be v4-only.  Bare address (no /128): nft strips a /128 prefix
     # when listing, so the verifier's literal round-trip needs the bare form.
-    "fd00:ec2::254",
+    "fd00:ec2::254",  # AWS IMDS IPv6 endpoint  # NOSONAR
 )
 
 # PRIVATE_RANGES — RFC 1918 + RFC 4193 (ULA): the private LAN.  Denied by

--- a/src/terok_shield/nft/rules.py
+++ b/src/terok_shield/nft/rules.py
@@ -157,7 +157,9 @@ class RulesetBuilder:
 
         Output policy is ``accept``, but the hard-deny floor and the
         security-deny tier (deny set + private ranges) are still enforced, and
-        every new connection is logged with the bypass prefix.
+        every new connection is logged with the bypass prefix.  The t10
+        override keeps its place *above* the deny — a break-glass host must
+        stay reachable in every posture that enforces the deny.
 
         Args:
             allow_all: If True (DISENGAGED), drop the hard-deny and private-range
@@ -166,6 +168,7 @@ class RulesetBuilder:
         sections = [self._preamble_lines()]
         if not allow_all:
             sections.append(self._range_reject(HARD_DENY_RANGES, PRIVATE_LOG_PREFIX))
+        sections.append(self._match(TIER_OVERRIDE, "accept"))
         sections.append(self._match(TIER_SECURITY_DENY, _REJECT, DENIED_LOG_PREFIX))
         if not allow_all:
             sections.append(self._range_reject(PRIVATE_RANGES, PRIVATE_LOG_PREFIX))

--- a/src/terok_shield/nft/rules.py
+++ b/src/terok_shield/nft/rules.py
@@ -142,7 +142,7 @@ class RulesetBuilder:
         body = self._join(
             self._preamble_lines(),
             self._range_reject(HARD_DENY_RANGES, PRIVATE_LOG_PREFIX),  # t00 absolute
-            self._match(TIER_OVERRIDE, "accept"),  # t10 break-glass
+            self._match(TIER_OVERRIDE, "accept", ALLOWED_LOG_PREFIX),  # t10 break-glass
             self._match(TIER_SECURITY_DENY, _REJECT, DENIED_LOG_PREFIX),  # t20 deny set
             self._range_reject(PRIVATE_RANGES, PRIVATE_LOG_PREFIX),  # t20 RFC1918
             self._match(TIER_PROVIDER_ALLOW, "accept", ALLOWED_LOG_PREFIX),  # t30 provider
@@ -168,7 +168,7 @@ class RulesetBuilder:
         sections = [self._preamble_lines()]
         if not allow_all:
             sections.append(self._range_reject(HARD_DENY_RANGES, PRIVATE_LOG_PREFIX))
-        sections.append(self._match(TIER_OVERRIDE, "accept"))
+        sections.append(self._match(TIER_OVERRIDE, "accept", BYPASS_LOG_PREFIX))
         sections.append(self._match(TIER_SECURITY_DENY, _REJECT, DENIED_LOG_PREFIX))
         if not allow_all:
             sections.append(self._range_reject(PRIVATE_RANGES, PRIVATE_LOG_PREFIX))

--- a/src/terok_shield/resources/_oci_state.py
+++ b/src/terok_shield/resources/_oci_state.py
@@ -41,7 +41,7 @@ ANN_STATE_DIR = "terok.shield.state_dir"
 ANN_VERSION = "terok.shield.version"
 """OCI annotation carrying the bundle version this container was prepared with."""
 
-BUNDLE_VERSION = 15
+BUNDLE_VERSION = 16
 """Wire-protocol version for the hook ↔ pre_start state-bundle contract.
 
 Bumped whenever the on-disk file layout, the hook → reader argv

--- a/src/terok_shield/state.py
+++ b/src/terok_shield/state.py
@@ -168,6 +168,17 @@ class EffectivePolicy:
         """Admitted domains + literal IPs to resolve (``localhost`` excluded) — the resolver input."""
         return _dedup([e.target for e in self._allows() if e.target != LOCALHOST])
 
+    def override_targets(self) -> list[str]:
+        """Break-glass override domains + literal IPs to resolve (``localhost`` excluded).
+
+        The t10 override is a *separate* above-deny nft set (see
+        [`_allows`][terok_shield.state.EffectivePolicy._allows]), so it is
+        resolved and seeded independently of the allow tiers.
+        """
+        return _dedup(
+            [e.target for e in self.override if e.action == "+" and e.target != LOCALHOST]
+        )
+
 
 STATE_DIR_MODE = 0o700
 """Permission mode for ``state_dir`` and its subdirectories.
@@ -280,6 +291,18 @@ class StateBundle:
         [`policy_mtime`][terok_shield.state.StateBundle.policy_mtime].
         """
         return self.state_dir / "resolved.ips"
+
+    @property
+    def override_resolved(self) -> Path:
+        """Derived per-container cache of resolved override IPs (the t10 set seed).
+
+        The t10 override sits *above* the security-deny tier and is a separate
+        nft set, so it is resolved and cached apart from the allow tiers.
+        Statically resolved at pre_start — break-glass entries are rare and
+        specific, and dnsmasq interception would populate t40 (below the deny),
+        defeating the override.
+        """
+        return self.state_dir / "override_resolved.ips"
 
     def policy_mtime(self) -> float:
         """Newest mtime among the policy files (``0.0`` when none exist yet).
@@ -409,6 +432,27 @@ class StateBundle:
         )
         seed = [ip for ip in cached if ip not in denied]
         return _dedup(seed + eff.effective_ips())
+
+    def read_override_ips(self) -> list[str]:
+        """The tier-10 override set seed: literal override IPs + resolved override domains.
+
+        Unions the current literal ``+`` override IPs with the statically
+        resolved [`override_resolved`][terok_shield.state.StateBundle.override_resolved]
+        cache.  Denies are *not* subtracted — the whole point of an override is
+        to sit above the security-deny tier.
+        """
+        eff = self.read_effective()
+        literal = ip_targets([e for e in eff.override if e.action == "+"])
+        cached = (
+            [
+                line.strip()
+                for line in self.override_resolved.read_text().splitlines()
+                if line.strip()
+            ]
+            if self.override_resolved.is_file()
+            else []
+        )
+        return _dedup(literal + cached)
 
     # ── Setup ──────────────────────────────────────────────
 

--- a/src/terok_shield/state.py
+++ b/src/terok_shield/state.py
@@ -23,6 +23,8 @@ Bundle layout::
     │   ├── 40-project-allow           #   → t40_project_allow
     │   └── live                       #   runtime overlay (folded into its tiers)
     ├── resolved.ips                   # derived: resolved allow IPs (t40 set seed)
+    ├── override_resolved.ips          # derived: resolved t10 override IPs (above-deny seed)
+    ├── deny_resolved.ips              # derived: resolved t20 security-deny IPs (deny seed)
     ├── ruleset.nft                    # pre-generated nft ruleset (gateways baked in)
     ├── upstream.dns                   # upstream DNS address
     ├── dns.tier                       # active DNS tier (dig/getent/dnsmasq)
@@ -73,9 +75,11 @@ stale on-disk entrypoint — bump it whenever the entrypoint *protocol*
 changes even if the file layout itself is unchanged, so that
 ``terok setup`` rewrites the script instead of short-circuiting.
 
-Current shape (v16): v15 plus the derived ``deny_resolved.ips`` cache —
-the statically resolved t20 security-deny seed, which the deny set is
-repopulated from on every ``shield down``/``up`` rebuild.  (v15
+Current shape (v16): v15 plus two derived seed caches —
+``override_resolved.ips`` (t10 break-glass) and ``deny_resolved.ips``
+(t20 security-deny).  Both tiers are now statically resolved, so each is
+repopulated *by address* on every ``shield down``/``up`` rebuild instead
+of depending on the DNS plane to re-learn it.  (v15
 replaced the six v14 split allow/deny files with the tiered ``policy/``
 bundle of unified ``+``/``-`` files plus the derived ``resolved.ips``
 cache.)  Earlier shapes are recoverable via

--- a/src/terok_shield/state.py
+++ b/src/terok_shield/state.py
@@ -28,6 +28,7 @@ Bundle layout::
     ├── ruleset.nft                    # pre-generated nft ruleset (gateways baked in)
     ├── upstream.dns                   # upstream DNS address
     ├── dns.tier                       # active DNS tier (dig/getent/dnsmasq)
+    ├── network.mode                   # rootless network mode (pasta/slirp4netns)
     ├── loopback.ports                 # per-container host-loopback TCP ports (newline-separated)
     ├── dnsmasq.conf                   # generated dnsmasq configuration
     ├── dnsmasq.pid                    # dnsmasq PID (in container netns)
@@ -59,6 +60,13 @@ from .policy import (
 def _dedup(items: list[str]) -> list[str]:
     """Deduplicate preserving first-seen order."""
     return list(dict.fromkeys(items))
+
+
+def _read_cached_ips(cache: Path) -> list[str]:
+    """Non-blank lines of a derived resolution cache; an absent cache is empty."""
+    if not cache.is_file():
+        return []
+    return [line.strip() for line in cache.read_text().splitlines() if line.strip()]
 
 
 BUNDLE_VERSION = 16
@@ -269,6 +277,17 @@ class StateBundle:
         return self.state_dir / "dns.tier"
 
     @property
+    def network_mode(self) -> Path:
+        """Path to the persisted rootless network mode (``pasta``/``slirp4netns``).
+
+        Detected once at ``pre_start`` and read back by ``HookMode.refresh``,
+        which derives the ruleset's gateway addresses from it — a restart
+        rebuilds the bundle without paying for a ``podman info`` probe, and
+        cannot pick a mode the running container was not launched with.
+        """
+        return self.state_dir / "network.mode"
+
+    @property
     def loopback_ports(self) -> Path:
         """Path to the per-container host-loopback TCP ports list.
 
@@ -459,12 +478,7 @@ class StateBundle:
         from — a denied *domain* must keep denying by address across every
         rebuild, or the bypass posture would silently un-deny it.
         """
-        cached = (
-            [line.strip() for line in self.deny_resolved.read_text().splitlines() if line.strip()]
-            if self.deny_resolved.is_file()
-            else []
-        )
-        return set(self.read_effective().deny_ips()) | set(cached)
+        return set(self.read_effective().deny_ips()) | set(_read_cached_ips(self.deny_resolved))
 
     def read_effective_ips(self) -> list[str]:
         """The tier-40 project-allow set seed: resolved allow IPs minus denied.
@@ -477,12 +491,7 @@ class StateBundle:
         """
         eff = self.read_effective()
         denied = set(eff.deny_ips())
-        cached = (
-            [line.strip() for line in self.resolved_cache.read_text().splitlines() if line.strip()]
-            if self.resolved_cache.is_file()
-            else []
-        )
-        seed = [ip for ip in cached if ip not in denied]
+        seed = [ip for ip in _read_cached_ips(self.resolved_cache) if ip not in denied]
         return _dedup(seed + eff.effective_ips())
 
     def read_override_ips(self) -> list[str]:
@@ -495,16 +504,7 @@ class StateBundle:
         """
         eff = self.read_effective()
         literal = ip_targets([e for e in eff.override if e.action == "+"])
-        cached = (
-            [
-                line.strip()
-                for line in self.override_resolved.read_text().splitlines()
-                if line.strip()
-            ]
-            if self.override_resolved.is_file()
-            else []
-        )
-        return _dedup(literal + cached)
+        return _dedup(literal + _read_cached_ips(self.override_resolved))
 
     # ── Setup ──────────────────────────────────────────────
 

--- a/src/terok_shield/state.py
+++ b/src/terok_shield/state.py
@@ -182,9 +182,10 @@ class EffectivePolicy:
     def override_targets(self) -> list[str]:
         """Break-glass override domains + literal IPs to resolve (``localhost`` excluded).
 
-        The t10 override is a *separate* above-deny nft set (see
-        [`_allows`][terok_shield.state.EffectivePolicy._allows]), so it is
-        resolved and seeded independently of the allow tiers.
+        The t10 override is a *separate* above-deny nft set — not part of the
+        ordinary allow tiers
+        ([`allow_targets`][terok_shield.state.EffectivePolicy.allow_targets]),
+        so it is resolved and seeded independently.
         """
         return _dedup(
             [e.target for e in self.override if e.action == "+" and e.target != LOCALHOST]

--- a/src/terok_shield/state.py
+++ b/src/terok_shield/state.py
@@ -59,7 +59,7 @@ def _dedup(items: list[str]) -> list[str]:
     return list(dict.fromkeys(items))
 
 
-BUNDLE_VERSION = 15
+BUNDLE_VERSION = 16
 """Integer version of the state bundle layout.
 
 Bumped whenever the file layout changes in a backwards-incompatible way.
@@ -73,11 +73,12 @@ stale on-disk entrypoint — bump it whenever the entrypoint *protocol*
 changes even if the file layout itself is unchanged, so that
 ``terok setup`` rewrites the script instead of short-circuiting.
 
-Current shape (v15): the six v14 split allow/deny files
-(``profile.allowed``/``.domains``, ``live.allowed``/``.domains``,
-``deny.list``, ``denied.domains``) are replaced by the tiered ``policy/``
+Current shape (v16): v15 plus the derived ``deny_resolved.ips`` cache —
+the statically resolved t20 security-deny seed, which the deny set is
+repopulated from on every ``shield down``/``up`` rebuild.  (v15
+replaced the six v14 split allow/deny files with the tiered ``policy/``
 bundle of unified ``+``/``-`` files plus the derived ``resolved.ips``
-cache.  Earlier shapes are recoverable via
+cache.)  Earlier shapes are recoverable via
 ``git log -L /^BUNDLE_VERSION/:src/terok_shield/state.py``.
 """
 
@@ -156,8 +157,18 @@ class EffectivePolicy:
         return [d for d in self.allow_domains() if d not in denied]
 
     def deny_ips(self) -> list[str]:
-        """IPs to load into the tier-20 security-deny set."""
+        """Literal denied IPs — the non-resolved part of the tier-20 set seed."""
         return _dedup(ip_targets(self._denies()))
+
+    def deny_targets(self) -> list[str]:
+        """Denied domains + literal IPs to resolve (``localhost`` excluded) — the deny-resolver input.
+
+        The t20 security-deny must hold *addresses* to survive a
+        ``shield down`` rebuild and to catch direct-IP access that never
+        touches the DNS plane, so its domains are statically resolved into
+        [`deny_resolved`][terok_shield.state.StateBundle.deny_resolved]
+        (mirroring the t10 override treatment)."""
+        return _dedup([e.target for e in self._denies() if e.target != LOCALHOST])
 
     def effective_ips(self) -> list[str]:
         """Admitted literal IPs minus denied (the non-resolved part of the set seed)."""
@@ -178,6 +189,16 @@ class EffectivePolicy:
         return _dedup(
             [e.target for e in self.override if e.action == "+" and e.target != LOCALHOST]
         )
+
+    def override_domains(self) -> list[str]:
+        """Break-glass override domains — the DNS-plane punch-through set.
+
+        A t10 override host is usually *also* denied by t20 (that is the
+        point of an override), so the dnsmasq sinkhole generator must treat
+        these names as allowed — otherwise the override host would NXDOMAIN
+        and the statically seeded t10 set would never see a connection.
+        """
+        return _dedup(domain_targets([e for e in self.override if e.action == "+"]))
 
 
 STATE_DIR_MODE = 0o700
@@ -304,6 +325,19 @@ class StateBundle:
         """
         return self.state_dir / "override_resolved.ips"
 
+    @property
+    def deny_resolved(self) -> Path:
+        """Derived per-container cache of resolved security-deny IPs (the t20 set seed).
+
+        Denied domains must reach the packet filter as addresses: the deny
+        set is what survives a ``shield down`` (bypass keeps enforcing it),
+        and an address-level deny also catches direct-IP access that never
+        consults the DNS plane.  Statically resolved at pre_start on every
+        DNS tier, cached apart from the allow-side ``resolved.ips`` so the
+        two invalidate independently.
+        """
+        return self.state_dir / "deny_resolved.ips"
+
     def policy_mtime(self) -> float:
         """Newest mtime among the policy files (``0.0`` when none exist yet).
 
@@ -411,8 +445,21 @@ class StateBundle:
     # ── State readers ──────────────────────────────────────
 
     def read_denied_ips(self) -> set[str]:
-        """Refused IPs composed from the security-deny tier + the runtime overlay."""
-        return set(self.read_effective().deny_ips())
+        """The tier-20 security-deny set seed: literal denied IPs + resolved denied domains.
+
+        Unions the current literal ``-`` IPs (security-deny tier + runtime
+        overlay) with the statically resolved
+        [`deny_resolved`][terok_shield.state.StateBundle.deny_resolved]
+        cache.  This is what ``shield down``/``up`` repopulate the deny set
+        from — a denied *domain* must keep denying by address across every
+        rebuild, or the bypass posture would silently un-deny it.
+        """
+        cached = (
+            [line.strip() for line in self.deny_resolved.read_text().splitlines() if line.strip()]
+            if self.deny_resolved.is_file()
+            else []
+        )
+        return set(self.read_effective().deny_ips()) | set(cached)
 
     def read_effective_ips(self) -> list[str]:
         """The tier-40 project-allow set seed: resolved allow IPs minus denied.

--- a/tests/testnet.py
+++ b/tests/testnet.py
@@ -150,6 +150,9 @@ EXPECTED_PRIVATE_RANGES: tuple[str, ...] = (
     "fc00::/7",
     "fe80::/10",
 )
+# ── Cloud metadata (IMDS) endpoints — the absolute hard-deny floor ──
+AWS_IMDS_V6 = "fd00:ec2::254"  # AWS IPv6 metadata endpoint (ULA space)
+
 # ── Normalization test pairs (non-canonical → canonical) ──
 
 IPV6_VERBOSE = "2001:0db8:0000:0000:0000:0000:0000:0001"  # Verbose IPv6 form

--- a/tests/unit/test_container_resolver.py
+++ b/tests/unit/test_container_resolver.py
@@ -89,8 +89,8 @@ class TestResolveStateDir:
                 assert resolver.resolve_state_dir("ctr") is None
 
 
-class TestExtractStateDir:
-    """Hardening: each type-check branch of ``_extract_state_dir`` hits ``None``.
+class TestAnnotations:
+    """Hardening: each type-check branch of ``_annotations`` hits ``None``.
 
     These are the tiny shape-guards that keep the resolver robust against
     a future podman release changing its JSON contract — each deserves a
@@ -98,10 +98,38 @@ class TestExtractStateDir:
     """
 
     def test_head_is_not_dict(self) -> None:
-        assert resolver._extract_state_dir([["not", "a", "dict"]]) is None
+        assert resolver._annotations([["not", "a", "dict"]]) is None
 
     def test_config_is_not_dict(self) -> None:
-        assert resolver._extract_state_dir([{"Config": "not-a-dict"}]) is None
+        assert resolver._annotations([{"Config": "not-a-dict"}]) is None
 
     def test_annotations_is_not_dict(self) -> None:
-        assert resolver._extract_state_dir([{"Config": {"Annotations": "not-a-dict"}}]) is None
+        assert resolver._annotations([{"Config": {"Annotations": "not-a-dict"}}]) is None
+
+
+class TestResolveShieldVersion:
+    """``resolve_shield_version`` reads the ``terok.shield.version`` annotation."""
+
+    def test_returns_version_int(self) -> None:
+        with mock.patch.object(resolver.shutil, "which", return_value="/usr/bin/podman"):
+            out = _fake_inspect_output({"terok.shield.version": "15"})
+            with mock.patch.object(
+                resolver.subprocess, "run", return_value=mock.MagicMock(returncode=0, stdout=out)
+            ):
+                assert resolver.resolve_shield_version("ctr") == 15
+
+    def test_missing_annotation_is_none(self) -> None:
+        with mock.patch.object(resolver.shutil, "which", return_value="/usr/bin/podman"):
+            out = _fake_inspect_output({})
+            with mock.patch.object(
+                resolver.subprocess, "run", return_value=mock.MagicMock(returncode=0, stdout=out)
+            ):
+                assert resolver.resolve_shield_version("ctr") is None
+
+    def test_non_integer_annotation_is_none(self) -> None:
+        with mock.patch.object(resolver.shutil, "which", return_value="/usr/bin/podman"):
+            out = _fake_inspect_output({"terok.shield.version": "v15"})
+            with mock.patch.object(
+                resolver.subprocess, "run", return_value=mock.MagicMock(returncode=0, stdout=out)
+            ):
+                assert resolver.resolve_shield_version("ctr") is None

--- a/tests/unit/test_container_resolver.py
+++ b/tests/unit/test_container_resolver.py
@@ -118,6 +118,11 @@ class TestResolveShieldVersion:
             ):
                 assert resolver.resolve_shield_version("ctr") == 15
 
+    def test_absent_container_is_none(self) -> None:
+        """No podman (or no inspect record) → "cannot determine", never a crash."""
+        with mock.patch.object(resolver.shutil, "which", return_value=None):
+            assert resolver.resolve_shield_version("ctr") is None
+
     def test_missing_annotation_is_none(self) -> None:
         with mock.patch.object(resolver.shutil, "which", return_value="/usr/bin/podman"):
             out = _fake_inspect_output({})

--- a/tests/unit/test_dnsmasq.py
+++ b/tests/unit/test_dnsmasq.py
@@ -16,6 +16,7 @@ from terok_shield.dns.dnsmasq import (
     nftset_entry,
     read_denied_domains,
     read_merged_domains,
+    read_override_domains,
     reload,
 )
 from terok_shield.nft.constants import (
@@ -549,6 +550,49 @@ def test_read_denied_domains_composes_from_policy(tmp_path: Path) -> None:
     bundle.write_tier("project_allow", f"+{TEST_DOMAIN}\n")
     bundle.overlay_set("-", TEST_DOMAIN2)
     assert read_denied_domains(tmp_path) == [TEST_DOMAIN2]
+
+
+def test_read_override_domains_composes_from_policy(tmp_path: Path) -> None:
+    """read_override_domains() surfaces '+' t10 domains from the tiered bundle."""
+    bundle = StateBundle(tmp_path)
+    bundle.ensure_dirs()
+    bundle.write_tier("override", f"+{TEST_DOMAIN}\n")
+    assert read_override_domains(tmp_path) == [TEST_DOMAIN]
+
+
+def test_generate_config_override_punches_through_exact_deny(tmp_path: Path) -> None:
+    """A t10 override at exactly a denied name suppresses its sinkhole.
+
+    The override host is usually *also* t20-denied — without the
+    punch-through it would NXDOMAIN before the statically seeded t10 set
+    ever saw a packet — while staying out of the ``nftset=`` population
+    (its addresses live in the t10 set, not t40).
+    """
+    config = generate_config(
+        PASTA_DNS,
+        [],
+        tmp_path / "dnsmasq.pid",
+        listen_address=DNSMASQ_BIND_DEFAULT,
+        deny_domains=[TEST_DOMAIN],
+        override_domains=[TEST_DOMAIN],
+    )
+    assert f"local=/{TEST_DOMAIN}/" not in config
+    assert f"nftset=/{TEST_DOMAIN}/" not in config
+
+
+def test_generate_config_override_subdomain_gets_punch_through(tmp_path: Path) -> None:
+    """A t10 override below a denied ancestor gets a server=/sub/upstream punch-through."""
+    sub = f"api.{TEST_DOMAIN}"
+    config = generate_config(
+        PASTA_DNS,
+        [],
+        tmp_path / "dnsmasq.pid",
+        listen_address=DNSMASQ_BIND_DEFAULT,
+        deny_domains=[TEST_DOMAIN],
+        override_domains=[sub],
+    )
+    assert f"local=/{TEST_DOMAIN}/" in config
+    assert f"server=/{sub}/{PASTA_DNS}" in config
 
 
 def test_reload_writes_deny_sinkholes(tmp_path: Path) -> None:

--- a/tests/unit/test_dnsmasq.py
+++ b/tests/unit/test_dnsmasq.py
@@ -602,7 +602,7 @@ def test_reload_writes_deny_sinkholes(tmp_path: Path) -> None:
     bundle.dnsmasq_pid.write_text("12345\n")
     bundle.dnsmasq_conf.write_text(f"listen-address={DNSMASQ_BIND_DEFAULT}\n")
 
-    _run_reload(tmp_path, PASTA_DNS, [TEST_DOMAIN], [TEST_DOMAIN2])
+    _run_reload(tmp_path, PASTA_DNS, [TEST_DOMAIN], deny_domains=[TEST_DOMAIN2])
 
     conf = bundle.dnsmasq_conf.read_text()
     assert f"nftset=/{TEST_DOMAIN}/" in conf

--- a/tests/unit/test_hook_mode_class.py
+++ b/tests/unit/test_hook_mode_class.py
@@ -1505,23 +1505,62 @@ def test_pre_start_with_denied_ips_includes_deny_elements(
     make_hook_mode: HookModeHarnessFactory,
     make_config: ConfigFactory,
 ) -> None:
-    """pre_start() includes deny elements in ruleset when deny.list exists."""
+    """pre_start(security_deny=…) writes the t20 tier and it reaches the ruleset."""
     _set_euid(monkeypatch, 0)
     config = make_config()
     harness = make_hook_mode(config=config)
     harness.runner.run.return_value = _MODERN_PODMAN_INFO
     harness.profiles.compose_profiles.return_value = []
 
-    # Write a deny.list before pre_start
-    _b = StateBundle(config.state_dir)
-    _b.ensure_dirs()
-    _b.write_tier("security_deny", f"-{TEST_IP1}\n")
+    harness.mode.pre_start("test", ["dev-standard"], security_deny=[TEST_IP1])
+
+    bundle = StateBundle(config.state_dir)
+    assert f"-{TEST_IP1}" in bundle.tier_path("security_deny").read_text()
+    ruleset = bundle.ruleset.read_text()
+    assert "t20_security_deny_v4" in ruleset
+    assert TEST_IP1 in ruleset
+
+
+@mock.patch("terok_shield.hooks.mode.has_global_hooks", return_value=True)
+def test_pre_start_writes_generated_provider_allow_tier(
+    _has_hooks: mock.Mock,
+    monkeypatch: pytest.MonkeyPatch,
+    make_hook_mode: HookModeHarnessFactory,
+    make_config: ConfigFactory,
+) -> None:
+    """pre_start(provider_allow=…) writes the t30 tier as ``+host`` lines."""
+    _set_euid(monkeypatch, 0)
+    config = make_config()
+    harness = make_hook_mode(config=config)
+    harness.runner.run.return_value = _MODERN_PODMAN_INFO
+    harness.profiles.compose_profiles.return_value = []
+
+    harness.mode.pre_start("test", ["dev-standard"], provider_allow=[TEST_DOMAIN])
+
+    tier = StateBundle(config.state_dir).tier_path("provider_allow").read_text()
+    assert f"+{TEST_DOMAIN}" in tier
+
+
+@mock.patch("terok_shield.hooks.mode.has_global_hooks", return_value=True)
+def test_pre_start_clears_generated_tiers_when_absent(
+    _has_hooks: mock.Mock,
+    monkeypatch: pytest.MonkeyPatch,
+    make_hook_mode: HookModeHarnessFactory,
+    make_config: ConfigFactory,
+) -> None:
+    """pre_start owns t20/t30 — a launch without a projection clears stale content."""
+    _set_euid(monkeypatch, 0)
+    config = make_config()
+    harness = make_hook_mode(config=config)
+    harness.runner.run.return_value = _MODERN_PODMAN_INFO
+    harness.profiles.compose_profiles.return_value = []
+    bundle = StateBundle(config.state_dir)
+    bundle.ensure_dirs()
+    bundle.write_tier("provider_allow", f"+{TEST_DOMAIN}\n")  # left by a prior launch
 
     harness.mode.pre_start("test", ["dev-standard"])
 
-    ruleset = StateBundle(config.state_dir).ruleset.read_text()
-    assert "t20_security_deny_v4" in ruleset
-    assert TEST_IP1 in ruleset
+    assert bundle.tier_path("provider_allow").read_text() == ""
 
 
 # ── Container ID persistence ─────────────────────────────

--- a/tests/unit/test_hook_mode_class.py
+++ b/tests/unit/test_hook_mode_class.py
@@ -28,10 +28,12 @@ from terok_shield.run import ExecError
 
 from ..testfs import BIN_DIR_NAME, HOOK_ENTRYPOINT_NAME, HOOKS_DIR_NAME
 from ..testnet import (
+    BROAD_CIDR_8,
     CONTAINER_HOSTNAME,
     IPV6_CLOUDFLARE,
     SLIRP4NETNS_GATEWAY,
     TEST_DOMAIN,
+    TEST_DOMAIN2,
     TEST_IP1,
     TEST_IP2,
     TEST_IP3,
@@ -1561,6 +1563,68 @@ def test_pre_start_clears_generated_tiers_when_absent(
     harness.mode.pre_start("test", ["dev-standard"])
 
     assert bundle.tier_path("provider_allow").read_text() == ""
+
+
+@mock.patch("terok_shield.hooks.mode.has_global_hooks", return_value=True)
+def test_pre_start_merges_project_allow_into_t40(
+    _has_hooks: mock.Mock,
+    monkeypatch: pytest.MonkeyPatch,
+    make_hook_mode: HookModeHarnessFactory,
+    make_config: ConfigFactory,
+) -> None:
+    """pre_start(project_allow=…) merges authored hosts into the t40 project-allow tier."""
+    _set_euid(monkeypatch, 0)
+    config = make_config()
+    harness = make_hook_mode(config=config)
+    harness.runner.run.return_value = _MODERN_PODMAN_INFO
+    harness.profiles.compose_profiles.return_value = [TEST_DOMAIN2]
+
+    harness.mode.pre_start("test", ["dev-standard"], project_allow=[TEST_DOMAIN])
+
+    tier = StateBundle(config.state_dir).tier_path("project_allow").read_text()
+    assert f"+{TEST_DOMAIN}" in tier  # authored
+    assert f"+{TEST_DOMAIN2}" in tier  # composed profile — both land in t40
+
+
+@mock.patch("terok_shield.hooks.mode.has_global_hooks", return_value=True)
+def test_pre_start_writes_override_tier_and_seeds_t10(
+    _has_hooks: mock.Mock,
+    monkeypatch: pytest.MonkeyPatch,
+    make_hook_mode: HookModeHarnessFactory,
+    make_config: ConfigFactory,
+) -> None:
+    """pre_start(override=…) writes t10 and seeds the override nft set (above the deny)."""
+    _set_euid(monkeypatch, 0)
+    config = make_config()
+    harness = make_hook_mode(config=config)
+    harness.runner.run.return_value = _MODERN_PODMAN_INFO
+    harness.profiles.compose_profiles.return_value = []
+
+    harness.mode.pre_start("test", ["dev-standard"], override=[TEST_IP1])
+
+    bundle = StateBundle(config.state_dir)
+    assert f"+{TEST_IP1}" in bundle.tier_path("override").read_text()
+    ruleset = bundle.ruleset.read_text()
+    assert "t10_override_v4" in ruleset
+    assert TEST_IP1 in ruleset
+
+
+@mock.patch("terok_shield.hooks.mode.has_global_hooks", return_value=True)
+def test_pre_start_override_rejects_cidr(
+    _has_hooks: mock.Mock,
+    monkeypatch: pytest.MonkeyPatch,
+    make_hook_mode: HookModeHarnessFactory,
+    make_config: ConfigFactory,
+) -> None:
+    """A CIDR in the override tier fails the launch closed — no subnet break-glass."""
+    _set_euid(monkeypatch, 0)
+    config = make_config()
+    harness = make_hook_mode(config=config)
+    harness.runner.run.return_value = _MODERN_PODMAN_INFO
+    harness.profiles.compose_profiles.return_value = []
+
+    with pytest.raises(ValueError, match="CIDR"):
+        harness.mode.pre_start("test", ["dev-standard"], override=[BROAD_CIDR_8])
 
 
 # ── Container ID persistence ─────────────────────────────

--- a/tests/unit/test_hook_mode_class.py
+++ b/tests/unit/test_hook_mode_class.py
@@ -1610,6 +1610,66 @@ def test_pre_start_writes_override_tier_and_seeds_t10(
 
 
 @mock.patch("terok_shield.hooks.mode.has_global_hooks", return_value=True)
+def test_pre_start_statically_resolves_security_deny(
+    _has_hooks: mock.Mock,
+    monkeypatch: pytest.MonkeyPatch,
+    make_hook_mode: HookModeHarnessFactory,
+    make_config: ConfigFactory,
+) -> None:
+    """t20 domains are statically resolved into the deny cache on every DNS tier.
+
+    The deny must hold by *address*: it is what ``shield down`` repopulates
+    the deny set from, and dnsmasq interception can never populate a deny.
+    The resolved IPs must reach the pre-generated ruleset's deny elements.
+    """
+    _set_euid(monkeypatch, 0)
+    config = make_config()
+    harness = make_hook_mode(config=config)
+    harness.runner.run.return_value = _MODERN_PODMAN_INFO
+    harness.profiles.compose_profiles.return_value = []
+    bundle = StateBundle(config.state_dir)
+
+    def _fake_resolve(targets: list[str], cache_path: Path, **_kw: object) -> None:
+        if cache_path == bundle.deny_resolved:
+            cache_path.write_text(f"{TEST_IP2}\n")
+
+    harness.dns.resolve_and_cache.side_effect = _fake_resolve
+
+    harness.mode.pre_start("test", ["dev-standard"], security_deny=[TEST_DOMAIN])
+
+    deny_calls = [
+        c for c in harness.dns.resolve_and_cache.call_args_list if c.args[1] == bundle.deny_resolved
+    ]
+    assert len(deny_calls) == 1
+    assert TEST_DOMAIN in deny_calls[0].args[0]
+    ruleset = bundle.ruleset.read_text()
+    assert "t20_security_deny_v4" in ruleset
+    assert TEST_IP2 in ruleset
+
+
+@mock.patch("terok_shield.hooks.mode.has_global_hooks", return_value=True)
+def test_pre_start_clears_stale_deny_cache_when_deny_tier_empties(
+    _has_hooks: mock.Mock,
+    monkeypatch: pytest.MonkeyPatch,
+    make_hook_mode: HookModeHarnessFactory,
+    make_config: ConfigFactory,
+) -> None:
+    """An emptied deny tier removes the stale resolved-deny cache."""
+    _set_euid(monkeypatch, 0)
+    config = make_config()
+    harness = make_hook_mode(config=config)
+    harness.runner.run.return_value = _MODERN_PODMAN_INFO
+    harness.profiles.compose_profiles.return_value = []
+    bundle = StateBundle(config.state_dir)
+    bundle.ensure_dirs()
+    bundle.deny_resolved.write_text(f"{TEST_IP2}\n")  # left by a prior launch
+
+    harness.mode.pre_start("test", ["dev-standard"])
+
+    assert not bundle.deny_resolved.exists()
+
+
+@mock.patch("terok_shield.hooks.mode.has_global_hooks", return_value=True)
 def test_pre_start_override_rejects_cidr(
     _has_hooks: mock.Mock,
     monkeypatch: pytest.MonkeyPatch,
@@ -1698,6 +1758,82 @@ def test_shield_down_repopulates_deny_sets(
     # Verify deny elements were sent via nsenter
     deny_calls = [c for c in harness.runner.nft_via_nsenter.call_args_list if c.kwargs.get("stdin")]
     assert any(TEST_IP1 in (c.kwargs.get("stdin", "") or "") for c in deny_calls)
+
+
+@pytest.mark.parametrize("transition", ["up", "down"])
+def test_shield_transitions_reseed_override_set(
+    make_hook_mode: HookModeHarnessFactory,
+    make_config: ConfigFactory,
+    transition: str,
+) -> None:
+    """shield_up()/shield_down() re-seed the t10 override set from the bundle.
+
+    The table rebuild recreates every set empty; without the re-seed a
+    break-glass override would silently die (still t20-denied) after one
+    down/up cycle and only recover on container re-creation.
+    """
+    config = make_config()
+    harness = make_hook_mode(config=config)
+    harness.mode._container_ruleset = lambda _c: harness.ruleset
+    harness.runner.nft_via_nsenter.return_value = ""
+    harness.ruleset.build_hook.return_value = "hook ruleset"
+    harness.ruleset.verify_hook.return_value = []
+    harness.ruleset.add_elements_dual.return_value = ""
+    harness.ruleset.build_bypass.return_value = "bypass ruleset"
+    harness.ruleset.verify_bypass.return_value = [] if transition == "down" else ["not bypass"]
+
+    _b = StateBundle(config.state_dir)
+    _b.ensure_dirs()
+    _b.write_tier("override", f"+{TEST_IP1}\n")
+
+    getattr(harness.mode, f"shield_{transition}")("test-ctr")
+
+    stdins = [
+        c.kwargs.get("stdin", "") or "" for c in harness.runner.nft_via_nsenter.call_args_list
+    ]
+    assert any("t10_override_v4" in s and TEST_IP1 in s for s in stdins)
+
+
+@mock.patch("terok_shield.hooks.mode.has_global_hooks", return_value=True)
+def test_refresh_rewrites_tiers_and_ruleset(
+    _has_hooks: mock.Mock,
+    monkeypatch: pytest.MonkeyPatch,
+    make_hook_mode: HookModeHarnessFactory,
+    make_config: ConfigFactory,
+) -> None:
+    """refresh() re-authors an existing bundle — current tier data replaces the frozen one.
+
+    A plain restart replays ``ruleset.nft`` through the OCI hook, so a
+    roster/config change between creation and restart must land in the
+    regenerated artifacts, not just the tier files.
+    """
+    _set_euid(monkeypatch, 0)
+    config = make_config()
+    harness = make_hook_mode(config=config)
+    harness.runner.run.return_value = _MODERN_PODMAN_INFO
+    harness.profiles.compose_profiles.return_value = []
+    harness.mode.pre_start("test", ["dev-standard"], security_deny=[TEST_IP1])
+
+    harness.mode.refresh(["dev-standard"], security_deny=[TEST_IP2])
+
+    bundle = StateBundle(config.state_dir)
+    tier = bundle.tier_path("security_deny").read_text()
+    assert f"-{TEST_IP2}" in tier
+    assert f"-{TEST_IP1}" not in tier
+    ruleset = bundle.ruleset.read_text()
+    assert TEST_IP2 in ruleset
+    assert TEST_IP1 not in ruleset
+
+
+def test_refresh_without_prepared_bundle_raises(
+    make_hook_mode: HookModeHarnessFactory,
+    make_config: ConfigFactory,
+) -> None:
+    """refresh() refuses a state dir pre_start never prepared (no persisted DNS tier)."""
+    harness = make_hook_mode(config=make_config())
+
+    with pytest.raises(RuntimeError, match="persisted DNS tier"):
+        harness.mode.refresh(["dev-standard"])
 
 
 from terok_shield.state import StateBundle

--- a/tests/unit/test_hook_mode_class.py
+++ b/tests/unit/test_hook_mode_class.py
@@ -1825,6 +1825,33 @@ def test_refresh_rewrites_tiers_and_ruleset(
     assert TEST_IP1 not in ruleset
 
 
+@mock.patch("terok_shield.hooks.mode.has_global_hooks", return_value=True)
+def test_refresh_reuses_persisted_network_mode(
+    _has_hooks: mock.Mock,
+    monkeypatch: pytest.MonkeyPatch,
+    make_hook_mode: HookModeHarnessFactory,
+    make_config: ConfigFactory,
+) -> None:
+    """refresh() derives its gateways from the bundle, never from a fresh ``podman info``.
+
+    A restart must rebuild for the network mode the container was launched
+    with — re-detecting could disagree with the mounts and annotations, and
+    would put a ``podman info`` probe on an interactive path.
+    """
+    _set_euid(monkeypatch, 0)
+    config = make_config()
+    harness = make_hook_mode(config=config)
+    harness.runner.run.return_value = _MODERN_PODMAN_INFO
+    harness.profiles.compose_profiles.return_value = []
+    harness.mode.pre_start("test", ["dev-standard"])
+    assert StateBundle(config.state_dir).network_mode.read_text().strip() == "pasta"
+    harness.runner.run.reset_mock()
+
+    harness.mode.refresh(["dev-standard"])
+
+    assert not [c for c in harness.runner.run.call_args_list if "info" in c.args[0]]
+
+
 def test_refresh_without_prepared_bundle_raises(
     make_hook_mode: HookModeHarnessFactory,
     make_config: ConfigFactory,

--- a/tests/unit/test_nft.py
+++ b/tests/unit/test_nft.py
@@ -36,6 +36,7 @@ from terok_shield.nft.rules import (
 )
 
 from ..testnet import (
+    AWS_IMDS_V6,
     IPV4_CIDR_HOST_BITS,
     IPV4_CIDR_HOST_BITS_CANONICAL,
     IPV6_CLOUDFLARE,
@@ -227,6 +228,22 @@ def test_hook_ruleset_tier_order_is_authority_order() -> None:
     private = rs.index(PRIVATE_RANGES[0])  # 10.0.0.0/8
     allow = rs.index("@t40_project_allow_v4")
     assert hard_deny < override < deny < private < allow
+
+
+def test_v6_imds_floor_is_absolute() -> None:
+    """The AWS v6 metadata endpoint is hard-denied ABOVE the override tier.
+
+    It lives inside ULA ``fc00::/7``, whose reject sits *below* the override
+    — so without its own t00 entry, a deliberate ULA carve-out override
+    would reach the v6 metadata service and the absolute-IMDS guarantee
+    would be v4-only.
+    """
+    rs = RulesetBuilder().build_hook()
+    imds = rs.index(f"ip6 daddr {AWS_IMDS_V6} ")
+    assert imds < rs.index("@t10_override_v4")
+    # Bare-address form: nft strips /128 on listing, so verification
+    # round-trips only the bare literal.
+    assert f"{AWS_IMDS_V6}/128" not in rs
 
 
 # ── Terminal deny rule (BLOCKED prefix) ───────────────

--- a/tests/unit/test_nft.py
+++ b/tests/unit/test_nft.py
@@ -57,6 +57,8 @@ _DENY_V4_SET = "set t20_security_deny_v4 { type ipv4_addr; flags interval; }"
 _DENY_V6_SET = "set t20_security_deny_v6 { type ipv6_addr; flags interval; }"
 _ALLOW_LOG_PREFIX = "TEROK_SHIELD_ALLOWED"
 _DENY_LOG_PREFIX = "TEROK_SHIELD_DENIED"
+_ALLOWED_LOG_PREFIX = "TEROK_SHIELD_ALLOWED"
+_BYPASS_LOG_PREFIX = "TEROK_SHIELD_BYPASS"
 _BLOCKED_LOG_PREFIX = "TEROK_SHIELD_BLOCKED"
 _ADMIN_PROHIBITED = "admin-prohibited"
 _INPUT_CHAIN = "chain input"
@@ -704,6 +706,23 @@ def test_bypass_ruleset_keeps_override_above_deny() -> None:
     host must stay reachable in every posture that enforces the deny."""
     rs = RulesetBuilder().build_bypass()
     assert rs.index("@t10_override_v4") < rs.index("@t20_security_deny_v4")
+
+
+def _rule_for(ruleset: str, set_name: str) -> str:
+    """The single rule line matching *set_name* in *ruleset*."""
+    return next(ln for ln in ruleset.splitlines() if f"@{set_name} " in ln)
+
+
+def test_override_accept_is_audited_in_both_postures() -> None:
+    """A break-glass accept carries an NFLOG tag — it is terminal, so nothing else logs it.
+
+    The t10 verdict ends evaluation before the tiers (and, in bypass, before
+    the catch-all ``ct state new`` log), so an untagged accept would make
+    exactly the traffic an auditor cares about most the only traffic that
+    leaves no trace.
+    """
+    assert _ALLOWED_LOG_PREFIX in _rule_for(RulesetBuilder().build_hook(), "t10_override_v4")
+    assert _BYPASS_LOG_PREFIX in _rule_for(RulesetBuilder().build_bypass(), "t10_override_v4")
 
 
 def test_bypass_ruleset_emits_loopback_port_rules() -> None:

--- a/tests/unit/test_nft.py
+++ b/tests/unit/test_nft.py
@@ -682,6 +682,13 @@ def test_bypass_ruleset_includes_deny_sets() -> None:
     assert _DENY_LOG_PREFIX in rs
 
 
+def test_bypass_ruleset_keeps_override_above_deny() -> None:
+    """Bypass mode keeps the t10 override match above the deny — a break-glass
+    host must stay reachable in every posture that enforces the deny."""
+    rs = RulesetBuilder().build_bypass()
+    assert rs.index("@t10_override_v4") < rs.index("@t20_security_deny_v4")
+
+
 def test_bypass_ruleset_emits_loopback_port_rules() -> None:
     """Host-loopback-proxy port exceptions survive in bypass mode, before private-range reject."""
     ruleset = RulesetBuilder(loopback_ports=(9418,)).build_bypass()

--- a/tests/unit/test_shield_facade.py
+++ b/tests/unit/test_shield_facade.py
@@ -143,7 +143,12 @@ def test_pre_start_dispatches_and_logs(make_shield: ShieldHarnessFactory) -> Non
     result = harness.shield.pre_start("test-ctr", ["dev-standard"])
 
     harness.mode.pre_start.assert_called_once_with(
-        "test-ctr", ["dev-standard"], security_deny=(), provider_allow=()
+        "test-ctr",
+        ["dev-standard"],
+        security_deny=(),
+        provider_allow=(),
+        project_allow=(),
+        override=(),
     )
     assert result == ["--network", "pasta:"]
     harness.audit.log_event.assert_called_once_with(
@@ -161,7 +166,7 @@ def test_pre_start_uses_default_profiles(
 
     harness.shield.pre_start("test-ctr")
     harness.mode.pre_start.assert_called_once_with(
-        "test-ctr", ["base"], security_deny=(), provider_allow=()
+        "test-ctr", ["base"], security_deny=(), provider_allow=(), project_allow=(), override=()
     )
 
 

--- a/tests/unit/test_shield_facade.py
+++ b/tests/unit/test_shield_facade.py
@@ -142,7 +142,9 @@ def test_pre_start_dispatches_and_logs(make_shield: ShieldHarnessFactory) -> Non
 
     result = harness.shield.pre_start("test-ctr", ["dev-standard"])
 
-    harness.mode.pre_start.assert_called_once_with("test-ctr", ["dev-standard"])
+    harness.mode.pre_start.assert_called_once_with(
+        "test-ctr", ["dev-standard"], security_deny=(), provider_allow=()
+    )
     assert result == ["--network", "pasta:"]
     harness.audit.log_event.assert_called_once_with(
         "test-ctr", "setup", detail="profiles=dev-standard"
@@ -158,7 +160,9 @@ def test_pre_start_uses_default_profiles(
     harness.mode.pre_start.return_value = []
 
     harness.shield.pre_start("test-ctr")
-    harness.mode.pre_start.assert_called_once_with("test-ctr", ["base"])
+    harness.mode.pre_start.assert_called_once_with(
+        "test-ctr", ["base"], security_deny=(), provider_allow=()
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_shield_facade.py
+++ b/tests/unit/test_shield_facade.py
@@ -14,7 +14,7 @@ import pytest
 from terok_shield import ExecError, Shield, ShieldConfig, ShieldState, state
 
 from ..testfs import FAKE_HOOKS_DIR, NFT_BINARY
-from ..testnet import TEST_DOMAIN, TEST_IP1, TEST_IP2
+from ..testnet import TEST_DOMAIN, TEST_DOMAIN2, TEST_IP1, TEST_IP2
 
 ConfigFactory = Callable[..., ShieldConfig]
 
@@ -168,6 +168,29 @@ def test_pre_start_uses_default_profiles(
     harness.mode.pre_start.assert_called_once_with(
         "test-ctr", ["base"], security_deny=(), provider_allow=(), project_allow=(), override=()
     )
+
+
+def test_refresh_dispatches_and_logs(
+    make_shield: ShieldHarnessFactory,
+    make_config: ConfigFactory,
+) -> None:
+    """refresh() delegates the tier data to the backend and audit-logs the event.
+
+    Same default-profiles fallback as pre_start — the restart path passes
+    ``None`` and gets the config's composed profile set.
+    """
+    harness = make_shield(config=make_config(default_profiles=("base",)))
+
+    harness.shield.refresh("test-ctr", security_deny=(TEST_DOMAIN,), override=(TEST_DOMAIN2,))
+
+    harness.mode.refresh.assert_called_once_with(
+        ["base"],
+        security_deny=(TEST_DOMAIN,),
+        provider_allow=(),
+        project_allow=(),
+        override=(TEST_DOMAIN2,),
+    )
+    harness.audit.log_event.assert_called_once_with("test-ctr", "refresh", detail="profiles=base")
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -165,6 +165,24 @@ def test_read_effective_ips_includes_runtime_allow_before_reresolve(tmp_path: Pa
     assert bundle.read_effective_ips() == [TEST_IP1, TEST_IP3]
 
 
+def test_read_override_ips_unions_literal_and_cache_ignoring_denies(tmp_path: Path) -> None:
+    """The t10 seed is literal + resolved override IPs; a deny does NOT subtract it."""
+    bundle = StateBundle(tmp_path)
+    bundle.policy_dir.mkdir()
+    bundle.tier_path("override").write_text(f"+{TEST_IP1}\n")  # literal override
+    bundle.override_resolved.write_text(f"{TEST_IP2}\n")  # resolved override domain
+    bundle.tier_path("security_deny").write_text(f"-{TEST_IP1}\n")  # deny is below the override
+    assert bundle.read_override_ips() == [TEST_IP1, TEST_IP2]
+
+
+def test_override_targets_lists_plus_entries(tmp_path: Path) -> None:
+    """override_targets returns the ``+`` override entries (domains + IPs) to resolve."""
+    bundle = StateBundle(tmp_path)
+    bundle.policy_dir.mkdir()
+    bundle.tier_path("override").write_text(f"+{TEST_DOMAIN}\n+{TEST_IP1}\n")
+    assert set(bundle.read_effective().override_targets()) == {TEST_DOMAIN, TEST_IP1}
+
+
 # ── ballast sync contract ────────────────────────────────────────────────────
 
 

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -183,6 +183,36 @@ def test_override_targets_lists_plus_entries(tmp_path: Path) -> None:
     assert set(bundle.read_effective().override_targets()) == {TEST_DOMAIN, TEST_IP1}
 
 
+def test_read_denied_ips_unions_resolved_cache(tmp_path: Path) -> None:
+    """The t20 seed unions literal ``-`` IPs with the resolved deny cache.
+
+    A denied *domain* only denies by address once resolved — the cache is
+    what keeps the deny enforced across ``shield down``/``up`` rebuilds.
+    """
+    bundle = StateBundle(tmp_path)
+    bundle.policy_dir.mkdir()
+    bundle.tier_path("security_deny").write_text(f"-{TEST_IP1}\n-{TEST_DOMAIN}\n")
+    bundle.deny_resolved.write_text(f"{TEST_IP2}\n")  # resolved deny domain
+    assert bundle.read_denied_ips() == {TEST_IP1, TEST_IP2}
+
+
+def test_deny_targets_lists_domains_and_ips(tmp_path: Path) -> None:
+    """deny_targets returns every ``-`` entry (security-deny + live) — the deny-resolver input."""
+    bundle = StateBundle(tmp_path)
+    bundle.policy_dir.mkdir()
+    bundle.tier_path("security_deny").write_text(f"-{TEST_DOMAIN}\n")
+    bundle.policy_live.write_text(f"-{TEST_IP2}\n")
+    assert set(bundle.read_effective().deny_targets()) == {TEST_DOMAIN, TEST_IP2}
+
+
+def test_override_domains_lists_only_domains(tmp_path: Path) -> None:
+    """override_domains returns the ``+`` override domains (no IPs) — the sinkhole punch-through set."""
+    bundle = StateBundle(tmp_path)
+    bundle.policy_dir.mkdir()
+    bundle.tier_path("override").write_text(f"+{TEST_DOMAIN}\n+{TEST_IP1}\n")
+    assert bundle.read_effective().override_domains() == [TEST_DOMAIN]
+
+
 # ── ballast sync contract ────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Base of the Phase 2 PR chain (shield → sandbox → executor).

## What

`pre_start()` gains `security_deny` / `provider_allow` keyword args (host/IP lists). Shield renders them into `policy/20-security-deny` (`-host`) and `policy/30-provider-allow` (`+host`) — the two tiers Phase 1 left empty.

## Why this shape (Option B)

`EffectivePolicy` already composes t20/t30 into resolution, dnsmasq domains, and the ruleset; the only gap was that nobody *wrote* the files. Rather than expose `StateBundle` for sandbox to reach into (a boundary leak past shield's public `__all__`), shield keeps ownership of its on-disk layout: **callers pass data, shield writes.**

- `pre_start` is the sole author of these two tiers, so a launch without a projection clears stale content (the task's providers changed). Runtime operator allow/deny still lands in the `policy/live` overlay, not these tiers — ownership stays clean.
- Empty is the default, so every existing caller is unaffected.

## Consumers (the rest of the chain)

- **terok-sandbox**: `ShieldManager.pre_start` forwards the projection to `Shield.pre_start(security_deny=…, provider_allow=…)`.
- **terok-executor**: `compose_egress()` produces the projection from the roster selection (ROSTER 2→3).

## Checks

`make check` green: 1314 unit tests, ruff, mypy, tach, bandit, docstrings, vulture, reuse. Draft (CodeRabbit off until ready).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tiered policy inputs for security denials, provider/project allowances, and break-glass overrides, including propagation into setup.
  * Added `refresh` support to recompute an existing container’s policy/rules with tier inputs and audit logging.
  * Added persisted deny/override resolution caches and override-domain handling in DNS protection.
  * Added shield version detection from container metadata.
* **Bug Fixes**
  * Kept break-glass override reachable above deny in both enforcing and bypass rulesets, including correct IPv6 IMDS handling.
* **Tests**
  * Expanded unit coverage for override/deny resolution, DNS override behavior, refresh dispatch, and hardened metadata parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->