### PR TITLE
fix(hooks): reap the NFLOG reader's whole process group at poststop

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,7 @@ allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
-fallback-version = "0.8.0a9"
+fallback-version = "0.8.0a10"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/terok_shield"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,15 @@ markers = [
   "needs_hooks: requires OCI hooks (global hooks installed or per-container hooks-dir persistence)",
 ]
 
+# Branch coverage on: an untested branch is an untested behavior.  The
+# ``python -m`` shim and entrypoint guards carry no logic to test.
+[tool.coverage.run]
+branch = true
+omit = ["*/terok_shield/cli/__main__.py"]
+
+[tool.coverage.report]
+exclude_also = ['if __name__ == "__main__":']
+
 [tool.ruff]
 target-version = "py312"
 line-length = 100

--- a/src/terok_shield/resources/reader_hook.py
+++ b/src/terok_shield/resources/reader_hook.py
@@ -214,14 +214,14 @@ def _spawn_reader(
 def _reap_reader(sd: Path) -> None:
     """SIGTERM the NFLOG reader's process group at poststop, SIGKILL past 2 s.
 
-    The spawned PID is only the head of the reader: it re-execs the real
-    reader inside the container's netns through ``nsenter`` (and
-    ``podman unshare`` outside the rootless userns), so the process
-    doing the work is a grandchild.  ``start_new_session=True`` at spawn
-    made the head a session leader, so every process in that chain
-    shares its process group — signalling the *group* reaps them all.
-    Signalling only the head PID orphaned the grandchild on every
-    container stop, leaking one netns reader per restart.
+    The spawned PID is only the head of the reader.  The head re-execs
+    the real reader inside the container's netns through ``nsenter``
+    (plus ``podman unshare`` outside the rootless userns), so the
+    working process is a grandchild.  ``start_new_session=True`` at
+    spawn makes the head a session leader, and every process in the
+    chain shares its process group.  A signal to the group reaps them
+    all.  A signal to only the head PID orphans the grandchild at every
+    container stop and leaks one netns reader per restart.
 
     Validates the PID against the expected reader cmdline before
     sending signals — mirrors the ``_is_our_dnsmasq`` pattern in
@@ -270,8 +270,8 @@ def _group_alive(pgid: int) -> bool:
     """Return ``True`` while any process of group *pgid* survives.
 
     ``killpg`` with signal 0 probes without signalling.  A
-    ``PermissionError`` means the group id was recycled by another
-    user's process — ours is gone.
+    ``PermissionError`` means another user's process now holds the
+    recycled group id — ours is gone.
     """
     try:
         os.killpg(pgid, 0)

--- a/src/terok_shield/resources/reader_hook.py
+++ b/src/terok_shield/resources/reader_hook.py
@@ -212,7 +212,16 @@ def _spawn_reader(
 
 
 def _reap_reader(sd: Path) -> None:
-    """SIGTERM the NFLOG reader at poststop, SIGKILL if it lingers past 2 s.
+    """SIGTERM the NFLOG reader's process group at poststop, SIGKILL past 2 s.
+
+    The spawned PID is only the head of the reader: it re-execs the real
+    reader inside the container's netns through ``nsenter`` (and
+    ``podman unshare`` outside the rootless userns), so the process
+    doing the work is a grandchild.  ``start_new_session=True`` at spawn
+    made the head a session leader, so every process in that chain
+    shares its process group — signalling the *group* reaps them all.
+    Signalling only the head PID orphaned the grandchild on every
+    container stop, leaking one netns reader per restart.
 
     Validates the PID against the expected reader cmdline before
     sending signals — mirrors the ``_is_our_dnsmasq`` pattern in
@@ -233,8 +242,10 @@ def _reap_reader(sd: Path) -> None:
         pid_file.unlink(missing_ok=True)
         return
     try:
-        # PID validated by ``_is_our_reader`` cmdline check above.
-        os.kill(pid, signal.SIGTERM)  # NOSONAR
+        # PID validated by ``_is_our_reader`` cmdline check above; the
+        # group id equals the head PID because spawn made it a session
+        # leader.
+        os.killpg(pid, signal.SIGTERM)  # NOSONAR
     except ProcessLookupError:
         pid_file.unlink(missing_ok=True)
         return
@@ -245,14 +256,28 @@ def _reap_reader(sd: Path) -> None:
 
     for _ in range(_REAP_POLL_TICKS):
         time.sleep(_REAP_POLL_INTERVAL_S)
-        if not _oci_state.pid_exists(pid):
+        if not _group_alive(pid):
             break
     else:
         with contextlib.suppress(ProcessLookupError, OSError):
-            # Reader didn't exit within the grace window; force-kill
-            # the same validated PID.
-            os.kill(pid, signal.SIGKILL)  # NOSONAR
+            # The group didn't drain within the grace window; force-kill
+            # the same validated group.
+            os.killpg(pid, signal.SIGKILL)  # NOSONAR
     pid_file.unlink(missing_ok=True)
+
+
+def _group_alive(pgid: int) -> bool:
+    """Return ``True`` while any process of group *pgid* survives.
+
+    ``killpg`` with signal 0 probes without signalling.  A
+    ``PermissionError`` means the group id was recycled by another
+    user's process — ours is gone.
+    """
+    try:
+        os.killpg(pgid, 0)
+    except (ProcessLookupError, PermissionError):
+        return False
+    return True
 
 
 def _reader_alive(pid_file: Path) -> bool:

--- a/tests/unit/test_commands.py
+++ b/tests/unit/test_commands.py
@@ -186,3 +186,30 @@ class TestHandlers:
         with pytest.raises(ValueError) as ctx:
             _handle_preview(shield, allow_all=True)
         assert "--all requires --down" in str(ctx.value)
+
+
+class TestPrintEnvHint:
+    """``print_env_hint`` prints issues and the setup hint when present."""
+
+    def test_prints_issues_and_hint(self, capsys: pytest.CaptureFixture) -> None:
+        from terok_shield import EnvironmentCheck
+        from terok_shield.verbs._common import print_env_hint
+
+        env = EnvironmentCheck(
+            ok=False,
+            hooks="none",
+            health="degraded",
+            issues=["nft missing"],
+            setup_hint="run setup",
+        )
+        print_env_hint(env)
+        out = capsys.readouterr().out
+        assert "nft missing" in out
+        assert "run setup" in out
+
+    def test_silent_when_clean(self, capsys: pytest.CaptureFixture) -> None:
+        from terok_shield import EnvironmentCheck
+        from terok_shield.verbs._common import print_env_hint
+
+        print_env_hint(EnvironmentCheck(ok=True, hooks="per-container", health="ok"))
+        assert capsys.readouterr().out == ""

--- a/tests/unit/test_confine.py
+++ b/tests/unit/test_confine.py
@@ -55,6 +55,20 @@ def test_state_policy_hardens_without_granting_system_runtime(tmp_path: Path) ->
     ]
 
 
+def test_full_confinement_is_silent(tmp_path: Path) -> None:
+    """Both floors fully applied → nothing to report, no debug lines."""
+    hardening = mock.Mock(fully_hardened=True)
+    filesystem = mock.Mock(confined=True, partially_confined=False)
+    with (
+        mock.patch.object(_confine, "harden_self", return_value=hardening),
+        mock.patch.object(_confine, "confine_filesystem", return_value=filesystem),
+        mock.patch.object(_confine._logger, "debug") as debug,
+    ):
+        _REAL_CONFINE_TO_STATE(tmp_path)
+
+    debug.assert_not_called()
+
+
 def test_partial_filesystem_confinement_is_reported(tmp_path: Path) -> None:
     """An installed partial policy is not misreported as absent."""
     hardening = mock.Mock(fully_hardened=True)

--- a/tests/unit/test_reader_hook.py
+++ b/tests/unit/test_reader_hook.py
@@ -798,10 +798,10 @@ class TestReapReaderReapsTheWholeGroup:
     """The netns re-exec grandchild dies with the head — the leak's locking test.
 
     The head PID in ``reader.pid`` re-execs the real reader as a
-    grandchild in its own process group.  Reaping only the head orphaned
-    that grandchild on every container stop, leaking one netns reader
-    per restart.  This drives ``_reap_reader`` against a real two-level
-    process tree and asserts the whole group is gone.
+    grandchild in its own process group.  A reap of only the head
+    orphans that grandchild at every container stop and leaks one netns
+    reader per restart.  The test drives ``_reap_reader`` against a
+    real two-level process tree and asserts the whole group dies.
     """
 
     def test_grandchild_dies_with_the_head(self, tmp_path: Path) -> None:

--- a/tests/unit/test_reader_hook.py
+++ b/tests/unit/test_reader_hook.py
@@ -447,8 +447,10 @@ class TestReapReader:
             mock.patch.object(reader_hook.time, "sleep"),
         ):
             reader_hook._reap_reader(tmp_path)
-        signals_sent = [call.args[1] for call in killpg.call_args_list]
-        assert signals_sent == [signal.SIGTERM, signal.SIGKILL]
+        assert killpg.call_args_list == [
+            mock.call(12345, signal.SIGTERM),
+            mock.call(12345, signal.SIGKILL),
+        ]
         assert not pid_file.exists()
 
     def test_already_gone_process_is_handled(self, tmp_path: Path) -> None:
@@ -816,7 +818,8 @@ class TestReapReaderReapsTheWholeGroup:
                 "-c",
                 (
                     "import subprocess, sys;"
-                    "child = subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(60)']);"
+                    "sleeper = [sys.executable, '-c', 'import time; time.sleep(60)'];"
+                    "child = subprocess.Popen(sleeper);"
                     "print('ready', flush=True);"
                     "child.wait()"
                 ),
@@ -843,6 +846,8 @@ class TestReapReaderReapsTheWholeGroup:
                 _time.sleep(0.05)
             assert not reader_hook._group_alive(head.pid), "the reader group survived the reap"
         finally:
-            with contextlib.suppress(ProcessLookupError, PermissionError):
-                os.killpg(head.pid, signal.SIGKILL)
+            if reader_hook._group_alive(head.pid):
+                # Only a failed reap leaves survivors to clean up.
+                with contextlib.suppress(ProcessLookupError, PermissionError):
+                    os.killpg(head.pid, signal.SIGKILL)
             head.wait()

--- a/tests/unit/test_reader_hook.py
+++ b/tests/unit/test_reader_hook.py
@@ -423,31 +423,31 @@ class TestReapReader:
             reader_hook._reap_reader(tmp_path)
         kill.assert_not_called()
 
-    def test_sigterm_sent_and_pid_file_removed(self, tmp_path: Path) -> None:
+    def test_sigterm_sent_to_the_group_and_pid_file_removed(self, tmp_path: Path) -> None:
         pid_file = tmp_path / "reader.pid"
         pid_file.write_text("12345\n")
-        # First poll sees the process gone → no SIGKILL.
+        # First poll sees the group drained → no SIGKILL.
         with (
-            mock.patch.object(_oci_state.os, "kill") as kill,
+            mock.patch.object(_oci_state.os, "killpg") as killpg,
             mock.patch.object(reader_hook, "_is_our_reader", return_value=True),
-            mock.patch.object(_oci_state, "pid_exists", return_value=False),
+            mock.patch.object(reader_hook, "_group_alive", return_value=False),
             mock.patch.object(reader_hook.time, "sleep"),
         ):
             reader_hook._reap_reader(tmp_path)
-        kill.assert_called_once_with(12345, signal.SIGTERM)
+        killpg.assert_called_once_with(12345, signal.SIGTERM)
         assert not pid_file.exists()
 
-    def test_sigkill_escalation_when_process_lingers(self, tmp_path: Path) -> None:
+    def test_sigkill_escalation_when_the_group_lingers(self, tmp_path: Path) -> None:
         pid_file = tmp_path / "reader.pid"
         pid_file.write_text("12345\n")
         with (
-            mock.patch.object(_oci_state.os, "kill") as kill,
+            mock.patch.object(_oci_state.os, "killpg") as killpg,
             mock.patch.object(reader_hook, "_is_our_reader", return_value=True),
-            mock.patch.object(_oci_state, "pid_exists", return_value=True),
+            mock.patch.object(reader_hook, "_group_alive", return_value=True),
             mock.patch.object(reader_hook.time, "sleep"),
         ):
             reader_hook._reap_reader(tmp_path)
-        signals_sent = [call.args[1] for call in kill.call_args_list]
+        signals_sent = [call.args[1] for call in killpg.call_args_list]
         assert signals_sent == [signal.SIGTERM, signal.SIGKILL]
         assert not pid_file.exists()
 
@@ -456,7 +456,7 @@ class TestReapReader:
         pid_file.write_text("12345\n")
         with (
             mock.patch.object(reader_hook, "_is_our_reader", return_value=True),
-            mock.patch.object(_oci_state.os, "kill", side_effect=ProcessLookupError),
+            mock.patch.object(_oci_state.os, "killpg", side_effect=ProcessLookupError),
         ):
             reader_hook._reap_reader(tmp_path)
         assert not pid_file.exists()
@@ -586,7 +586,7 @@ class TestReapReaderSIGTERMFailureBranches:
         pid_file.write_text("12345\n")
         with (
             mock.patch.object(reader_hook, "_is_our_reader", return_value=True),
-            mock.patch.object(_oci_state.os, "kill", side_effect=OSError("EPERM")),
+            mock.patch.object(_oci_state.os, "killpg", side_effect=OSError("EPERM")),
         ):
             reader_hook._reap_reader(tmp_path)
         assert not pid_file.exists()
@@ -792,3 +792,57 @@ class TestResolveDossierFromMeta:
         meta = tmp_path / "dossier.json"
         meta.write_text(json.dumps({"task": 42, "name": True}))
         assert _oci_state.resolve_dossier_from_meta(meta) == {"task": "42", "name": "True"}
+
+
+class TestReapReaderReapsTheWholeGroup:
+    """The netns re-exec grandchild dies with the head — the leak's locking test.
+
+    The head PID in ``reader.pid`` re-execs the real reader as a
+    grandchild in its own process group.  Reaping only the head orphaned
+    that grandchild on every container stop, leaking one netns reader
+    per restart.  This drives ``_reap_reader`` against a real two-level
+    process tree and asserts the whole group is gone.
+    """
+
+    def test_grandchild_dies_with_the_head(self, tmp_path: Path) -> None:
+        import contextlib
+        import os
+        import subprocess
+        import time as _time
+
+        head = subprocess.Popen(  # noqa: S603
+            [
+                sys.executable,
+                "-c",
+                (
+                    "import subprocess, sys;"
+                    "child = subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(60)']);"
+                    "print('ready', flush=True);"
+                    "child.wait()"
+                ),
+            ],
+            stdout=subprocess.PIPE,
+            start_new_session=True,
+            text=True,
+        )
+        try:
+            assert head.stdout is not None
+            assert head.stdout.readline().strip() == "ready"  # grandchild is alive
+            (tmp_path / "reader.pid").write_text(f"{head.pid}\n")
+
+            with mock.patch.object(reader_hook, "_is_our_reader", return_value=True):
+                reader_hook._reap_reader(tmp_path)
+
+            # The head is this test's child: reap its zombie so it leaves
+            # the group, then only a surviving grandchild can hold it open.
+            head.wait(timeout=5)
+            deadline = _time.monotonic() + 5.0
+            while _time.monotonic() < deadline:
+                if not reader_hook._group_alive(head.pid):
+                    break
+                _time.sleep(0.05)
+            assert not reader_hook._group_alive(head.pid), "the reader group survived the reap"
+        finally:
+            with contextlib.suppress(ProcessLookupError, PermissionError):
+                os.killpg(head.pid, signal.SIGKILL)
+            head.wait()

--- a/tests/unit/test_shield_probe.py
+++ b/tests/unit/test_shield_probe.py
@@ -59,6 +59,10 @@ def make_probe_result() -> Iterator[ProbeResultFactory]:
         mock_poller.poll = MagicMock(side_effect=poll_returns)
         if recvmsg_result is not None:
             mock_sock.recvmsg.return_value = recvmsg_result
+        else:
+            # Paths that reach recvmsg without a scripted result model an
+            # empty error queue; paths that never reach it are unaffected.
+            mock_sock.recvmsg.side_effect = OSError("queue empty")
         if send_side_effect is not None:
             mock_sock.send.side_effect = send_side_effect
 
@@ -130,6 +134,20 @@ def _make_ancdata(ee_errno: int, ee_origin: int, ee_type: int, ee_code: int) -> 
             OSError("send failed"),
             {"result": "icmp-error", "icmp_code": 3},
             id="first-send-error-still-detects-icmp",
+        ),
+        pytest.param(
+            [[], [(0, 8)]],
+            (b"\x00", _make_ancdata(113, _SO_EE_ORIGIN_ICMP, 3, 13), 0, (TEST_IP1, 443)),
+            OSError("cached ICMP errno"),
+            {"result": "icmp-error", "icmp_code": 13},
+            id="late-error-surfaces-on-the-re-poll",
+        ),
+        pytest.param(
+            [[], [(0, 8)]],
+            None,
+            OSError("cached ICMP errno"),
+            {"result": "timeout"},
+            id="re-poll-events-but-empty-error-queue",
         ),
     ],
 )


### PR DESCRIPTION
🤖 The spawned PID in `reader.pid` is only the head of the reader. The head re-execs the real reader inside the container's netns through `nsenter`, so the working process is a grandchild in the head's process group. A reap of only the head orphans that grandchild at every container stop — one leaked netns reader per restart (observed: ~50 stale readers on one host).

- `poststop` now signals the process group that the spawn's `start_new_session=True` already creates. The SIGKILL escalation probes group emptiness instead of one PID.
- The locking test drives `_reap_reader` against a real two-level process tree and asserts the whole group dies. It fails on master.

Leaked readers from before the upgrade need one manual sweep: `pkill -f 'nflog-reader.py .* --hub-socket='`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reader process cleanup by terminating complete process groups, including child processes.
  * Added fallback force-termination when processes remain active beyond the grace period.
  * Improved handling of already-exited or inaccessible process groups to prevent cleanup errors.
  * Improved network probing reliability by detecting cached connection errors and correctly handling empty error queues.
  * Clarified environment diagnostics by displaying setup guidance only when configuration issues are detected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
