### PR TITLE
feat: route logging through terok-util unified facility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dynamic = ["version"]
 dependencies = [
     "PyYAML~=6.0",
     "pydantic~=2.13",
-    "terok-util @ https://github.com/terok-ai/terok-util/releases/download/v0.3.1a3/terok_util-0.3.1a3-py3-none-any.whl",
+    "terok-util @ git+https://github.com/sliwowitz/terok-util@feat/unified-logging",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dynamic = ["version"]
 dependencies = [
     "PyYAML~=6.0",
     "pydantic~=2.13",
-    "terok-util @ git+https://github.com/sliwowitz/terok-util@feat/unified-logging",
+    "terok-util @ https://github.com/terok-ai/terok-util/releases/download/v0.3.1a4/terok_util-0.3.1a4-py3-none-any.whl",
 ]
 
 [project.urls]
@@ -87,7 +87,7 @@ allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
-fallback-version = "0.8.0a7"
+fallback-version = "0.8.0a8"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/terok_shield"]

--- a/src/terok_shield/cli/main.py
+++ b/src/terok_shield/cli/main.py
@@ -24,7 +24,7 @@ from collections.abc import Collection
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from terok_util import CommandDef
+from terok_util import CommandDef, configure
 
 from .. import Shield, ShieldConfig, ShieldMode
 from ..commands import COMMANDS, needs_container
@@ -40,6 +40,9 @@ from ..validation import validate_container_name
 
 def main(argv: list[str] | None = None) -> None:
     """Run the terok-shield CLI."""
+    # One-time unified logging setup: routes every ``getLogger(__name__)`` in
+    # the library to journald (when present) or stderr, with no call-site edits.
+    configure(identifier="terok-shield")
     if argv is None:
         argv = sys.argv[1:]
 

--- a/uv.lock
+++ b/uv.lock
@@ -1439,7 +1439,7 @@ test = [
 requires-dist = [
     { name = "pydantic", specifier = "~=2.13" },
     { name = "pyyaml", specifier = "~=6.0" },
-    { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a3/terok_util-0.3.1a3-py3-none-any.whl" },
+    { name = "terok-util", git = "https://github.com/sliwowitz/terok-util?rev=feat%2Funified-logging" },
 ]
 
 [package.metadata.requires-dev]
@@ -1470,22 +1470,12 @@ test = [
 
 [[package]]
 name = "terok-util"
-version = "0.3.1a3"
-source = { url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a3/terok_util-0.3.1a3-py3-none-any.whl" }
+version = "0.3.1a4.dev87+g969a358c4"
+source = { git = "https://github.com/sliwowitz/terok-util?rev=feat%2Funified-logging#969a358c451e44128c3cb5f59b4f50a7bc003a7d" }
 dependencies = [
     { name = "jinja2" },
     { name = "platformdirs" },
     { name = "ruamel-yaml" },
-]
-wheels = [
-    { url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a3/terok_util-0.3.1a3-py3-none-any.whl", hash = "sha256:dc579905a4c9d815ccadb8370834002a9f2f0c0f2fd35d42e58140e7563799c1" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "jinja2", specifier = "~=3.1" },
-    { name = "platformdirs", specifier = "~=4.10" },
-    { name = "ruamel-yaml", specifier = "==0.19.1" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1439,7 +1439,7 @@ test = [
 requires-dist = [
     { name = "pydantic", specifier = "~=2.13" },
     { name = "pyyaml", specifier = "~=6.0" },
-    { name = "terok-util", git = "https://github.com/sliwowitz/terok-util?rev=feat%2Funified-logging" },
+    { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a4/terok_util-0.3.1a4-py3-none-any.whl" },
 ]
 
 [package.metadata.requires-dev]
@@ -1470,12 +1470,22 @@ test = [
 
 [[package]]
 name = "terok-util"
-version = "0.3.1a4.dev87+g969a358c4"
-source = { git = "https://github.com/sliwowitz/terok-util?rev=feat%2Funified-logging#969a358c451e44128c3cb5f59b4f50a7bc003a7d" }
+version = "0.3.1a4"
+source = { url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a4/terok_util-0.3.1a4-py3-none-any.whl" }
 dependencies = [
     { name = "jinja2" },
     { name = "platformdirs" },
     { name = "ruamel-yaml" },
+]
+wheels = [
+    { url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a4/terok_util-0.3.1a4-py3-none-any.whl", hash = "sha256:8878f21e8101c5d70e17c7c44737ea5ea1390226738c0e9221f91d7dedfb38b3" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "jinja2", specifier = "~=3.1" },
+    { name = "platformdirs", specifier = "~=4.10" },
+    { name = "ruamel-yaml", specifier = "==0.19.1" },
 ]
 
 [[package]]


### PR DESCRIPTION
Part of the fleet-wide logging unification (terok-util terok-ai/terok-util#85).

One `configure(identifier="terok-shield")` call at `cli/main.py:main()` routes
the entire library — every `getLogger(__name__)` propagating to root — to
journald when present, else stderr. **No call-site edits.**

Deliberately **not** migrated (they run outside the venv / are not diagnostic
logging, per the survey): the stdlib-only OCI hooks (`_oci_state.log`,
`nft_hook`, `reader_hook`), the namespaced NFLOG-reader subprocess, and the
JSONL `AuditLogger`.

Pins terok-util to the `feat/unified-logging` branch. Repin to the release
wheel before merge. CLI tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Centralized application logging initialization at startup.
  * Logging is now set up once during launch, routing to journald when available and otherwise falling back to stderr.
  * Enhances consistency and visibility of diagnostic messages across the application.
* **Chores**
  * Updated the `terok-util` dependency reference to pull from a newer source.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->